### PR TITLE
optimization to sketch: cache MD5(0)

### DIFF
--- a/methods/sketch/src/pg_gp/sketch.sql_in
+++ b/methods/sketch/src/pg_gp/sketch.sql_in
@@ -344,8 +344,8 @@ $$ LANGUAGE plpythonu;
 
 /** @brief <c>cmsketch_depth_histogram</c> is a UDA that takes a cmsketch and a number of buckets n, and produces an n-bucket histogram for the column where each bucket has approximately the same count. The output is a text string containing triples {lo, hi, count} representing the buckets; counts are approximate.  Note that an equi-depth histogram is equivalent to a spanning set of equi-spaced centiles.  
 */
-DROP FUNCTION IF EXISTS madlib.cmsketch_depth_histogram(text, /*+ nbuckets */ int4) CASCADE;
-CREATE FUNCTION madlib.cmsketch_depth_histogram(sketches64 text, nbuckets int4)
+DROP FUNCTION IF EXISTS MADLIB_SCHEMA.cmsketch_depth_histogram(text, /*+ nbuckets */ int4) CASCADE;
+CREATE FUNCTION MADLIB_SCHEMA.cmsketch_depth_histogram(sketches64 text, nbuckets int4)
 RETURNS text
 AS $$
     PythonFunctionBodyOnly(`sketch', `countmin')    

--- a/methods/sketch/src/pg_gp/sketch.sql_in
+++ b/methods/sketch/src/pg_gp/sketch.sql_in
@@ -242,7 +242,7 @@ DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__cmsketch_base64_final(bytea) CASCADE;
 CREATE FUNCTION MADLIB_SCHEMA.__cmsketch_base64_final(sketch bytea)
 RETURNS text
 AS $$
-select encode(madlib.__cmsketch_final($1), 'base64');
+select encode(MADLIB_SCHEMA.__cmsketch_final($1), 'base64');
 $$ LANGUAGE SQL;
 
 DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__cmsketch_merge(bytea, bytea) CASCADE;

--- a/methods/sketch/src/pg_gp/sketch_support.c
+++ b/methods/sketch/src/pg_gp/sketch_support.c
@@ -30,25 +30,6 @@
 
 /*
 @addtogroup sketches
-@todo
-- Provide a relatively portable SQL-only implementation of CountMin.  (FM bit manipulation won't port well regardless).
-- Provide a python wrapper to the CountMin sketch output, and write scalar functions in python.
-
-
-@bug
-- <i>Equality-Testing Corner Case:</i>
-For hashing, we convert values into text using the type's text output routine.
-In general this should work fine, but there is the possibility that two
-different values in the domain could have the same textual representation.
-In these corner cases we will see incorrect counts for those values.
-The proper way to do this is not to use the "outfunc", but rather to look up the
-type-specific hash function as is done internally for hashjoin, hash indexes,
-etc.  The basic pattern for looking up the hash function in Postgres
-internals is something like the following:
-@code
-get_sort_group_operators(dtype, false, true, false, &ltOpr, &eqOpr, &gtOpr);
-success = get_op_hash_functions(eqOpr, result, NULL));
-@endcode
 */
 /* THIS CODE MAY NEED TO BE REVISITED TO ENSURE ALIGNMENT! */
 


### PR DESCRIPTION
In the CountMin sketch, it's common to hash the value 0 -- this results from the "dyadic range" trick that divides things by 2 lots of times.  Rather than hard-code the MD5 value of 0 in Postgres int8 type, I just cache it on first invocation.

This seems to speed things up very nicely in my little tests (factor of more than 2x).

In future would be nice to implement a proper frequency-based cache in front of MD5, but I figure that can await a rewrite of sketches in the new C++ layer. 
