### PR TITLE
fix signature of cmsketch_median in DROP FUNCTION

### DIFF
--- a/methods/sketch/src/pg_gp/sketch.sql_in
+++ b/methods/sketch/src/pg_gp/sketch.sql_in
@@ -397,7 +397,7 @@ $$ LANGUAGE plpythonu;
  sketched column that is approximately at the halfway position in sorted
  order.
  */
-DROP FUNCTION IF EXISTS MADLIB_SCHEMA.cmsketch_median(int8) CASCADE;
+DROP FUNCTION IF EXISTS MADLIB_SCHEMA.cmsketch_median(text, int8) CASCADE;
 CREATE FUNCTION MADLIB_SCHEMA.cmsketch_median(sketches64 text, cnt int8)
 RETURNS int8
 AS $$


### PR DESCRIPTION
SQL script was slightly broken: mismatched signature of DROP and CREATE FUNCTION for cmsketch_median.  Exhibited failed install on Postgres 8.4
