### PR TITLE
Fixed warnings in C code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,11 @@ endif(NOT CMAKE_BUILD_TYPE)
 if(CMAKE_COMPILER_IS_GNUCC)
     # A useful summary of warning options can be found here:
     # http://developer.apple.com/tools/xcode/compilercodewarnings.html
-    # Note: gcc does not implicitly set _POSIX_C_SOURCE when using -std=c99.
+    # Note: gcc does not implicitly set _POSIX_C_SOURCE or _XOPEN_SOURCE when using -std=c99.
     # http://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_02_01_01
-    # We specify that we are POSIX.1-2001 compliant.
-    set(CMAKE_C_FLAGS "-std=c99 -pedantic -Wall -Wextra -D_POSIX_C_SOURCE=200112L"
+    # We specify that we are POSIX.1-2001 compliant and XSI-conforming. We only
+    # need to specify _XOPEN_SOURCE as _POSIX_C_SOURCE will be set implicitly.
+    set(CMAKE_C_FLAGS "-std=c99 -pedantic -Wall -Wextra -D_XOPEN_SOURCE=600"
         CACHE STRING
         "Flags used by the compiler during all build types." FORCE)
     

--- a/methods/array_ops/src/pg_gp/array_ops.c
+++ b/methods/array_ops/src/pg_gp/array_ops.c
@@ -92,14 +92,18 @@ Datum array_of_bigint(PG_FUNCTION_ARGS){
 }
 
 Datum noop_finalize(Datum elt,int size,Oid element_type){
+	(void) size; /* avoid warning about unused parameter */
+	(void) element_type; /* avoid warning about unused parameter */
 	return elt;
 }
 
 Datum average_finalize(Datum elt,int size,Oid element_type){
+	(void) element_type; /* avoid warning about unused parameter */
 	return Float8GetDatum(DatumGetFloat8(elt)/(float8)size);
 }
 
 Datum average_root_finalize(Datum elt,int size,Oid element_type){
+	(void) element_type; /* avoid warning about unused parameter */
 	return Float8GetDatum(sqrt(DatumGetFloat8(elt)/(float8)size));
 }
 
@@ -125,6 +129,7 @@ Datum element_diff(Datum elt1, Datum *elt2, Oid element_type, Datum result){
 }
 
 Datum element_sum(Datum elt1, Datum *flag, Oid element_type, Datum result){
+	(void) flag; /* avoid warning about unused parameter */
 	switch(element_type){
 		case INT2OID:
 			return Int16GetDatum(DatumGetInt16(elt1) + DatumGetInt16(result));break;
@@ -259,6 +264,7 @@ Datum element_contains(Datum elt1, Datum elt2, Oid element_type, Datum result){
 }
 
 inline char* element_set(Datum elt1, Datum elt2, Oid element_type, char* result){
+	(void) elt1; /* avoid warning about unused parameter */
 	switch(element_type){
 		case INT2OID:
 			*((int16*)(result)) = DatumGetInt16(elt2);break;
@@ -389,6 +395,7 @@ char* element_div(Datum elt1, Datum elt2, Oid element_type, char* result){
 }
 
 char* element_sqrt(Datum elt1, Datum elt2, Oid element_type, char* result){
+	(void) elt2; /* avoid warning about unused parameter */
 	switch(element_type){
 		case INT2OID:
 			*((int16*)(result)) = sqrt(DatumGetInt16(elt1));break;

--- a/methods/decision_tree/src/pg_gp/decision_tree.c
+++ b/methods/decision_tree/src/pg_gp/decision_tree.c
@@ -196,7 +196,6 @@ Datum WeightedNoReplacement(PG_FUNCTION_ARGS) {
 	int32 i = 0;
 	int32 k = 0;
 	ArrayType *pgarray;
-	float prob = 1.0;	
 	float to_select = value1;
 
    	for(;i < value2; i++){

--- a/methods/kernel_machines/src/pg_gp/online_sv.c
+++ b/methods/kernel_machines/src/pg_gp/online_sv.c
@@ -228,7 +228,7 @@ Datum svm_predict_sub(PG_FUNCTION_ARGS)
 	ArrayType * ind_arr = PG_GETARG_ARRAYTYPE_P(4);
 	text * kernel = PG_GETARG_TEXT_P(5);
 
-	float8 * weights, * supp_vecs, * ind;
+	float8 * weights;
 
 	// input error checking 
 	if (ARR_NULLBITMAP(weights_arr) || ARR_NDIM(weights_arr) != 1 ||
@@ -464,7 +464,7 @@ Datum svm_reg_update(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 			errmsg("function \"%s\" produced null results",
-			       format_procedure(fcinfo->flinfo->fn_oid),i)));
+			       format_procedure(fcinfo->flinfo->fn_oid))));
 
 	PG_RETURN_DATUM(HeapTupleGetDatum(ret));
 }

--- a/methods/plda/src/pg_gp/plda.c
+++ b/methods/plda/src/pg_gp/plda.c
@@ -231,7 +231,7 @@ static int32 sampleTopic
 		topic_prs[j] = topic_prs[j] / total_unpr;
 
 	/* Draw a topic at random */
-	r = (random() * 1.0) / RAND_MAX;
+	r = drand48();
 	ret = 1;
 	while (true) {
 		if (ret == numtopics || r < topic_prs[ret-1]) break;
@@ -347,7 +347,7 @@ Datum sampleNewTopics(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 			 errmsg("function \"%s\" produced null results",
-				format_procedure(fcinfo->flinfo->fn_oid),i)));
+				format_procedure(fcinfo->flinfo->fn_oid))));
 
 	PG_RETURN_DATUM(HeapTupleGetDatum(ret));
 }
@@ -406,7 +406,7 @@ Datum randomTopics(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 			 errmsg("function \"%s\" produced null results",
-				format_procedure(fcinfo->flinfo->fn_oid),i)));
+				format_procedure(fcinfo->flinfo->fn_oid))));
 
 	PG_RETURN_DATUM(HeapTupleGetDatum(ret));
 }

--- a/methods/sketch/src/pg_gp/countmin.c
+++ b/methods/sketch/src/pg_gp/countmin.c
@@ -167,6 +167,7 @@ void countmin_dyadic_trans_c(cmtransval *transval, Datum input)
  */
 Datum countmin_trans_c(countmin sketch, Datum dat, Oid outFuncOid, Oid typOid)
 {
+	(void) outFuncOid; /* avoid warning about unused parameter */
     bytea *nhash;
 
     nhash = sketch_md5_bytea(dat, typOid);
@@ -278,6 +279,7 @@ int64 cmsketch_count_c(countmin sketch, Datum arg, Oid funcOid, Oid typOid)
 
 int64 cmsketch_count_md5_datum(countmin sketch, bytea *md5_bytea, Oid funcOid)
 {
+	(void) funcOid; /* avoid warning about unused parameter */
     /* iterate through the sketches, finding the min counter associated with this hash */
     return(hash_counters_iterate(md5_bytea, sketch, INT64_MAX,
                                           &min_counter));
@@ -363,6 +365,7 @@ int64 increment_counter(uint32 i,
                         countmin sketch,
                         int64 transval)
 {
+	(void) transval; /* avoid warning about unused parameter */
     int64 oldval = sketch[i][col];
     if (sketch[i][col] == (INT64_MAX))
         elog(ERROR, "maximum count exceeded in sketch");

--- a/methods/sketch/src/pg_gp/countmin.h
+++ b/methods/sketch/src/pg_gp/countmin.h
@@ -126,7 +126,7 @@ typedef struct {
      * convention is followed by the values themselves as text Datums,
      * accessible via the offsets
      */
-    offsetcnt mfvs[0];
+    offsetcnt mfvs[];
 } mfvtransval;
 
 /*! base size of an MFV transval */

--- a/methods/sketch/src/pg_gp/fm.c
+++ b/methods/sketch/src/pg_gp/fm.c
@@ -76,7 +76,7 @@ typedef struct {
     Oid      funcOid;
     int16    typLen;
     bool     typByVal;   
-    char storage[0];
+    char storage[];
 } fmtransval;
 
 Datum __fmsketch_trans_c(bytea *, Datum);

--- a/methods/sketch/src/pg_gp/mfvsketch.c
+++ b/methods/sketch/src/pg_gp/mfvsketch.c
@@ -209,7 +209,7 @@ void *mfv_transval_getval(bytea *blob, uint32 i)
     void *       retval = (void *)(((char*)tvp) + tvp->mfvs[i].offset);
     Datum        dat = PointerExtractDatum(retval, tvp->typByVal);
 
-    if (i > tvp->next_mfv || i < 0)
+    if (i > tvp->next_mfv)
         elog(ERROR,
              "attempt to get frequent value at illegal index %d in mfv sketch",
              i);
@@ -264,7 +264,7 @@ bytea *mfv_transval_insert_at(bytea *transblob, Datum dat, uint32 i)
     bytea *      tmpblob;
     size_t       datumLen = ExtractDatumLen(dat, transval->typLen, transval->typByVal);
 
-    if (i > transval->next_mfv || i < 0)
+    if (i > transval->next_mfv)
         elog(
             ERROR,
             "attempt to insert frequent value at illegal index %d in mfv sketch",
@@ -508,22 +508,14 @@ bytea *mfvsketch_merge_c(bytea *transblob1, bytea *transblob2)
          cnt < newval->max_mfvs
          && (j < transval2->next_mfv || i < transval1->next_mfv);
          cnt++) {
-        void *tmppi, *tmppj;
         Datum iDatum, jDatum;
-
-        if (i < transval1->next_mfv) {
-          tmppi = mfv_transval_getval(transblob1, i);
-          iDatum = PointerExtractDatum(tmppi, transval1->typByVal);
-        }
-        if (j < transval2->next_mfv) {
-          tmppj = mfv_transval_getval(transblob2, j);
-          jDatum = PointerExtractDatum(tmppj, transval2->typByVal);
-        }
 
 	if (i < transval1->next_mfv &&
             (j == transval2->next_mfv
              || transval1->mfvs[i].cnt >= transval2->mfvs[j].cnt)) {
           /* next item comes from transval1 */
+          iDatum = PointerExtractDatum(mfv_transval_getval(transblob1, i),
+                                       transval1->typByVal);
           newblob = mfv_transval_append(newblob, iDatum);
           newval = (mfvtransval *)VARDATA(newblob);
           newval->mfvs[cnt].cnt = transval1->mfvs[i].cnt;
@@ -533,6 +525,8 @@ bytea *mfvsketch_merge_c(bytea *transblob1, bytea *transblob2)
                  (i == transval1->next_mfv 
                   || transval1->mfvs[i].cnt < transval2->mfvs[j].cnt)) {
           /* next item comes from transval2 */
+          jDatum = PointerExtractDatum(mfv_transval_getval(transblob2, j),
+                                       transval2->typByVal);
           newblob = mfv_transval_append(newblob, jDatum);
           newval = (mfvtransval *)VARDATA(newblob);
           newval->mfvs[cnt].cnt = transval2->mfvs[j].cnt;

--- a/methods/sketch/src/pg_gp/sketch_support.c
+++ b/methods/sketch/src/pg_gp/sketch_support.c
@@ -56,6 +56,7 @@ uint32 rightmost_one(uint8 *bits,
                      size_t sketchsz_bits,
                      size_t sketchnum)
 {
+    (void) numsketches; /* avoid warning about unused parameter */
     uint8 *s =
         &(((uint8 *)(bits))[sketchnum*sketchsz_bits/8]);
     int    i;
@@ -329,6 +330,15 @@ Datum sketch_rightmost_one(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(sketch_leftmost_zero);
 Datum sketch_leftmost_zero(PG_FUNCTION_ARGS);
 
+#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+/*
+ * Unfortunately, the VARSIZE_ANY_EXHDR macro produces a warning because of the
+ * way type promotion and artihmetic conversions works in C99. See §6.1.3.8 of
+ * the C99 standard.
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
 Datum sketch_rightmost_one(PG_FUNCTION_ARGS)
 {
     bytea *bitmap = (bytea *)PG_GETARG_BYTEA_P(0);
@@ -350,6 +360,9 @@ Datum sketch_leftmost_zero(PG_FUNCTION_ARGS)
 
     return leftmost_zero((uint8 *)bits, len, sketchsz, sketchnum);
 }
+#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+#pragma GCC diagnostic pop
+#endif
 
 Datum sketch_array_set_bit_in_place(PG_FUNCTION_ARGS)
 {
@@ -379,6 +392,7 @@ int4 safe_log2(int64 x)
 
 size_t ExtractDatumLen(Datum x, int len, bool byVal)
 {
+    (void) byVal; /* avoid warning about unused parameter */
     if (len > 0) 
         return len;
     else if (len == -1) 

--- a/methods/sketch/src/pg_gp/sortasort.h
+++ b/methods/sketch/src/pg_gp/sortasort.h
@@ -28,7 +28,7 @@ typedef struct {
     int    typLen;         /*! length of this Postgres type (-1 for bytea, -2 for cstring) */
     size_t typByVal;       /*! Postgres typByVal flag */
     unsigned storage_cur;  /*! offset after the directory to do the next insertion */
-    unsigned dir[0];       /*! storage of the strings */
+    unsigned dir[];        /*! storage of the strings */
 } sortasort;
 
 #define SORTASORT_DATA(s)  (((char *)(s->dir)) + \

--- a/methods/svec/src/pg_gp/SparseData.c
+++ b/methods/svec/src/pg_gp/SparseData.c
@@ -254,7 +254,6 @@ int compar(const void *i, const void *j){
 
 SparseData posit_to_sdata(char *array, int64* array_pos, size_t width, Oid type_of_data, int count, int64 end, char *base_val){
 	char *run_val=array;
-	char *curr_val;
 	int64 run_len;
 	SparseData sdata = makeSparseData();
 	
@@ -433,7 +432,6 @@ void printSparseData(SparseData sdata) {
 double sd_proj(SparseData sdata, int idx) {
 	char * ix = sdata->index->data;
 	double * vals = (double *)sdata->vals->data;
-	float8 ret;
 	int read, i;
 
 	/* error checking */

--- a/methods/svec/src/pg_gp/SparseData.h
+++ b/methods/svec/src/pg_gp/SparseData.h
@@ -299,6 +299,7 @@ static inline int64 compword_to_int8(const char *entry)
 static inline void printout_double(double *vals, int num_values, int stop);
 static inline void printout_double(double *vals, int num_values, int stop)
 {
+	(void) stop; /* avoid warning about unused parameter */
 	char *output_str = (char *)palloc(sizeof(char)*(num_values*(6+18+2))+1);
 	char *str = output_str;
 	int numout;
@@ -313,6 +314,7 @@ static inline void printout_double(double *vals, int num_values, int stop)
 static inline void printout_index(char *ix, int num_values, int stop);
 static inline void printout_index(char *ix, int num_values, int stop)
 {
+	(void) stop; /* avoid warning about unused parameter */
 	char *output_str = (char *)palloc(sizeof(char)*((num_values*7)+1));
 	char *str = output_str;
 	int numout;
@@ -743,7 +745,6 @@ static inline bool sparsedata_eq_zero_is_equal(SparseData left, SparseData right
 	
 	char * rix = right->index->data;
 	double* rvals = (double *)right->vals->data;
-	char* result;
 	
 	int read = 0, rread = 0;
 	int i=-1, j=-1, minimum = 0;
@@ -797,7 +798,6 @@ static inline bool sparsedata_contains(SparseData left, SparseData right)
 	
 	char * rix = right->index->data;
 	double* rvals = (double *)right->vals->data;
-	char* result;
 	
 	int read = 0, rread = 0;
 	int i=-1, j=-1, minimum = 0;

--- a/methods/svec/src/pg_gp/sparse_vector.c
+++ b/methods/svec/src/pg_gp/sparse_vector.c
@@ -418,9 +418,9 @@ SvecType *reallocSvec(SvecType *source)
 {
 	SvecType *svec;
 	SparseData sdata = sdata_from_svec(source);
-	int val_newmaxlen = Max(2*sizeof(float8)+1,2*(sdata->vals->maxlen));
+	int val_newmaxlen = Max(2*sizeof(float8)+1, 2 * (Size) sdata->vals->maxlen);
 	char *newvals = (char *)palloc(val_newmaxlen);
-	int ind_newmaxlen = Max(2*sizeof(int8)+1,2*(sdata->index->maxlen));
+	int ind_newmaxlen = Max(2*sizeof(int8)+1, 2 * (Size) sdata->index->maxlen);
 	char *newindex = (char *)palloc(ind_newmaxlen);
 	/*
 	 * This space was never allocated with palloc, so we can't repalloc it!

--- a/src/ports/greenplum/CMakeLists.txt
+++ b/src/ports/greenplum/CMakeLists.txt
@@ -64,12 +64,19 @@ if(GREENPLUM_FOUND)
     # FIXME: Convert legacy source code written in C
     # BEGIN Legacy Code
     
-        if(${CMAKE_COMPILER_IS_GNUCC})
+        if(CMAKE_COMPILER_IS_GNUCC)
             # FIXME: Is there a portable (not just for gcc) way of including a header file?
             # Due to Greenplum bug MPP-13254, we need to include <sys/time.h>
             # before <postgres.h>
-            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -include sys/time.h")
-        endif(${CMAKE_COMPILER_IS_GNUCC})
+            # FIXME: In the C code, we have several places where strict aliasing
+            # rules are violated. See this web page for some background:
+            # http://dbp-consulting.com/tutorials/StrictAliasing.html
+            # For now, we tell GCC that it cannot rely on strict aliasing rules.
+            # Downside: We forgo some potential optimization.
+            # The warning GCC would output without -fno-strict-aliasing is:
+            # dereferencing type-punned pointer will break strict-aliasing rules
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -include sys/time.h -fno-strict-aliasing")
+        endif(CMAKE_COMPILER_IS_GNUCC)
         file(GLOB_RECURSE LEGACY_C_FILES_GREENPLUM RELATIVE
             "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}/methods/*.c")
 

--- a/src/ports/postgres/CMakeLists.txt
+++ b/src/ports/postgres/CMakeLists.txt
@@ -50,6 +50,16 @@ if(POSTGRESQL_FOUND)
     # FIXME: Convert legacy source code written in C
     # BEGIN Legacy Code
     
+        if(CMAKE_COMPILER_IS_GNUCC)
+            # FIXME: In the C code, we have several places where strict aliasing
+            # rules are violated. See this web page for some background:
+            # http://dbp-consulting.com/tutorials/StrictAliasing.html
+            # For now, we tell GCC that it cannot rely on strict aliasing rules.
+            # Downside: We forgo some potential optimization.
+            # The warning GCC would output without -fno-strict-aliasing is:
+            # dereferencing type-punned pointer will break strict-aliasing rules
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing")
+        endif(CMAKE_COMPILER_IS_GNUCC)
         file(GLOB_RECURSE LEGACY_C_FILES_POSTGRES RELATIVE
             "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}/methods/*.c")
 


### PR DESCRIPTION
I turned on almost all warnings (static analysis) that gcc supports. The goal should be to write warning-free code. Please carefully review my changes to your code that I did to fix the warnings.

Commit message:
Fixed all warnings in legacy C code. Unfortunately, you need gcc >= 4.6 so that all warnings disappear.
Changes included:
- Replaced calls to random() with POSIX function calls. For that I set the _XOPEN_SOURCE macro for all C files.
- Turned off strict aliasing for legacy C code.
- Avoid warning about uninitalized use of variables in mfvsketch.c. I actually moved some code here.
