### PR TITLE
Stochastic Gradient Descent for Linear SVM Training Added

### DIFF
--- a/methods/array_ops/src/pg_gp/array_ops.sql_in
+++ b/methods/array_ops/src/pg_gp/array_ops.sql_in
@@ -227,4 +227,12 @@ AS 'MODULE_PATHNAME', 'array_sqrt'
 LANGUAGE C IMMUTABLE;
 
 
-
+/**
+ * @brief Array normalization function.
+ *
+ * @param x Array x.
+ * @return  Array normalized by its norm.
+ *      
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.normalize(x float8[]) RETURNS float8[]
+AS 'MODULE_PATHNAME', 'array_normalize' LANGUAGE C IMMUTABLE STRICT;

--- a/methods/array_ops/src/pg_gp/test/array_ops.sql_in
+++ b/methods/array_ops/src/pg_gp/test/array_ops.sql_in
@@ -21,12 +21,12 @@ declare
     result TEXT;
 begin
 
-    SELECT INTO result_num1 MADLIB_SCHEMA.array_dot(MADLIB_SCHEMA.array_mult(MADLIB_SCHEMA.array_add(an,b), MADLIB_SCHEMA.array_sub(an,b)),MADLIB_SCHEMA.array_div(an,b));
+    SELECT INTO result_num1 MADLIB_SCHEMA.array_dot(MADLIB_SCHEMA.array_mult(MADLIB_SCHEMA.array_add(an,b), MADLIB_SCHEMA.array_sub(an,b)), MADLIB_SCHEMA.array_mult(MADLIB_SCHEMA.array_div(an,b), MADLIB_SCHEMA.normalize(an)));
     b[4] = NULL;
     SELECT INTO result_num2 (MADLIB_SCHEMA.array_max(b)+MADLIB_SCHEMA.array_min(b)+MADLIB_SCHEMA.array_sum(b)+MADLIB_SCHEMA.array_sum_big(b)+
     MADLIB_SCHEMA.array_mean(b)+MADLIB_SCHEMA.array_stddev(b));
     SELECT INTO result_num3 MADLIB_SCHEMA.array_sum(MADLIB_SCHEMA.array_scalar_mult(MADLIB_SCHEMA.array_fill(MADLIB_SCHEMA.array_of_float(20), 234.343::FLOAT8),3.7::FLOAT));
-    result_num1 = result_num1+result_num2+result_num3-17361.6696953194;
+    result_num1 = result_num1+result_num2+result_num3-17371.7254700712;
     
     SELECT INTO result CASE WHEN((result_num1 < .01)AND(result_num1 > -.01)) THEN 'PASS' ELSE 'FAIL' END;
     

--- a/methods/kernel_machines/src/pg_gp/online_sv.c
+++ b/methods/kernel_machines/src/pg_gp/online_sv.c
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Support functions for the online SVM routines
- * @author Kee Siong Ng
+ * @author Kee Siong Ng and Jin Yu
  */
 
 #include "postgres.h"
@@ -28,7 +28,7 @@ PG_MODULE_MAGIC;
  * This function constructs an array of zeros.
  */
 static ArrayType *construct_zero_array(int inNumElements,
-	Oid inElementType, int inElementSize)
+									   Oid inElementType, int inElementSize)
 {
 	int64 size = inElementSize * inNumElements + ARR_OVERHEAD_NONULLS(1);
 	ArrayType * array;
@@ -51,8 +51,8 @@ static ArrayType *construct_zero_array(int inNumElements,
 static float8 apply_kernel(Oid foid, ArrayType * x1, ArrayType * x2) 
 {
 	float8 ret = 
-	  DatumGetFloat8(
-		OidFunctionCall2(foid,PointerGetDatum(x1),PointerGetDatum(x2)));
+	DatumGetFloat8(
+				   OidFunctionCall2(foid,PointerGetDatum(x1),PointerGetDatum(x2)));
 	return ret;
 }
 
@@ -60,16 +60,58 @@ static float8 apply_kernel(Oid foid, ArrayType * x1, ArrayType * x2)
  * This function computes the inner product of two points.
  */
 /*
-static float8 apply_kernel(Oid foid, ArrayType * x1, ArrayType * x2) 
+ static float8 apply_kernel(Oid foid, ArrayType * x1, ArrayType * x2) 
+ {
+ float8 * arr1 = (float8 *)ARR_DATA_PTR(x1);
+ float8 * arr2 = (float8 *)ARR_DATA_PTR(x2);
+ float ret = 0;
+ for (int i=0; i!=ARR_DIMS(x1)[0]; i++)
+ ret += arr1[i] * arr2[i];
+ return ret;
+ }
+ */
+
+Datum svm_normalization(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(svm_normalization);
+
+/*
+ * This function normalizes a vector.
+ */
+Datum svm_normalization(PG_FUNCTION_ARGS)
 {
-	float8 * arr1 = (float8 *)ARR_DATA_PTR(x1);
-	float8 * arr2 = (float8 *)ARR_DATA_PTR(x2);
-	float ret = 0;
-	for (int i=0; i!=ARR_DIMS(x1)[0]; i++)
-		ret += arr1[i] * arr2[i];
-	return ret;
+	ArrayType * arg = PG_GETARG_ARRAYTYPE_P(0);
+	
+	if (ARR_NDIM(arg) != 1 || ARR_ELEMTYPE(arg) != FLOAT8OID)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameters",
+						format_procedure(fcinfo->flinfo->fn_oid))));
+	
+	float8 * x = (float8 *)ARR_DATA_PTR(arg);
+	int dim = ARR_DIMS(arg)[0];
+	
+	float8 d = 0; 
+	for (int i=0; i!=dim; i++)
+		d += x[i] * x[i];
+	
+	if (d > 0 && d != 1.0) {
+		/* Allocate memory for return value */
+		Datum * array = palloc0(dim*sizeof(Datum));
+		ArrayType * ret = construct_array(array,dim,FLOAT8OID,sizeof(float8),true,'i');
+		float8 * ret_v = (float8 *)ARR_DATA_PTR(ret);
+		
+		float8 sqrtd = sqrt(d);
+
+		for (int i=0; i!=dim; i++)
+			ret_v[i] = x[i] / sqrtd;
+		
+		PG_RETURN_ARRAYTYPE_P(ret);
+	} else {
+		PG_RETURN_ARRAYTYPE_P(arg);
+	}	
+
 }
-*/
+
 
 Datum svm_dot(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(svm_dot);
@@ -81,26 +123,25 @@ Datum svm_dot(PG_FUNCTION_ARGS)
 {
 	ArrayType * arg1 = PG_GETARG_ARRAYTYPE_P(0);
 	ArrayType * arg2 = PG_GETARG_ARRAYTYPE_P(1);
-
+	
 	if (ARR_NDIM(arg1) != 1 || ARR_ELEMTYPE(arg1) != FLOAT8OID ||
 	    ARR_NDIM(arg2) != 1 || ARR_ELEMTYPE(arg2) != FLOAT8OID)
 		ereport(ERROR,
-		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" called with invalid parameters",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
-
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameters",
+				 format_procedure(fcinfo->flinfo->fn_oid))));
 	int dim1 = ARR_DIMS(arg1)[0];
 	int dim2 = ARR_DIMS(arg2)[0];
-
+	
 	if (dim1 != dim2)
 		ereport(ERROR,
-		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" called with invalid parameters",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameters",
+                                 format_procedure(fcinfo->flinfo->fn_oid))));
 	
 	float8 * x1 = (float8 *)ARR_DATA_PTR(arg1);
 	float8 * x2 = (float8 *)ARR_DATA_PTR(arg2);
-
+	
 	float8 ret = 0; 
 	for (int i=0; i!=dim1; i++)
 		ret += x1[i] * x2[i];
@@ -119,32 +160,32 @@ Datum svm_polynomial(PG_FUNCTION_ARGS)
 	ArrayType * arg1 = PG_GETARG_ARRAYTYPE_P(0);
 	ArrayType * arg2 = PG_GETARG_ARRAYTYPE_P(1);
 	float8 degree = PG_GETARG_FLOAT8(2);
-
+	
 	if (ARR_NDIM(arg1) != 1 || ARR_ELEMTYPE(arg1) != FLOAT8OID ||
 	    ARR_NDIM(arg2) != 1 || ARR_ELEMTYPE(arg2) != FLOAT8OID)
 		ereport(ERROR,
-		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" called with invalid parameters",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
-
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameters",
+						format_procedure(fcinfo->flinfo->fn_oid))));
+	
 	int dim1 = ARR_DIMS(arg1)[0];
 	int dim2 = ARR_DIMS(arg2)[0];
-
+	
 	if (dim1 != dim2)
 		ereport(ERROR,
-		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" called with invalid parameters",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameters",
+						format_procedure(fcinfo->flinfo->fn_oid))));
 	
 	float8 * x1 = (float8 *)ARR_DATA_PTR(arg1);
 	float8 * x2 = (float8 *)ARR_DATA_PTR(arg2);
-
+	
 	float8 ret = 0; 
 	for (int i=0; i!=dim1; i++)
 		ret += x1[i] * x2[i];
 	
 	ret = pow(ret,degree);
-
+	
 	PG_RETURN_FLOAT8(ret);
 }
 
@@ -159,32 +200,32 @@ Datum svm_gaussian(PG_FUNCTION_ARGS)
 	ArrayType * arg1 = PG_GETARG_ARRAYTYPE_P(0);
 	ArrayType * arg2 = PG_GETARG_ARRAYTYPE_P(1);
 	float8 gamma = PG_GETARG_FLOAT8(2);
-
+	
 	if (ARR_NDIM(arg1) != 1 || ARR_ELEMTYPE(arg1) != FLOAT8OID ||
 	    ARR_NDIM(arg2) != 1 || ARR_ELEMTYPE(arg2) != FLOAT8OID)
 		ereport(ERROR,
-		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" called with invalid parameters",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
-
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameters",
+						format_procedure(fcinfo->flinfo->fn_oid))));
+	
 	int dim1 = ARR_DIMS(arg1)[0];
 	int dim2 = ARR_DIMS(arg2)[0];
-
+	
 	if (dim1 != dim2)
 		ereport(ERROR,
-		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" called with invalid parameters",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameters",
+						format_procedure(fcinfo->flinfo->fn_oid))));
 	
 	float8 * x1 = (float8 *)ARR_DATA_PTR(arg1);
 	float8 * x2 = (float8 *)ARR_DATA_PTR(arg2);
-
+	
 	float8 ret = 0; 
 	for (int i=0; i!=dim1; i++)
 		ret += (x1[i] - x2[i]) * (x1[i] - x2[i]);
 	
 	ret = exp(-1 * gamma * ret);
-
+	
 	PG_RETURN_FLOAT8(ret);
 }
 
@@ -193,17 +234,17 @@ Datum svm_gaussian(PG_FUNCTION_ARGS)
  */
 static float8 
 svm_predict_eval(Oid koid, float8 * weights, ArrayType * supp_vectors, 
-		 ArrayType * ind, int32 nsvs, int32 ind_dim)
+				 ArrayType * ind, int32 nsvs, int32 ind_dim)
 {
 	// We are not error-checking the ArrayTypes here because that has
 	// been done in the calling function
-
+	
 	int i; float8 ret = 0;
 	float8 * spvs = (float8 *)ARR_DATA_PTR(supp_vectors);
-
+	
 	ArrayType * spp_vec = construct_zero_array(ind_dim, FLOAT8OID, 8);
 	float8 * spp_vec_data = (float8 *)ARR_DATA_PTR(spp_vec);
-
+	
 	for (i=0; i!=nsvs; i++) {
 		// first copy the relevant portion of spvs to spp_vec_data
 		memcpy(spp_vec_data, spvs+ind_dim*i, sizeof(float8) * ind_dim);
@@ -227,9 +268,9 @@ Datum svm_predict_sub(PG_FUNCTION_ARGS)
 	ArrayType * supp_vecs_arr = PG_GETARG_ARRAYTYPE_P(3);
 	ArrayType * ind_arr = PG_GETARG_ARRAYTYPE_P(4);
 	text * kernel = PG_GETARG_TEXT_P(5);
-
+	
 	float8 * weights;
-
+	
 	// input error checking 
 	if (ARR_NULLBITMAP(weights_arr) || ARR_NDIM(weights_arr) != 1 ||
 	    ARR_ELEMTYPE(weights_arr) != FLOAT8OID ||
@@ -239,16 +280,16 @@ Datum svm_predict_sub(PG_FUNCTION_ARGS)
 	    ARR_NULLBITMAP(ind_arr) || ARR_NDIM(ind_arr) != 1 ||
 	    ARR_ELEMTYPE(ind_arr) != FLOAT8OID)
 		ereport(ERROR,
-		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" called with invalid parameters",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
-
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameters",
+						format_procedure(fcinfo->flinfo->fn_oid))));
+	
 	weights = (float8 *)ARR_DATA_PTR(weights_arr);
-
+	
 	Oid argtypes[2] = { FLOAT8ARRAYOID, FLOAT8ARRAYOID };
 	List * funcname = textToQualifiedNameList(kernel);
 	Oid koid = LookupFuncName(funcname, 2, argtypes, false);
-
+	
 	ret = svm_predict_eval(koid,weights,supp_vecs_arr,ind_arr,nsvs,ind_dim);
 	
 	PG_RETURN_FLOAT8(ret);
@@ -264,15 +305,15 @@ static int blocksize = 100;
 static ArrayType * addNewWeight(ArrayType * weights, float8 weight, int nsvs) 
 {
 	float8 * weights_data = (float8 *)ARR_DATA_PTR(weights);
-
+	
 	if (nsvs % blocksize == 0) {
 		ArrayType * ret_arr = 
-			construct_zero_array(nsvs+blocksize, FLOAT8OID, 8);
+		construct_zero_array(nsvs+blocksize, FLOAT8OID, 8);
 		float8 * ret = (float8 *)ARR_DATA_PTR(ret_arr); 
-
+		
 		memcpy(ret, weights_data, sizeof(float8) * nsvs);
 		ret[nsvs] = weight;
-
+		
 		return ret_arr;
 	} else {
 		weights_data[nsvs] = weight;
@@ -289,15 +330,15 @@ static ArrayType * addNewSV(ArrayType * spvs, float8 * ind, int nsvs, int dim)
 {
 	int i;
 	float8 * spvs_data = (float8 *)ARR_DATA_PTR(spvs);
-
+	
 	if (nsvs % blocksize == 0) {
 		ArrayType * ret_arr = 
-			construct_zero_array((nsvs+blocksize)*dim, FLOAT8OID,8);
+		construct_zero_array((nsvs+blocksize)*dim, FLOAT8OID,8);
 		float8 * ret = (float8 *)ARR_DATA_PTR(ret_arr); 
-
+		
 		memcpy(ret, spvs_data, sizeof(float8) * nsvs * dim);
 		for (i=0; i!=dim; i++) ret[nsvs*dim + i] = ind[i];
-
+		
 		return ret_arr;
 	} else {
 		for (i=0; i!=dim; i++) spvs_data[nsvs*dim + i] = ind[i];
@@ -322,9 +363,9 @@ Datum svm_reg_update(PG_FUNCTION_ARGS)
 	float8 diff;          // difference between p and target label
 	float8 error;         // absolute value of diff
 	float8 weight;        // the weight of new support vector
-
+	
 	int i;
-
+	
 	// Get the input arguments and check for errors
 	HeapTupleHeader t = PG_GETARG_HEAPTUPLEHEADER(0);
 	ArrayType * ind_arr = PG_GETARG_ARRAYTYPE_P(1);
@@ -333,25 +374,25 @@ Datum svm_reg_update(PG_FUNCTION_ARGS)
 	float8 eta = PG_GETARG_FLOAT8(4);
 	float8 nu = PG_GETARG_FLOAT8(5);
 	float8 slambda = PG_GETARG_FLOAT8(6);
-
+	
 	if (eta <= 0 || eta > 1 || nu <= 0 || nu > 1 || eta * slambda > 1)
 		ereport(ERROR,
-			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			 errmsg("function \"%s\" called with invalid parameter",
-				format_procedure(fcinfo->flinfo->fn_oid))));
-
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameter",
+						format_procedure(fcinfo->flinfo->fn_oid))));
+	
 	if (ARR_NULLBITMAP(ind_arr) || ARR_NDIM(ind_arr) != 1 ||
 	    ARR_ELEMTYPE(ind_arr) != FLOAT8OID)
 		ereport(ERROR,
-		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" called with invalid parameter",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
-
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameter",
+						format_procedure(fcinfo->flinfo->fn_oid))));
+	
 	float8 * ind = (float8 *)ARR_DATA_PTR(ind_arr);
-
+	
 	// Read the attributes of the input support vector model
 	bool nil[10] = { 0,0,0,0,0,0,0,0,0,0 };
-
+	
 	int32 inds = DatumGetInt32(GetAttributeByName(t, "inds", &nil[0]));
 	float8 cum_err =DatumGetFloat8(GetAttributeByName(t,"cum_err",&nil[1]));
 	float8 epsilon =DatumGetFloat8(GetAttributeByName(t,"epsilon",&nil[2]));
@@ -360,14 +401,14 @@ Datum svm_reg_update(PG_FUNCTION_ARGS)
 	int32 nsvs = DatumGetInt32(GetAttributeByName(t, "nsvs", &nil[5]));
 	int32 ind_dim =DatumGetInt32(GetAttributeByName(t, "ind_dim", &nil[6]));
 	ArrayType * weights_arr = 
-		DatumGetArrayTypeP(GetAttributeByName(t, "weights", &nil[7]));
+	DatumGetArrayTypeP(GetAttributeByName(t, "weights", &nil[7]));
 	ArrayType * supp_vecs_arr = 
-		DatumGetArrayTypeP(GetAttributeByName(t,"individuals",&nil[8]));
+	DatumGetArrayTypeP(GetAttributeByName(t,"individuals",&nil[8]));
 	Oid koid = DatumGetUInt32(GetAttributeByName(t, "kernel_oid",&nil[9]));
-
+	
 	for (i=0; i!=10; i++)
 		if (nil[i]) elog(ERROR, "error reading support vector model");
-
+	
 	// The first time this function is called, the initial state doesn't
 	// tell us the dimension of the data points; this needs to be extracted
 	// from the ind argument. 
@@ -394,24 +435,24 @@ Datum svm_reg_update(PG_FUNCTION_ARGS)
 		    ARR_NDIM(supp_vecs_arr) != 1 ||
 		    ARR_ELEMTYPE(supp_vecs_arr) != FLOAT8OID)
 			ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" called with invalid parameters",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("function \"%s\" called with invalid parameters",
+							format_procedure(fcinfo->flinfo->fn_oid))));
 	}
-
+	
 	float8 * weights = (float8 *)ARR_DATA_PTR(weights_arr);
-
+	
 	// This is the main regression update algorithm
 	p = svm_predict_eval(koid,weights,supp_vecs_arr,ind_arr,nsvs,ind_dim) + b; 
-
+	
 	diff = label - p;
 	error = fabs(diff);
-			     
+	
 	inds++;
 	cum_err = cum_err + error;
-
+	
 	float8 cap = 0.1 + 1 / (1 - eta * slambda);
-
+	
 	if (error > epsilon) {
 		// unlike the original algorithm in Kivinen et al, this 
 		// rescaling is only done when we make a large enough error
@@ -424,17 +465,17 @@ Datum svm_reg_update(PG_FUNCTION_ARGS)
 			}
 			weights[i] = weights[i] * (1 - eta * slambda);
 		}
-
+		
 		weight = diff < 0 ? -eta : eta;
 		weights_arr = addNewWeight(weights_arr,weight,nsvs);
-	        supp_vecs_arr = addNewSV(supp_vecs_arr,ind,nsvs,ind_dim);
+		supp_vecs_arr = addNewSV(supp_vecs_arr,ind,nsvs,ind_dim);
 		nsvs++;
 		b = b + weight;
 		epsilon = epsilon + (1 - nu) * eta;
 	} else {
 		epsilon = epsilon - eta * nu;
 	}
-
+	
 	// Package up the attributes and return the resultant composite object
 	Datum values[10];
 	values[0] = Int32GetDatum(inds);
@@ -447,25 +488,25 @@ Datum svm_reg_update(PG_FUNCTION_ARGS)
 	values[7] = PointerGetDatum(weights_arr);
 	values[8] = PointerGetDatum(supp_vecs_arr);
 	values[9] = UInt32GetDatum(koid);
-
+	
 	TupleDesc tuple;
 	if (get_call_result_type(fcinfo, NULL, &tuple) != TYPEFUNC_COMPOSITE)
 		ereport(ERROR,
-			(errcode( ERRCODE_FEATURE_NOT_SUPPORTED ),
-			 errmsg( "function returning record called in context "
-				 "that cannot accept type record" )));
+				(errcode( ERRCODE_FEATURE_NOT_SUPPORTED ),
+				 errmsg( "function returning record called in context "
+						"that cannot accept type record" )));
 	tuple = BlessTupleDesc(tuple);
-
+	
 	bool * isnulls = palloc0(10 * sizeof(bool));
 	HeapTuple ret = heap_form_tuple(tuple, values, isnulls);
-
+	
 	for (i=0; i!=10; i++)
 		if (isnulls[i])
 			ereport(ERROR,
-		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" produced null results",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
-
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("function \"%s\" produced null results",
+							format_procedure(fcinfo->flinfo->fn_oid))));
+	
 	PG_RETURN_DATUM(HeapTupleGetDatum(ret));
 }
 
@@ -484,7 +525,7 @@ Datum svm_cls_update(PG_FUNCTION_ARGS)
 {
 	float8 p;             // label * prediction for data point 
 	int i;
-
+	
 	// Get the input arguments and check for errors
 	HeapTupleHeader t = PG_GETARG_HEAPTUPLEHEADER(0);
 	ArrayType * ind_arr = PG_GETARG_ARRAYTYPE_P(1);
@@ -492,28 +533,28 @@ Datum svm_cls_update(PG_FUNCTION_ARGS)
 	text * kernel = PG_GETARG_TEXT_P(3);
 	float8 eta = PG_GETARG_FLOAT8(4);     // learning rate
 	float8 nu = PG_GETARG_FLOAT8(5);  /* compression parameter; about nu
-					   * fraction of the training data will
-					   * become support vectors
-					   */
-
+									   * fraction of the training data will
+									   * become support vectors
+									   */
+	
 	if (eta <= 0 || eta > 1 || nu <= 0 || nu > 1)
 		ereport(ERROR,
-			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			 errmsg("function \"%s\" called with invalid parameter",
-				format_procedure(fcinfo->flinfo->fn_oid))));
-
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameter",
+						format_procedure(fcinfo->flinfo->fn_oid))));
+	
 	if (ARR_NULLBITMAP(ind_arr) || ARR_NDIM(ind_arr) != 1 ||
 	    ARR_ELEMTYPE(ind_arr) != FLOAT8OID)
 		ereport(ERROR,
-		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" called with invalid parameter",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
-
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameter",
+						format_procedure(fcinfo->flinfo->fn_oid))));
+	
 	float8 * ind = (float8 *)ARR_DATA_PTR(ind_arr);
-
+	
 	// Read the attributes of the input support vector model
 	bool nil[10] = { 0,0,0,0,0,0,0,0,0 };
-
+	
 	int32 inds = DatumGetInt32(GetAttributeByName(t, "inds", &nil[0]));
 	float8 cum_err =DatumGetFloat8(GetAttributeByName(t,"cum_err",&nil[1]));
 	float8 epsilon =DatumGetFloat8(GetAttributeByName(t,"epsilon",&nil[2]));
@@ -522,14 +563,14 @@ Datum svm_cls_update(PG_FUNCTION_ARGS)
 	int32 nsvs = DatumGetInt32(GetAttributeByName(t, "nsvs", &nil[5]));
 	int32 ind_dim =DatumGetInt32(GetAttributeByName(t, "ind_dim", &nil[6]));
 	ArrayType * weights_arr = 
-		DatumGetArrayTypeP(GetAttributeByName(t, "weights", &nil[7]));
+	DatumGetArrayTypeP(GetAttributeByName(t, "weights", &nil[7]));
 	ArrayType * supp_vecs_arr = 
-		DatumGetArrayTypeP(GetAttributeByName(t,"individuals",&nil[8]));
+	DatumGetArrayTypeP(GetAttributeByName(t,"individuals",&nil[8]));
 	Oid koid = DatumGetUInt32(GetAttributeByName(t, "kernel_oid",&nil[9]));
-
+	
 	for (i=0; i!=10; i++)
 		if (nil[i]) elog(ERROR, "error reading support vector model");
-
+	
 	// The first time this function is called, the initial state doesn't
 	// tell us the dimension of the data points; this needs to be extracted
 	// from the ind argument. 
@@ -556,22 +597,26 @@ Datum svm_cls_update(PG_FUNCTION_ARGS)
 		    ARR_NDIM(supp_vecs_arr) != 1 ||
 		    ARR_ELEMTYPE(supp_vecs_arr) != FLOAT8OID) 
 			ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" called with invalid array parameters",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("function \"%s\" called with invalid array parameters",
+							format_procedure(fcinfo->flinfo->fn_oid))));
 	}
-
+	
 	float8 * weights = (float8 *)ARR_DATA_PTR(weights_arr);
-
+	
 	// This is the nu-SV classification update algorithm.
 	p = svm_predict_eval(koid,weights,supp_vecs_arr,ind_arr,nsvs,ind_dim) + b; 
 	// elog(NOTICE, "%f \t %f \t %d", label, p, nsvs);
-
+	
 	p = label * p;
-
+	
 	inds++;
+	
+	eta = eta / sqrt(inds*1.0);
+	// elog(NOTICE, "eta = %f", eta);
+	
 	if (p <= 0) cum_err++;
-
+	
 	if (p <= rho) {
 		// unlike the original algorithm in Kivinen et al, this 
 		// rescaling is only done when we make a large enough error
@@ -587,16 +632,19 @@ Datum svm_cls_update(PG_FUNCTION_ARGS)
 			// is mathematically irrelevant
 			weights[i] = weights[i] * (1 - 0.1*eta); 
 		}
-
+		
 		weights_arr = addNewWeight(weights_arr,label * eta,nsvs);
-	        supp_vecs_arr = addNewSV(supp_vecs_arr,ind,nsvs,ind_dim);
+		supp_vecs_arr = addNewSV(supp_vecs_arr,ind,nsvs,ind_dim);
 		nsvs++;
 		b = b + eta * label;
 		rho = rho - eta * (1 - nu);
+		// update rho in log space
+		//rho = rho * exp(-eta * rho * (1-nu));
 	} else {
 		rho = rho + eta * nu; 
+		//rho = rho * exp(eta * rho * nu);
 	}
-
+	
 	// Package up the attributes and return the resultant composite object
 	Datum values[10];
 	values[0] = Int32GetDatum(inds);
@@ -609,25 +657,25 @@ Datum svm_cls_update(PG_FUNCTION_ARGS)
 	values[7] = PointerGetDatum(weights_arr);
 	values[8] = PointerGetDatum(supp_vecs_arr);
 	values[9] = UInt32GetDatum(koid);
-
+	
 	TupleDesc tuple;
 	if (get_call_result_type(fcinfo, NULL, &tuple) != TYPEFUNC_COMPOSITE)
 		ereport(ERROR,
-			(errcode( ERRCODE_FEATURE_NOT_SUPPORTED ),
-			 errmsg( "function returning record called in context "
-				 "that cannot accept type record" )));
+				(errcode( ERRCODE_FEATURE_NOT_SUPPORTED ),
+				 errmsg( "function returning record called in context "
+						"that cannot accept type record" )));
 	tuple = BlessTupleDesc(tuple);
-
+	
 	bool * isnulls = palloc0(10 * sizeof(bool));
 	HeapTuple ret = heap_form_tuple(tuple, values, isnulls);
-
+	
 	for (i=0; i!=10; i++)
 		if (isnulls[i])
 			ereport(ERROR,
-		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" produced null results %d",
-			       format_procedure(fcinfo->flinfo->fn_oid),i)));
-
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("function \"%s\" produced null results %d",
+							format_procedure(fcinfo->flinfo->fn_oid),i)));
+	
 	PG_RETURN_DATUM(HeapTupleGetDatum(ret));
 }
 
@@ -646,35 +694,35 @@ Datum svm_nd_update(PG_FUNCTION_ARGS)
 {
 	float8 p;             // prediction for data point 
 	int i;
-
+	
 	// Get the input arguments and check for errors
 	HeapTupleHeader t = PG_GETARG_HEAPTUPLEHEADER(0);
 	ArrayType * ind_arr = PG_GETARG_ARRAYTYPE_P(1);
 	text * kernel = PG_GETARG_TEXT_P(2);
 	float8 eta = PG_GETARG_FLOAT8(3);     // learning rate
 	float8 nu = PG_GETARG_FLOAT8(4);  /* compression parameter; about nu
-					   * fraction of the training data will
-					   * become support vectors
-					   */
-
+									   * fraction of the training data will
+									   * become support vectors
+									   */
+	
 	if (eta <= 0 || eta > 1 || nu <= 0 || nu > 1)
 		ereport(ERROR,
-			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			 errmsg("function \"%s\" called with invalid parameter",
-				format_procedure(fcinfo->flinfo->fn_oid))));
-
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameter",
+						format_procedure(fcinfo->flinfo->fn_oid))));
+	
 	if (ARR_NULLBITMAP(ind_arr) || ARR_NDIM(ind_arr) != 1 ||
 	    ARR_ELEMTYPE(ind_arr) != FLOAT8OID)
 		ereport(ERROR,
-		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" called with invalid parameter",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
-
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("function \"%s\" called with invalid parameter",
+						format_procedure(fcinfo->flinfo->fn_oid))));
+	
 	float8 * ind = (float8 *)ARR_DATA_PTR(ind_arr);
-
+	
 	// Read the attributes of the input support vector model
 	bool nil[10] = { 0,0,0,0,0,0,0,0,0 };
-
+	
 	int32 inds = DatumGetInt32(GetAttributeByName(t, "inds", &nil[0]));
 	float8 cum_err =DatumGetFloat8(GetAttributeByName(t,"cum_err",&nil[1]));
 	float8 epsilon =DatumGetFloat8(GetAttributeByName(t,"epsilon",&nil[2]));
@@ -683,14 +731,14 @@ Datum svm_nd_update(PG_FUNCTION_ARGS)
 	int32 nsvs = DatumGetInt32(GetAttributeByName(t, "nsvs", &nil[5]));
 	int32 ind_dim =DatumGetInt32(GetAttributeByName(t, "ind_dim", &nil[6]));
 	ArrayType * weights_arr = 
-		DatumGetArrayTypeP(GetAttributeByName(t, "weights", &nil[7]));
+	DatumGetArrayTypeP(GetAttributeByName(t, "weights", &nil[7]));
 	ArrayType * supp_vecs_arr = 
-		DatumGetArrayTypeP(GetAttributeByName(t,"individuals",&nil[8]));
+	DatumGetArrayTypeP(GetAttributeByName(t,"individuals",&nil[8]));
 	Oid koid = DatumGetUInt32(GetAttributeByName(t, "kernel_oid",&nil[9]));
-
+	
 	for (i=0; i!=10; i++)
 		if (nil[i]) elog(ERROR, "error reading support vector model");
-
+	
 	// The first time this function is called, the initial state doesn't
 	// tell us the dimension of the data points; this needs to be extracted
 	// from the ind argument. 
@@ -717,17 +765,17 @@ Datum svm_nd_update(PG_FUNCTION_ARGS)
 		    ARR_NDIM(supp_vecs_arr) != 1 ||
 		    ARR_ELEMTYPE(supp_vecs_arr) != FLOAT8OID) 
 			ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" called with invalid array parameters",
-			       format_procedure(fcinfo->flinfo->fn_oid))));
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("function \"%s\" called with invalid array parameters",
+							format_procedure(fcinfo->flinfo->fn_oid))));
 	}
-
+	
 	float8 * weights = (float8 *)ARR_DATA_PTR(weights_arr);
-
+	
 	// This is the nu-SV novelty detection update algorithm.
 	p = svm_predict_eval(koid,weights,supp_vecs_arr,ind_arr,nsvs,ind_dim); 
 	inds++;
-
+	
 	if (p < rho) {
 		// unlike the original algorithm in Kivinen et al, this 
 		// rescaling is only done when we make a large enough error
@@ -743,15 +791,15 @@ Datum svm_nd_update(PG_FUNCTION_ARGS)
 			// is mathematically irrelevant
 			weights[i] = weights[i] * (1 - 0.1*eta); 
 		}
-
+		
 		weights_arr = addNewWeight(weights_arr,eta,nsvs);
-	        supp_vecs_arr = addNewSV(supp_vecs_arr,ind,nsvs,ind_dim);
+		supp_vecs_arr = addNewSV(supp_vecs_arr,ind,nsvs,ind_dim);
 		nsvs++;
 		rho = rho - eta * (1 - nu);
 	} else {
 		rho = rho + eta * nu; 
 	}
-
+	
 	// Package up the attributes and return the resultant composite object
 	Datum values[10];
 	values[0] = Int32GetDatum(inds);
@@ -764,24 +812,140 @@ Datum svm_nd_update(PG_FUNCTION_ARGS)
 	values[7] = PointerGetDatum(weights_arr);
 	values[8] = PointerGetDatum(supp_vecs_arr);
 	values[9] = UInt32GetDatum(koid);
-
+	
 	TupleDesc tuple;
 	if (get_call_result_type(fcinfo, NULL, &tuple) != TYPEFUNC_COMPOSITE)
 		ereport(ERROR,
-			(errcode( ERRCODE_FEATURE_NOT_SUPPORTED ),
-			 errmsg( "function returning record called in context "
-				 "that cannot accept type record" )));
+				(errcode( ERRCODE_FEATURE_NOT_SUPPORTED ),
+				 errmsg( "function returning record called in context "
+						"that cannot accept type record" )));
 	tuple = BlessTupleDesc(tuple);
-
+	
 	bool * isnulls = palloc0(10 * sizeof(bool));
 	HeapTuple ret = heap_form_tuple(tuple, values, isnulls);
-
+	
 	for (i=0; i!=10; i++)
 		if (isnulls[i])
 			ereport(ERROR,
-		       (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			errmsg("function \"%s\" produced null results %d",
-			       format_procedure(fcinfo->flinfo->fn_oid),i)));
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("function \"%s\" produced null results %d",
+							format_procedure(fcinfo->flinfo->fn_oid),i)));
+	
+	PG_RETURN_DATUM(HeapTupleGetDatum(ret));
+}
 
+// Hinge loss
+float8 dloss(float8 a, float8 y) {
+	float8 z = a * y;
+	if (z > 1) return 0;
+	return y;
+}
+
+#define LSVM_MODEL_C 6
+
+Datum lsvm_sgd_update(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(lsvm_sgd_update);
+
+/**
+ * This is the stochastic gradient descent algorithm for linear SVM in the
+ * primal space.
+ */ 
+Datum lsvm_sgd_update(PG_FUNCTION_ARGS)
+{
+	// Get the input arguments
+	HeapTupleHeader t = PG_GETARG_HEAPTUPLEHEADER(0);
+	ArrayType * ind_arr = PG_GETARG_ARRAYTYPE_P(1);
+	float8 label = PG_GETARG_FLOAT8(2);
+	float8 eta0 = PG_GETARG_FLOAT8(3);
+	float8 lambda = PG_GETARG_FLOAT8(4);
+	
+	bool nil[LSVM_MODEL_C] = {0,0,0,0,0,0};
+	ArrayType * weights_arr = 
+	DatumGetArrayTypeP(GetAttributeByName(t, "weights", &nil[0]));
+	float8 wDivisor = DatumGetFloat8(GetAttributeByName(t, "wdiv",&nil[1]));
+	float8 wBias = DatumGetFloat8(GetAttributeByName(t, "wbias", &nil[2]));
+	int32 ind_dim = DatumGetInt32(GetAttributeByName(t, "ind_dim",&nil[3]));
+	int32 inds = DatumGetInt32(GetAttributeByName(t, "inds", &nil[4]));
+	int32 cum_err = DatumGetInt32(GetAttributeByName(t, "cum_err",&nil[5]));
+	
+	for (int i=0; i!=LSVM_MODEL_C; i++)
+		if (nil[i]) elog(ERROR, "error reading support vector model");
+	
+	// The first time this function is called, the initial state doesn't
+	// tell us the dimension of the data points; this needs to be extracted
+	// from the ind argument. 
+	if (ind_dim == 0) {
+		int ndims = ARR_NDIM(ind_arr);
+		int * dims = ARR_DIMS(ind_arr);
+		ind_dim = ArrayGetNItems(ndims, dims);
+		// initialise weight vector
+		weights_arr = construct_zero_array(ind_dim, FLOAT8OID, 8);
+	} 
+	
+	float8 * weights = (float8 *)ARR_DATA_PTR(weights_arr);
+	float8 * ind = (float8 *)ARR_DATA_PTR(ind_arr);
+	
+	float8 eta = eta0 / (1 + lambda * eta0 * inds);
+	inds++;
+	
+	float8 s = 0;
+	for (int i=0; i!=ind_dim; i++)
+		if (ind[i] != 0) 
+			s += weights[i] * ind[i];
+	
+	s = s / wDivisor + wBias;
+	
+	if (s * label < 0) cum_err++;
+	
+	// update for regularisation term
+	wDivisor = wDivisor / (1 - eta * lambda);
+	
+	if (wDivisor > 1e5)
+		if (wDivisor != 1.0) {
+			for (int i=0; i!=ind_dim; i++)
+				weights[i] *= 1.0 / wDivisor;
+			wDivisor = 1.0;
+		}
+	
+	// update for loss term
+	float8 d = dloss(s,label);
+	if (d != 0) {
+		float8 c = eta * d * wDivisor;
+		for (int i=0; i!=ind_dim; i++)
+			if (ind[i] != 0)
+				weights[i] += ind[i] * c;
+	}
+	
+	// update for bias term
+	float8 etab = eta * 0.01;
+	wBias += etab * d;
+	
+	// Package up the attributes and return the composite object
+	Datum values[LSVM_MODEL_C];
+	values[0] = PointerGetDatum(weights_arr);
+	values[1] = Float8GetDatum(wDivisor);
+	values[2] = Float8GetDatum(wBias);
+	values[3] = Int32GetDatum(ind_dim);
+	values[4] = Int32GetDatum(inds);
+	values[5] = Int32GetDatum(cum_err);
+	
+	TupleDesc tuple;
+	if (get_call_result_type(fcinfo, NULL, &tuple) != TYPEFUNC_COMPOSITE)
+		ereport(ERROR,
+				(errcode( ERRCODE_FEATURE_NOT_SUPPORTED ),
+				 errmsg( "function returning record called in context "
+						"that cannot accept type record" )));
+	tuple = BlessTupleDesc(tuple);
+	
+	bool * isnulls = palloc0(LSVM_MODEL_C * sizeof(bool));
+	HeapTuple ret = heap_form_tuple(tuple, values, isnulls);
+	
+	for (int i=0; i!=LSVM_MODEL_C; i++)
+		if (isnulls[i])
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("function \"%s\" produced null results",
+							format_procedure(fcinfo->flinfo->fn_oid))));
+	
 	PG_RETURN_DATUM(HeapTupleGetDatum(ret));
 }

--- a/methods/kernel_machines/src/pg_gp/online_sv.py_in
+++ b/methods/kernel_machines/src/pg_gp/online_sv.py_in
@@ -120,6 +120,7 @@ def svm_classification( madlib_schema, input_table, model_table, parallel, kerne
 
         # Start learning process
         sql = 'insert into svm_temp_result (select \'' + model_table + '\' || m4_ifdef(`GREENPLUM', `gp_segment_id', `0'), ' + madlib_schema + '.svm_cls_agg(ind, label,\'' + kernel_func + '\',' + str(eta) + ',' + str(nu) + ') from ' + input_table + ' group by 1)';
+
         plpy.execute(sql);
 
         # Store the models learned
@@ -152,7 +153,7 @@ def svm_classification( madlib_schema, input_table, model_table, parallel, kerne
         result = result + [(model_table, summary[i]['id'], summary[i]['inds'], summary[i]['cum_err'], summary[i]['rho'], summary[i]['b'], summary[i]['nsvs'])];
 
     # Clean up temp storage of models
-    plpy.execute('drop table svm_temp_result');
+    #plpy.execute('drop table svm_temp_result');
 
     return result;
 
@@ -336,4 +337,189 @@ def svm_predict_batch( input_table, data_col, id_col, model_table, output_table,
 
     return '''Finished processing data points in %s table; results are stored in %s table. 
            ''' % (input_table,output_table)
+           
+
+
+# ---------------------------------------------------
+# Function to run the linear classification algorithm
+# ---------------------------------------------------
+def lsvm_classification( madlib_schema, input_table, model_table, parallel, verbose=False, eta=0.1, reg=0.001):
+    """
+    Executes the linear support vector classification algorithm.
+
+    @param input_table Name of table/view containing the training data
+    @param model_table Name under which we want to store the learned model 
+    @param parallel A flag indicating whether the system should learn multiple models in parallel
+    @param verbose Verbosity of reporting
+    @param eta Initial learning rate in (0,1] (default value is 0.1)
+    @param reg Regularization parameter, often chosen by cross-validation (default value is 0.001)
+    
+    """
+    plpy.execute('CREATE TABLE ' + model_table + ' (id text, weights float8[], wdiv float8, wbias float8) m4_ifdef(`GREENPLUM', `DISTRIBUTED RANDOMLY')');
+    plpy.execute('CREATE TEMP TABLE svm_temp_result ( id text, model ' + madlib_schema + '.lsvm_sgd_model_rec ) m4_ifdef(`GREENPLUM', `DISTRIBUTED RANDOMLY')');
+
+    if (verbose):
+        plpy.info("Parameters:");
+        plpy.info(" * input_table = %s" % input_table);
+        plpy.info(" * model_table = " + model_table);
+        plpy.info(" * parallel = " + str(parallel));
+        plpy.info(" * eta = " + str(eta));
+        plpy.info(" * reg = " + str(reg));
+
+    if (parallel) :
+        # Learning multiple models in parallel
+        
+        # Start learning process
+        sql = 'INSERT INTO svm_temp_result (SELECT \'' + model_table + '\' || m4_ifdef(`GREENPLUM', `gp_segment_id', `0'), ' + madlib_schema + '.lsvm_sgd_agg(ind, label, ' + str(eta) + ',' + str(reg) + ') FROM ' + input_table + ' group by 1)';
+        plpy.execute(sql);
+
+        # Store the model learned
+        plpy.execute('INSERT INTO ' + model_table + ' SELECT id, (model).weights, (model).wdiv, (model).wbias From svm_temp_result');
+        
+    else :
+        # Learning multiple models in parallel
+        
+        # Start learning a single model    
+        sql = 'INSERT INTO svm_temp_result (SELECT \'' + model_table + '\',' + madlib_schema + '.lsvm_sgd_agg(ind, label,' + str(eta) + ',' + str(reg) + ') FROM ' + input_table + ')';
+        plpy.execute(sql);
+
+        # Store the model learned
+        plpy.execute('INSERT INTO ' + model_table + ' SELECT id, (model).weights, (model).wdiv, (model).wbias FROM svm_temp_result');
+
+    # Retrieve and return the summary for each model learned    
+    if parallel:
+        where_cond = "position('" + model_table + "' in id) > 0 AND '" + model_table + "' <> id";
+    else:
+        where_cond = "id = '" + model_table + "'";
+
+    summary = plpy.execute("SELECT id, (model).inds, (model).ind_dim, (model).cum_err, (model).wbias, (model).wdiv from svm_temp_result where " + where_cond);
+
+    result = [];
+    for i in range(0,summary.nrows()):
+        result = result + [(model_table, summary[i]['id'], summary[i]['inds'], summary[i]['ind_dim'], summary[i]['cum_err'], summary[i]['wbias'], summary[i]['wdiv'])];
+
+    # Clean up temp storage of models
+    plpy.execute('drop table svm_temp_result');
+
+    return result;
+
+
+# ----------------------------------------------------------------------------------
+# Function to predict the labels of a data point using a linear support vector model
+# ----------------------------------------------------------------------------------
+def lsvm_predict(madlib_schema, model_table, ind):
+    """
+    Scores a data point using a learned linear support vector model.
+
+    @param model_table The table storing the learned model to be used
+    @param ind The data point to be scored
+    
+    """
+    
+    nmodels_rec = plpy.execute("SELECT count(distinct id) FROM " + model_table)
+
+    if (nmodels_rec[0]['count'] <> 1):
+        plpy.error("Error in lsvm_predict(): the table contains an ensemble of models")
+
+    param_t = plpy.execute('SELECT * FROM ' + model_table);
+    weights = param_t[0]['weights']
+    wdiv = param_t[0]['wdiv']
+    wbias = param_t[0]['wbias']
+    
+    sql = 'SELECT ' + madlib_schema + '.svm_dot(\'' + str(weights) + '\', \'' + str(ind) +'\') /' + str(wdiv) + ' + ' + str(wbias) + ' AS sum FROM ' + model_table
+    ret = plpy.execute(sql);
+
+    if (ret.nrows() == 0):
+       plpy.error("Error executing lsvm_predict()");    
+
+    return ret[0]['sum'];
+
+    
+# ------------------------------------------------------------------------------------------
+# Function to predict the labels of a data point using a set of linear support vector models
+# ------------------------------------------------------------------------------------------
+def lsvm_predict_combo( madlib_schema, model_table, ind):
+    """
+    Scores a data point using an ensemble of support vector models.
+
+    @param model_table The table storing the learned model to be used
+    @param ind The data point to be scored
+    
+    """
+
+    nmodels_rec = plpy.execute("select count(distinct id) from " + model_table);
+    nmodels = nmodels_rec[0]['count'];
+
+    if (nmodels <= 1):
+        plpy.info("lsvm_predict_combo(): not an ensemble of models, will use a single prediction");
+        pred = plpy.execute("SELECT * from " + madlib_schema + ".lsvm_predict('" + model_table + "', array[" + str(ind)[1:-1] + "])")
+        return [( model_table, pred[0]['lsvm_predict'] )]
+
+    sumpr = 0.0;
+    ret = [];
+
+    for i in range(0,nmodels):
+        param_t = plpy.execute("SELECT * FROM " + model_table + " WHERE id = '" + model_table + str(i) + "'")
+        weights = param_t[0]['weights']
+        wdiv = param_t[0]['wdiv']
+        wbias = param_t[0]['wbias']
+
+        sql = 'SELECT ' + madlib_schema + '.svm_dot(\'' + str(weights) + '\', \'' + str(ind) +'\') /' + str(wdiv) + ' + ' + str(wbias) + ' AS sum FROM ' + model_table + ' WHERE id = \'' +  model_table + str(i) + '\''
+        pred = plpy.execute(sql);
+        if (pred.nrows() == 0):
+            plpy.error("lsvm_predict_combo(): failed to compute prediction for model '" + model_table + str(i) + "'.");
+
+        prediction = pred[0]['sum'];
+        sumpr = sumpr + prediction;
+        ret = ret + [(model_table + str(i), prediction)];
+
+    ret = ret + [('avg', sumpr/nmodels)];	
+    return ret;
+
+
+# ------------------------------------------------------------------------------
+# Function to predict the labels of points in a table using a linear classifier
+# ------------------------------------------------------------------------------
+def lsvm_predict_batch( madlib_schema, input_table, data_col, id_col, model_table, output_table, parallel):
+    """
+    Scores the data points stored in a table using a learned support vector model.
+
+    @param input_table Name of table/view containing the data points to be scored
+    @param data_col Name of column in input_table containing the data points
+    @param id_col Name of column in input_table containing (integer) identifier for data point
+    @param model_table Name of learned model 
+    @param output_table Name of table to store the results 
+    @param parallel A flag indicating whether the system should learn multiple models in parallel
+    
+    """
+
+    plpy.execute('DROP TABLE IF EXISTS ' + output_table);
+    plpy.execute('CREATE TABLE ' + output_table + ' ( id int, prediction float8 ) m4_ifdef(`GREENPLUM', `distributed by (id)')');
+        
+    if (parallel) :
+        num_models_t = plpy.execute('SELECT COUNT(DISTINCT(id)) n FROM ' + model_table + ' WHERE position(\'' + model_table + '\' in id) > 0 AND \'' + model_table + '\' <> id;'); 
+        num_models = num_models_t[0]['n'];
+        if (num_models == 0) :
+            plpy.error("lsvm_predict_batch(): the specified model table does not contain parallelly learned models.");
+            
+        for i in range(0,num_models):
+            param_t = plpy.execute('SELECT * FROM ' + model_table + ' WHERE id = \'' + model_table + str(i) + '\'')
+            weights = param_t[0]['weights']
+            wdiv = param_t[0]['wdiv']
+            wbias = param_t[0]['wbias']
+
+            sql = 'INSERT INTO ' + output_table + ' (SELECT ' + id_col + ',' + madlib_schema + '.svm_dot(\'' + str(weights) + '\', ind)/' + str(wdiv) + '+' + str(wbias) + ' FROM ' + input_table + ')';
+            plpy.execute(sql);
+    else :
+        param_t = plpy.execute('SELECT * FROM ' + model_table);
+        weights = param_t[0]['weights']
+        wdiv = param_t[0]['wdiv']
+        wbias = param_t[0]['wbias']
+        sql = 'INSERT INTO ' + output_table + ' (SELECT ' + id_col + ', ' +  madlib_schema + '.svm_dot(\'' + str(weights) + '\', ind) /' + str(wdiv) + ' + ' + str(wbias) + ' FROM ' + input_table + ')';
+
+        plpy.execute(sql);
+
+    return '''Finished processing data points in %s table; results are stored in %s table. 
+           ''' % (input_table,output_table)
+           
 

--- a/methods/kernel_machines/src/pg_gp/online_sv.sql_in
+++ b/methods/kernel_machines/src/pg_gp/online_sv.sql_in
@@ -386,16 +386,6 @@ CREATE TYPE MADLIB_SCHEMA.svm_nd_result AS (
 CREATE TYPE MADLIB_SCHEMA.svm_support_vector AS ( id text, weight float8, sv float8[] );
 
 
-/**
- * @brief Data normalization function
- *
- * @param x The data point \f$ \boldsymbol x \f$
- * @return Returns normalized data.
- *      
- */
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.svm_normalization(x float8[]) RETURNS float8[]
-AS 'MODULE_PATHNAME', 'svm_normalization' LANGUAGE C IMMUTABLE STRICT;
-
 
 -- Kernel functions are a generalisation of inner products. 
 -- They provide the means by which we can extend linear machines to work in non-linear transformed feature spaces.

--- a/methods/kernel_machines/src/pg_gp/online_sv.sql_in
+++ b/methods/kernel_machines/src/pg_gp/online_sv.sql_in
@@ -19,7 +19,7 @@ Support vector machines (SVMs) and related kernel methods have been one of
 the most popular and well-studied machine learning techniques of the 
 past 15 years, with an amazing number of innovations and applications.
 
-In a nutshell, an SVM model $f(x)$ takes the form of
+In a nutshell, an SVM model \f$f(x)\f$ takes the form of
 \f[
     f(x) = \sum_i \alpha_i k(x_i,x),
 \f]
@@ -29,7 +29,7 @@ data point from the training set (called a support vector), and
 objects are. In regression, \f$ f(\boldsymbol x) \f$ is the regression function
 we seek. In classification, \f$ f(\boldsymbol x) \f$ serves as
 the decision boundary; so for example in binary classification, the predictor 
-can output class 1 for object $x$ if \f$ f(\boldsymbol x) \geq 0 \f$, and class
+can output class 1 for object \f$x\f$ if \f$ f(\boldsymbol x) \geq 0 \f$, and class
 2 otherwise.
 
 In the case when the kernel function \f$ k(\cdot, \cdot) \f$ is the standard
@@ -51,18 +51,22 @@ space:
 where \f$ \phi(\boldsymbol x) \f$ projects \f$ \boldsymbol x \f$ into a
 (possibly infinite-dimensional) feature space.
 
-There are many algorithms for learning kernel machines. This module 
-implements the class of online learning with kernels algorithms 
-described in Kivinen et al. [1]. See also the book Scholkopf and Smola [2]
-for much more details.
+There are many algorithms for learning kernel machines. This module
+implements the class of online learning with kernels algorithms
+described in Kivinen et al. [1]. It also includes the Stochastic
+Gradient Descent (SGD) method [3] for learning linear SVMs with the Hinge
+loss \f$l(z) = \max(0, 1-z)\f$. See also the book Scholkopf and Smola [2] for much more
+details.
 
-The implementation follows the original description in the Kivinen et al 
-paper faithfully, except that we only update the support vector model 
-when we make a significant error. The original algorithms update the 
-support vector model at every step, even when no error was made, in the 
-name of regularisation. For practical purposes, and this is verified 
-empirically to a certain degree, updating only when necessary is both 
-faster and better from a learning-theoretic point of view, at least in 
+The SGD implementation is based on L&eacute;on Bottou's SGD package
+(http://leon.bottou.org/projects/sgd). The methods introduced in [1]
+are implemented according to their original descriptions, except that
+we only update the support vector model when we make a significant
+error. The original algorithms in [1] update the support vector model at
+every step, even when no error was made, in the name of
+regularisation. For practical purposes, and this is verified
+empirically to a certain degree, updating only when necessary is both
+faster and better from a learning-theoretic point of view, at least in
 the i.i.d. setting.
 
 Methods for classification, regression and novelty detection are 
@@ -93,8 +97,15 @@ For novelty detection, the label field is not required.
     <em>verbose DEFAULT false</em>, <em>eta DEFAULT 0.1</em>, <em>nu DEFAULT 0.005</em>, <em>slambda DEFAULT 0.05</em>
     );</pre>   
 
--  Classification learning is achieved through the following function:
-	<pre>SELECT \ref svm_classification(
+-  Classification learning is achieved through the following two
+   functions:
+     -# Learn linear SVM(s) using SGD [3]:
+     <pre>SELECT \ref lsvm_classification(
+    '<em>input_table</em>', '<em>model_table</em>', <em>parallel</em>, 
+    <em>verbose DEFAULT false</em>, <em>eta DEFAULT 0.1</em>, <em>reg DEFAULT 0.001</em>
+    );</pre>   
+     -# Learn linear or non-linear SVM(s) using the method described in [1]:
+     <pre>SELECT \ref svm_classification(
     '<em>input_table</em>', '<em>model_table</em>', <em>parallel</em>, '<em>kernel_func</em>', 
     <em>verbose DEFAULT false</em>, <em>eta DEFAULT 0.1</em>, <em>nu DEFAULT 0.005</em>
     );</pre>   
@@ -112,22 +123,39 @@ For novelty detection, the label field is not required.
 
 - To make predictions on a single data point x using a single model
   learned previously, we use the function
-  <pre>SELECT \ref svm_predict('<em>model_table</em>',<em>x</em>);</pre>
+  <pre>SELECT \ref
+  svm_predict('<em>model_table</em>',<em>x</em>);</pre>
+  If the model is produced by the lsvm_classification() function, use
+  the following prediction function instead
+  <pre>SELECT \ref
+  lsvm_predict('<em>model_table</em>',<em>x</em>);</pre>
 
 - To make predictions on new data points using multiple models
   learned in parallel, we use the function
-  <pre>SELECT \ref svm_predict_combo('<em>model_table</em>',<em>x</em>);</pre>
+  <pre>SELECT \ref
+  svm_predict_combo('<em>model_table</em>',<em>x</em>);</pre>
+  If the models are produced by the lsvm_classification() function, use
+  the following prediction function instead
+  <pre>SELECT \ref
+  lsvm_predict_combo('<em>model_table</em>',<em>x</em>);</pre>
+
 
 - Note that, at the moment, we cannot use MADLIB_SCHEMA.svm_predict() and MADLIB_SCHEMA.svm_predict_combo()
   on multiple data points. For example, something like the following will fail:
   <pre>SELECT \ref svm_predict('<em>model_table</em>',<em>x</em>) FROM data_table;</pre>
   Instead, to make predictions on new data points stored in a table using
   previously learned models, we use the function:
-  <pre>SELECT \ref svm_predict_batch('<em>input_table</em>', '<em>data_col</em>', '<em>id</em>', '<em>model_table</em>', '<em>output_table</em>', <em>parallel</em>);</pre>
+  <pre>SELECT \ref svm_predict_batch('<em>input_table</em>', '<em>data_col</em>', '<em>id_col</em>', '<em>model_table</em>', '<em>output_table</em>', <em>parallel</em>);</pre>
   The output_table is created during the function call; an existing table with 
   the same name will be dropped.
   If the parallel parameter is true, then each data point in the input table will have multiple 
-  predicted values corresponding to the number of models learned in parallel.
+  predicted values corresponding to the number of models learned in
+  parallel.\n\n
+  Similarly, use the following function for batch prediction if the
+  model(s) is produced by the lsvm_classification() function:
+  <pre>SELECT \ref lsvm_predict_batch('<em>input_table</em>', '<em>data_col</em>', '<em>id_col</em>', '<em>model_table</em>','<em>output_table</em>', <em>parallel</em>);</pre>
+  
+  
 
 @implementation
 
@@ -224,6 +252,16 @@ sql> select MADLIB_SCHEMA.svm_predict('myexpc', '{10,-2,4,20,10}');
 sql> select MADLIB_SCHEMA.svm_classification('my_schema.my_train_data', 'myexpc', true, 'MADLIB_SCHEMA.svm_dot');
 sql> select * from MADLIB_SCHEMA.svm_predict_combo('myexpc', '{10,-2,4,20,10}');
 \endcode
+-# To learn a linear support vector model using SGD, replace the model-building and prediction steps above by 
+\code
+sql> select MADLIB_SCHEMA.lsvm_classification('my_schema.my_train_data', 'myexpc', false);
+sql> select MADLIB_SCHEMA.lsvm_predict('myexpc', '{10,-2,4,20,10}');
+\endcode
+-# To learn multiple linear support vector models using SGD, replace the model-building and prediction steps above by 
+\code
+sql> select MADLIB_SCHEMA.lsvm_classification('my_schema.my_train_data', 'myexpc', true);
+sql> select MADLIB_SCHEMA.lsvm_predict_combo('myexpc', '{10,-2,4,20,10}');
+\endcode
 
 <strong>Example usage for novelty detection:</strong>
 -# We can randomly generate 100 2-dimensional data (the normal cases)
@@ -254,6 +292,10 @@ sql> select * from MADLIB_SCHEMA.svm_predict_combo('myexpnd', '{-1,-1}');
 [2] Bernhard Scholkopf and Alexander J. Smola: <em>Learning with Kernels:
     Support Vector Machines, Regularization, Optimization, and Beyond</em>, 
     MIT Press, 2002.
+
+[3] L&eacute;on Bottou: <em>Large-Scale Machine Learning with Stochastic
+Gradient Descent</em>, Proceedings of the 19th International
+Conference on Computational Statistics, Springer, 2010.
 	
 @sa File online_sv.sql_in documenting the SQL functions.
 
@@ -281,6 +323,18 @@ CREATE TYPE MADLIB_SCHEMA.svm_model_rec AS (
        kernel_oid oid   -- OID of kernel function
 );
 
+-- The following is the structure to record the results of the linear SVM sgd algorithm
+--
+CREATE TYPE MADLIB_SCHEMA.lsvm_sgd_model_rec AS (
+       weights float8[], -- the weight vector
+       wdiv float8,      -- scaling factor for the weights
+       wbias float8, 	 -- offset/bias of the linear model
+       ind_dim int,      -- the dimension of the individuals
+       inds int,         -- number of individuals processed 
+       cum_err int	 -- cumulative error
+);
+
+
 -- The following is the return type of a regression learning process
 --
 CREATE TYPE MADLIB_SCHEMA.svm_reg_result AS (
@@ -305,6 +359,18 @@ CREATE TYPE MADLIB_SCHEMA.svm_cls_result AS (
        nsvs int          -- number of support vectors
 );
 
+-- The following is the return type of a linear classifier learning process
+--
+CREATE TYPE MADLIB_SCHEMA.lsvm_sgd_result AS (
+       model_table text, -- table where the model is stored
+       model_name text,  -- model name
+       inds int,         -- number of individuals processed 
+       ind_dim int,      -- the dimension of the individuals
+       cum_err float8,   -- cumulative error
+       wdiv float8,      -- scaling factor for the weights
+       wbias float8      -- classifier offset
+);
+
 -- The following is the return type of a novelty detection learning process
 --
 CREATE TYPE MADLIB_SCHEMA.svm_nd_result AS (
@@ -318,6 +384,18 @@ CREATE TYPE MADLIB_SCHEMA.svm_nd_result AS (
 -- The type for representing support vectors
 --
 CREATE TYPE MADLIB_SCHEMA.svm_support_vector AS ( id text, weight float8, sv float8[] );
+
+
+/**
+ * @brief Data normalization function
+ *
+ * @param x The data point \f$ \boldsymbol x \f$
+ * @return Returns normalized data.
+ *      
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.svm_normalization(x float8[]) RETURNS float8[]
+AS 'MODULE_PATHNAME', 'svm_normalization' LANGUAGE C IMMUTABLE STRICT;
+
 
 -- Kernel functions are a generalisation of inner products. 
 -- They provide the means by which we can extend linear machines to work in non-linear transformed feature spaces.
@@ -409,6 +487,21 @@ CREATE AGGREGATE MADLIB_SCHEMA.svm_nd_agg(float8[], text, float8, float8) (
        initcond = '(0,0,0,0,0,0,0,{},{},0)'
 );
 
+-- This is the SGD algorithm for linear SVMs. 
+-- The function updates the support vector model as it processes each new training example.
+-- This function is wrapped in an aggregate function to process all the training examples stored in a table.  
+--
+CREATE OR REPLACE FUNCTION 
+MADLIB_SCHEMA.lsvm_sgd_update(svs MADLIB_SCHEMA.lsvm_sgd_model_rec, ind FLOAT8[], label FLOAT8, eta FLOAT8, reg FLOAT8)
+RETURNS MADLIB_SCHEMA.lsvm_sgd_model_rec AS 'MODULE_PATHNAME', 'lsvm_sgd_update' LANGUAGE C STRICT;   
+
+CREATE AGGREGATE MADLIB_SCHEMA.lsvm_sgd_agg(float8[], float8, float8, float8) (
+       sfunc = MADLIB_SCHEMA.lsvm_sgd_update,
+       stype = MADLIB_SCHEMA.lsvm_sgd_model_rec,
+       initcond = '({},1,0,0,0,0)'
+);
+
+
 -- This function stores a MADLIB_SCHEMA.svm_model_rec stored in model_temp_table into the model_table.
 --
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.svm_store_model(model_temp_table TEXT, model_name TEXT, model_table TEXT) RETURNS VOID AS $$
@@ -433,7 +526,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.svm_store_model(model_temp_table TEXT, 
 	    sql = "INSERT INTO " + model_table \
 	    	      + " SELECT \'" + model_name + "\', (model).weights[" + str(i) + "], " \
 	    	      + "            (model).individuals[(" + str(idx+1) + "):(" + str(idx) + "+" + str(myind_dim) + ")] " \
-	    	      + " FROM " + model_temp_table + " WHERE id = \'" + model_name + "\' LIMIT 1";	    
+	    	      + " FROM " + model_temp_table + " WHERE id = \'" + model_name + "\' LIMIT 1";
 	    plpy.execute(sql);		      
 
 $$ LANGUAGE plpythonu;
@@ -746,3 +839,131 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.svm_generate_nd_data(output_table text,
     plpy.execute("INSERT INTO " + output_table + " SELECT a.val, MADLIB_SCHEMA.__svm_random_ind2(" + str(dim) + ") FROM (SELECT generate_series(1," + str(num) + ") AS val) AS a")
 $$ LANGUAGE 'plpythonu';
 
+
+/**
+ * @brief Normalizes the data stored in a table, and save the normalized data in a new table. 
+ *
+ * @param input_table Name of table/view containing the data points to be scored
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.svm_data_normalization(input_table TEXT) RETURNS VOID AS $$
+    output_table = input_table + "_scaled";
+    plpy.execute("DROP TABLE IF EXISTS " + output_table);
+    plpy.execute("CREATE TABLE " + output_table + " ( id int, ind float8[], label int ) m4_ifdef(`GREENPLUM', `distributed by (id)')");
+    plpy.execute("INSERT INTO " + output_table + " SELECT id, MADLIB_SCHEMA.svm_normalization(ind), label FROM " + input_table);
+    plpy.info("output table: %s" % output_table)
+$$ LANGUAGE plpythonu;
+
+
+/**
+ * @brief This is the linear support vector classification function
+ *
+ * @param input_table The name of the table/view with the training data
+ * @param model_table The name of the table under which we want to store the learned model
+ * @param parallel A flag indicating whether the system should learn multiple models in parallel
+ * @return A summary of the learning process
+ *
+ * @internal 
+ * @sa This function is a wrapper for online_sv::lsvm_classification().
+*/ 
+CREATE OR REPLACE FUNCTION 
+MADLIB_SCHEMA.lsvm_classification(input_table text, model_table text, parallel bool) 
+RETURNS SETOF MADLIB_SCHEMA.lsvm_sgd_result
+AS $$
+    PythonFunctionBodyOnly(`kernel_machines', `online_sv')
+    # MADlibSchema comes from PythonFunctionBodyOnly
+    return online_sv.lsvm_classification( MADlibSchema, input_table, model_table, parallel);
+$$ LANGUAGE 'plpythonu';
+
+
+
+/**
+ * @brief This is the linear support vector classification function
+ *
+ * @param input_table The name of the table/view with the training data
+ * @param model_table The name of the table under which we want to store the learned model
+ * @param parallel A flag indicating whether the system should learn multiple models in parallel
+ * @param verbose Verbosity of reporting
+ * @param eta Initial learning rate in (0,1]
+ * @param reg Regularization parameter, often chosen by cross-validation
+ * @return A summary of the learning process
+ *
+ * @internal 
+ * @sa This function is a wrapper for online_sv::lsvm_classification().
+*/ 
+CREATE OR REPLACE FUNCTION 
+MADLIB_SCHEMA.lsvm_classification(input_table text, model_table text, parallel bool, verbose bool, eta float8, reg float8)
+RETURNS SETOF MADLIB_SCHEMA.lsvm_sgd_result
+AS $$
+
+    PythonFunctionBodyOnly(`kernel_machines', `online_sv')
+    
+    # MADlibSchema comes from PythonFunctionBodyOnly
+    return online_sv.lsvm_classification( MADlibSchema, input_table, model_table, parallel, verbose, eta, reg);
+
+$$ LANGUAGE 'plpythonu';
+
+
+/**
+ * @brief Scores the data points stored in a table using a learned linear support-vector model
+ *
+ * @param input_table Name of table/view containing the data points to be scored
+ * @param data_col Name of column in input_table containing the data points
+ * @param id_col Name of column in input_table containing the integer identifier of data points
+ * @param model_table Name of table where the learned model to be used is stored
+ * @param output_table Name of table to store the results 
+ * @param parallel A flag indicating whether the model to be used was learned in parallel
+ * @return Textual summary of the algorithm run
+ *
+ * @internal 
+ * @sa This function is a wrapper for online_sv::lsvm_predict_batch().
+ */
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.lsvm_predict_batch(input_table text, data_col text, id_col text, model_table text, output_table text, parallel bool)
+RETURNS TEXT
+AS $$
+
+    PythonFunctionBodyOnly(`kernel_machines', `online_sv')
+    
+    # MADlibSchema comes from PythonFunctionBodyOnly
+    return online_sv.lsvm_predict_batch( MADlibSchema, input_table, data_col, id_col, model_table, output_table, parallel);
+    
+$$ LANGUAGE 'plpythonu';
+
+
+/**
+ * @brief Evaluates a linear support-vector model on a given data point
+ *
+ * @param model_table The table storing the learned model \f$ f \f$ to be used
+ * @param ind The data point \f$ \boldsymbol x \f$
+ * @return This function returns \f$ f(\boldsymbol x) \f$
+ */
+CREATE OR REPLACE FUNCTION 
+MADLIB_SCHEMA.lsvm_predict(model_table text, ind float8[]) RETURNS FLOAT8 AS $$
+
+    PythonFunctionBodyOnly(`kernel_machines', `online_sv')
+    
+    # MADlibSchema comes from PythonFunctionBodyOnly
+    return online_sv.lsvm_predict(MADlibSchema, model_table, ind);
+
+$$ LANGUAGE plpythonu;
+
+/**
+ * @brief Evaluates multiple linear support-vector models on a data point
+ *
+ * @param model_table The table storing the learned models to be used.
+ * @param ind The data point \f$ \boldsymbol x \f$
+ * @return This function returns a table, a row for each model.
+ *      Moreover, the last row contains the average value, over all models.
+ *
+ * The different models are assumed to be named <tt><em>model_table</em>0</tt>,
+ * <tt><em>model_table</em>1</tt>, ....
+ */
+CREATE OR REPLACE FUNCTION
+MADLIB_SCHEMA.lsvm_predict_combo(model_table text, ind float8[]) RETURNS SETOF MADLIB_SCHEMA.svm_model_pr AS $$
+
+    PythonFunctionBodyOnly(`kernel_machines', `online_sv')
+    
+    # MADlibSchema comes from PythonFunctionBodyOnly
+    return online_sv.lsvm_predict_combo( MADlibSchema, model_table, ind);
+
+$$ LANGUAGE plpythonu;

--- a/methods/kernel_machines/src/pg_gp/sql/kernel_mach.sql_in
+++ b/methods/kernel_machines/src/pg_gp/sql/kernel_mach.sql_in
@@ -41,6 +41,16 @@ select * from MADLIB_SCHEMA.svm_classification('svm_train_data', 'clsp', true, '
 select pred.prediction > 0 from MADLIB_SCHEMA.svm_predict_combo('clsp', '{10,-20,5,5}') as pred;
 select pred.prediction < 0 from MADLIB_SCHEMA.svm_predict_combo('clsp', '{-10,20,5,5}') as pred;
 
+-- Example usage for LINEAR classification, replace the above by
+select * from MADLIB_SCHEMA.lsvm_classification('svm_train_data', 'lclss', false);
+select MADLIB_SCHEMA.lsvm_predict('lclss', '{10,-20,5,5}') > 0;
+select MADLIB_SCHEMA.lsvm_predict('lclss', '{-10,20,5,5}') < 0;
+
+-- To learn multiple LINEAR support vector models, replace the above by 
+select * from MADLIB_SCHEMA.lsvm_classification('svm_train_data', 'lclsp', true);
+select pred.prediction > 0 from MADLIB_SCHEMA.lsvm_predict_combo('lclsp', '{10,-20,5,5}') as pred;
+select pred.prediction < 0 from MADLIB_SCHEMA.lsvm_predict_combo('lclsp', '{-10,20,5,5}') as pred;
+
 -- Example usage for novelty detection:
 select MADLIB_SCHEMA.svm_generate_nd_data('svm_train_data', 10000, 4);
 select * from MADLIB_SCHEMA.svm_novelty_detection('svm_train_data', 'nds', false, 'MADLIB_SCHEMA.svm_dot');

--- a/methods/svec/src/pg_gp/SparseData.c
+++ b/methods/svec/src/pg_gp/SparseData.c
@@ -37,10 +37,14 @@ SparseData makeSparseData(void) {
 	/* Allocate the included elements */
 	sdata->vals  = makeStringInfo();
 	sdata->index = makeStringInfo();
-	sdata->vals->len = 0;
-	sdata->index->len = 0;
-	sdata->vals->cursor = 0;
-	sdata->index->cursor = 0;
+
+	Assert(sdata->vals->len == 0);
+	Assert(sdata->index->len == 0);
+	Assert(sdata->vals->cursor == 0);
+	Assert(sdata->index->cursor == 0);
+	Assert(sdata->vals->data[0] == '\0');
+	Assert(sdata->index->data[0] == '\0');
+	
 	sdata->unique_value_count=0;
 	sdata->total_value_count=0;
 	sdata->type_of_data = FLOAT8OID;
@@ -59,8 +63,16 @@ SparseData makeEmptySparseData(void) {
 	pfree(sdata->index->data);
 	sdata->vals->data  = palloc(1);
 	sdata->index->data = palloc(1);
-	sdata->vals->maxlen=0;
-	sdata->index->maxlen=0;
+
+	// -- KS fix
+	sdata->vals->data[0] = '\0';
+	sdata->index->data[0] = '\0';
+	sdata->vals->maxlen = 1;
+	sdata->index->maxlen = 1;
+
+	// sdata->vals->maxlen=0;
+	// sdata->index->maxlen=0;
+
 	return sdata;
 }
 
@@ -94,7 +106,18 @@ SparseData makeInplaceSparseData(char *vals, char *index,
 	sdata->index->len = indexsize;
 	sdata->index->maxlen = sdata->index->len;
 	sdata->type_of_data = datatype;
+
+	// These will fail for sure
+	Assert(sdata->vals->maxlen > sdata->vals->len);
+	Assert(sdata->index->maxlen > sdata-index->len);
+
 	return sdata;
+
+	/*
+	 * Note: If we can ensure the input vals and index always terminate
+	 * with a null, then we can retain the code, changing only 
+	 * maxlen = len + 1
+	 */
 }
 
 /**
@@ -129,6 +152,12 @@ SparseData makeSparseDataFromDouble(double constant,int64 dimension) {
 		ereport(ERROR,(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 			       errmsg("Internal error")));
 	}
+
+	Assert(sdata->index->maxlen > sdata->index->len &&
+	       sdata->index[sdata->index->len] == '\0');
+	Assert(sdata->vals->maxlen > sdata->vals->len &&
+	       sdata->vals[sdata->vals->len] == '\0');
+
 	return sdata;
 }
 
@@ -159,6 +188,7 @@ StringInfo copyStringInfo(StringInfo sinfo) {
 	char *data;
 	if (sinfo->data == NULL) {
 		data = NULL;
+		Assert(sinfo->len == 0);
 	} else {
 		data   = (char *)palloc(sizeof(char)*(sinfo->len+1));
 		memcpy(data,sinfo->data,sinfo->len);
@@ -175,10 +205,14 @@ StringInfo copyStringInfo(StringInfo sinfo) {
  */
 StringInfo makeStringInfoFromData(char *data,int len) {
 	StringInfo sinfo;
+
+	// We assume data is a length len+1 array terminated by a null
+	Assert(data[len] == '\0');
+
 	sinfo = (StringInfo)palloc(sizeof(StringInfoData));
 	sinfo->data   = data;
 	sinfo->len    = len;
-	sinfo->maxlen = len;
+	sinfo->maxlen = len+1; // KS fix
 	sinfo->cursor = 0;
 	return sinfo;
 }
@@ -241,6 +275,11 @@ SparseData arr_to_sdata(char *array, size_t width, Oid type_of_data, int count){
 	/* Add the final tallies */
 	sdata->unique_value_count = sdata->vals->len/width;
 	sdata->total_value_count = count;
+
+	Assert(sdata->index->maxlen > sdata->index->len &&
+	       sdata->index[sdata->index->len] == '\0');
+	Assert(sdata->vals->maxlen > sdata->vals->len &&
+	       sdata->vals[sdata->vals->len] == '\0');
 
 	return sdata;
 }
@@ -317,8 +356,15 @@ SparseData posit_to_sdata(char *array, int64* array_pos, size_t width, Oid type_
 	
 	/* Add the final tallies */
 	sdata->unique_value_count = sdata->vals->len/width;
-	sdata->total_value_count = count;
+	// sdata->total_value_count = count;
+	sdata->total_value_count = end;
 	pfree(index);
+
+	Assert(sdata->index->maxlen > sdata->index->len &&
+	       sdata->index[sdata->index->len] == '\0');
+	Assert(sdata->vals->maxlen > sdata->vals->len &&
+	       sdata->vals[sdata->vals->len] == '\0');
+
 	return sdata;
 }
 
@@ -506,6 +552,12 @@ SparseData subarr(SparseData sdata, int start, int end) {
 		read += esize;
 		if (read == end) break;
 	}
+
+	Assert(ret->index->maxlen > ret->index->len &&
+	       ret->index[ret->index->len] == '\0');
+	Assert(ret->vals->maxlen > ret->vals->len &&
+	       ret->vals[ret->vals->len] == '\0');
+
 	return ret;
 }
 
@@ -528,6 +580,12 @@ SparseData reverse(SparseData sdata) {
 		add_run_to_sdata((char *)(&vals[j]),compword_to_int8(ix),w,ret);
 		ix -= int8compstoragesize(ix);
 	}
+
+	Assert(ret->index->maxlen > ret->index->len &&
+	       ret->index[ret->index->len] == '\0');
+	Assert(ret->vals->maxlen > ret->vals->len &&
+	       ret->vals[ret->vals->len] == '\0');
+
 	return ret;
 }
 
@@ -553,13 +611,16 @@ SparseData concat(SparseData left, SparseData right) {
 	int val_len=l_val_len+r_val_len;
 	int ind_len=l_ind_len+r_ind_len;
 	
-	vals = (char *)palloc(sizeof(char)*val_len);
-	index = (char *)palloc(sizeof(char)*ind_len);
+	vals = (char *)palloc(sizeof(char)*(val_len+1)); // KS fix
+	index = (char *)palloc(sizeof(char)*(ind_len+1)); // KS fix
 	
 	memcpy(vals          ,left->vals->data,l_val_len);
 	memcpy(vals+l_val_len,right->vals->data,r_val_len);
 	memcpy(index,          left->index->data,l_ind_len);
 	memcpy(index+l_ind_len,right->index->data,r_ind_len);
+
+	vals[val_len] = '\0'; // KS fix
+	index[ind_len] = '\0'; // KS fix
 	
 	sdata->vals  = makeStringInfoFromData(vals,val_len);
 	sdata->index = makeStringInfoFromData(index,ind_len);
@@ -568,6 +629,12 @@ SparseData concat(SparseData left, SparseData right) {
 		right->unique_value_count;
 	sdata->total_value_count  = left->total_value_count+
 		right->total_value_count;
+
+	Assert(sdata->index->maxlen > sdata->index->len &&
+	       sdata->index[sdata->index->len] == '\0');
+	Assert(sdata->vals->maxlen > sdata->vals->len &&
+	       sdata->vals[sdata->vals->len] == '\0');
+
 	return sdata;
 }
 
@@ -594,6 +661,12 @@ SparseData lapply(text * func, SparseData sdata) {
 		    DatumGetFloat8(
 		      OidFunctionCall1(foid,
 				    Float8GetDatum(valref(float8,sdata,i))));
+
+	Assert(result->index->maxlen > result->index->len &&
+	       result->index[result->index->len] == '\0');
+	Assert(result->vals->maxlen > result->vals->len &&
+	       result->vals[result->vals->len] == '\0');
+
 	return result;
 }
 


### PR DESCRIPTION
Hi,

Kee Siong and I added the Stochastic Gradient Descent method for Linear SVM Training to online_sv.c. New functions are declared in online_sv.sql_in with their corresponding python wrappers in online_sv.py_in. Unit tests for the new functions are added to the kernel_mach.sql_in file. The usage documentation in online_sv.sql_in is already updated to incorporate the changes.

A bug in SparseData.c is also fixed.

I would appreciate if you could review the changes.

Thanks,
Jin
