### PR TITLE
Greenplum 4.1 compatibility / Underflow-safe logistic function

### DIFF
--- a/src/config/Modules.yml
+++ b/src/config/Modules.yml
@@ -21,6 +21,7 @@ modules:
 #    - name: prob
     - name: quantile 
     - name: regress
+      depends: ['array_ops']
     - name: sketch
     - name: svd_mf
     - name: svec

--- a/src/ports/greenplum/modules/compatibility/compatibility.sql_in
+++ b/src/ports/greenplum/modules/compatibility/compatibility.sql_in
@@ -20,15 +20,23 @@ known limitations in support of the SQL standard or bugs.
 
 This module contains workarounds for the following issues:
 
-- Using <tt>CREATE TABLE AS</tt> with the output of certain MADlib functions
-  fails with the error “function cannot execute on segment because it issues a
-  non-SELECT statement”. The workaround is:
+- <tt>CREATE TABLE <em>table_name</em> AS <em>query</em></tt> statements where
+  <em>query</em> contains certain MADlib functions fails with the error
+  “function cannot execute on segment because it issues a non-SELECT statement”.
+  The workaround is:
   <pre>SELECT \ref create_table_as('<em>table_name</em>', $$
     <em>query</em>
 $$, 'BY (<em>column</em>, [...]) | RANDOMLY');</pre>
+- <tt>INSERT INTO <em>table_name</em> <em>query</em></tt> where <em>query</em>
+  contains certain MADlib functions fails with the error “function cannot
+  execute on segment because it issues a non-SELECT statement”. The workaround
+  is:
+  <pre>SELECT \ref insert_into('<em>table_name</em>', $$
+    <em>query</em>
+$$);</pre>
 
 @note
-These function are not installed on other DBMSs (and not needed there).
+These functions are not installed on other DBMSs (and not needed there).
 Workarounds should be used only when necessary. For portability and best
 performance, standard SQL should be prefered whenever possible.
 
@@ -41,7 +49,22 @@ performance, standard SQL should be prefered whenever possible.
 
 */
 
-CREATE FUNCTION MADLIB_SCHEMA.internal_create_table_as(
+CREATE FUNCTION MADLIB_SCHEMA.create_schema_pg_temp()
+RETURNS VOID
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    IF pg_my_temp_schema() = 0 THEN
+        -- The pg_temp schema does not exist, yet. Creating a temporary table
+        -- will create it.
+        EXECUTE 'CREATE TEMPORARY TABLE _madlib_temp_table AS SELECT 1;
+            DROP TABLE pg_temp._madlib_temp_table CASCADE;';
+    END IF;
+END;
+$$;
+
+CREATE FUNCTION MADLIB_SCHEMA.internal_create_empty_table_as(
     "inTemporary" BOOLEAN,
     "inTableName" VARCHAR,
     "inSQL" VARCHAR,
@@ -52,20 +75,8 @@ VOLATILE
 RETURNS NULL ON NULL INPUT
 AS $$
 DECLARE
-    oldClientMinMessages VARCHAR;
     whatToCreate VARCHAR;
 BEGIN
-    oldClientMinMessages :=
-        (SELECT setting FROM pg_settings WHERE name = 'client_min_messages');
-    EXECUTE 'SET client_min_messages TO warning';
-    
-    IF pg_my_temp_schema() = 0 THEN
-        -- The pg_temp schema does not exist, yet. Creating a temporary table
-        -- will create it.
-        EXECUTE 'CREATE TEMPORARY TABLE _madlib_temp_table AS SELECT 1;
-            DROP TABLE pg_temp._madlib_temp_table CASCADE;';
-    END IF;
-    
     IF "inTemporary" = TRUE THEN
         whatToCreate := 'TEMPORARY TABLE';
     ELSE
@@ -80,7 +91,55 @@ BEGIN
         AS SELECT * FROM (' || "inSQL" || ') AS _madlib_ignore
         WHERE FALSE
         DISTRIBUTED ' || "inDistributed";
-    
+END;
+$$;
+
+
+/**
+ * @brief Mimick <tt>INSERT INTO</tt>. Create new rows in a table.
+ *
+ * @param inTableName The name (optionally schema-qualified) of an existing
+ *     table.
+ * @param inSQL A SELECT command.
+ *
+ * @usage
+ * Use in the same way as the <tt>INSERT INTO</tt> statement:
+ * <pre>SELECT insert_into('<em>table_name</em>', $$
+ *    <em>query</em>
+ *$$);</pre>
+ * 
+ * @examp
+ * <pre>SELECT insert_into('public.test', $$
+ *    SELECT * FROM generate_series(1,10) AS id
+ *$$);\n
+ *SELECT insert_into('logregr_results', $$
+ *    SELECT * FROM logregr('data', 'y', 'x')
+ *$$);</pre>
+ *
+ * @note This function is a workaround. For compliance with the SQL standard and
+ *     for optimal performance, please use the normal <tt>INSERT INTO</tt>
+ *     statement whenever possible.
+ *     Known caveats of this workaround:
+ *     - For queries returning a large number of rows, this function will be
+ *       significantly slower than the <tt>INSERT INTO</tt> statement.
+ */
+CREATE FUNCTION MADLIB_SCHEMA.insert_into(
+    "inTableName" VARCHAR,
+    "inSQL" VARCHAR)
+RETURNS VOID
+LANGUAGE plpgsql
+VOLATILE
+RETURNS NULL ON NULL INPUT
+AS $$
+DECLARE
+    oldClientMinMessages VARCHAR;
+BEGIN
+    oldClientMinMessages :=
+        (SELECT setting FROM pg_settings WHERE name = 'client_min_messages');
+    EXECUTE 'SET client_min_messages TO warning';
+
+    PERFORM MADLIB_SCHEMA.create_schema_pg_temp();
+        
     EXECUTE
         'DROP FUNCTION IF EXISTS pg_temp._madlib_temp_function();
         CREATE FUNCTION pg_temp._madlib_temp_function()
@@ -152,7 +211,9 @@ LANGUAGE sql
 VOLATILE
 RETURNS NULL ON NULL INPUT
 AS $$
-    SELECT MADLIB_SCHEMA.internal_create_table_as(FALSE, $1, $2, $3);
+    SELECT MADLIB_SCHEMA.internal_create_empty_table_as(FALSE,
+        $1, $2, $3);
+    SELECT MADLIB_SCHEMA.insert_into($1, $2);
 $$;
 
 
@@ -164,7 +225,9 @@ LANGUAGE sql
 VOLATILE
 RETURNS NULL ON NULL INPUT
 AS $$
-    SELECT MADLIB_SCHEMA.internal_create_table_as(FALSE, $1, $2, 'RANDOMLY');
+    SELECT MADLIB_SCHEMA.internal_create_empty_table_as(FALSE,
+        $1, $2, 'RANDOMLY');
+    SELECT MADLIB_SCHEMA.insert_into($1, $2);
 $$;
 
 
@@ -183,7 +246,9 @@ LANGUAGE sql
 VOLATILE
 RETURNS NULL ON NULL INPUT
 AS $$
-    SELECT MADLIB_SCHEMA.internal_create_table_as(TRUE, $1, $2, $3);
+    SELECT MADLIB_SCHEMA.internal_create_empty_table_as(TRUE,
+        $1, $2, $3);
+    SELECT MADLIB_SCHEMA.insert_into($1, $2);
 $$;
 
 
@@ -195,7 +260,9 @@ LANGUAGE sql
 VOLATILE
 RETURNS NULL ON NULL INPUT
 AS $$
-    SELECT MADLIB_SCHEMA.internal_create_table_as(TRUE, $1, $2, 'RANDOMLY');
+    SELECT MADLIB_SCHEMA.internal_create_empty_table_as(TRUE,
+        $1, $2, 'RANDOMLY');
+    SELECT MADLIB_SCHEMA.insert_into($1, $2);
 $$;
 
 
@@ -212,7 +279,9 @@ LANGUAGE sql
 VOLATILE
 RETURNS NULL ON NULL INPUT
 AS $$
-    SELECT MADLIB_SCHEMA.internal_create_table_as(TRUE, $1, $2, $3);
+    SELECT MADLIB_SCHEMA.internal_create_empty_table_as(TRUE,
+        $1, $2, $3);
+    SELECT MADLIB_SCHEMA.insert_into($1, $2);
 $$;
 
 
@@ -224,5 +293,7 @@ LANGUAGE sql
 VOLATILE
 RETURNS NULL ON NULL INPUT
 AS $$
-    SELECT MADLIB_SCHEMA.internal_create_table_as(TRUE, $1, $2, 'RANDOMLY');
+    SELECT MADLIB_SCHEMA.internal_create_empty_table_as(TRUE,
+        $1, $2, 'RANDOMLY');
+    SELECT MADLIB_SCHEMA.insert_into($1, $2);
 $$;

--- a/src/ports/greenplum/modules/compatibility/compatibility.sql_in
+++ b/src/ports/greenplum/modules/compatibility/compatibility.sql_in
@@ -64,36 +64,6 @@ BEGIN
 END;
 $$;
 
-CREATE FUNCTION MADLIB_SCHEMA.internal_create_empty_table_as(
-    "inTemporary" BOOLEAN,
-    "inTableName" VARCHAR,
-    "inSQL" VARCHAR,
-    "inDistributed" VARCHAR)
-RETURNS VOID
-LANGUAGE plpgsql
-VOLATILE
-RETURNS NULL ON NULL INPUT
-AS $$
-DECLARE
-    whatToCreate VARCHAR;
-BEGIN
-    IF "inTemporary" = TRUE THEN
-        whatToCreate := 'TEMPORARY TABLE';
-    ELSE
-        whatToCreate := 'TABLE';
-    END IF;
-    
-    -- We separate the following EXECUTE statement because it is prone
-    -- to generate an exception -- e.g., if the table already exists
-    -- In that case we want to keep the context in the error message short
-    EXECUTE
-        'CREATE ' || whatToCreate || ' ' || "inTableName" || '
-        AS SELECT * FROM (' || "inSQL" || ') AS _madlib_ignore
-        WHERE FALSE
-        DISTRIBUTED ' || "inDistributed";
-END;
-$$;
-
 
 /**
  * @brief Mimick <tt>INSERT INTO</tt>. Create new rows in a table.
@@ -170,6 +140,39 @@ END;
 $$;
 
 
+CREATE FUNCTION MADLIB_SCHEMA.internal_create_table_as(
+    "inTemporary" BOOLEAN,
+    "inTableName" VARCHAR,
+    "inSQL" VARCHAR,
+    "inDistributed" VARCHAR)
+RETURNS VOID
+LANGUAGE plpgsql
+VOLATILE
+RETURNS NULL ON NULL INPUT
+AS $$
+DECLARE
+    whatToCreate VARCHAR;
+BEGIN
+    IF "inTemporary" = TRUE THEN
+        whatToCreate := 'TEMPORARY TABLE';
+    ELSE
+        whatToCreate := 'TABLE';
+    END IF;
+    
+    -- We separate the following EXECUTE statement because it is prone
+    -- to generate an exception -- e.g., if the table already exists
+    -- In that case we want to keep the context in the error message short
+    EXECUTE
+        'CREATE ' || whatToCreate || ' ' || "inTableName" || ' AS 
+        SELECT * FROM (' || "inSQL" || ') AS _madlib_ignore
+        WHERE FALSE
+        DISTRIBUTED ' || "inDistributed";
+    
+    PERFORM MADLIB_SCHEMA.insert_into("inTableName", "inSQL");
+END;
+$$;
+
+
 /**
  * @brief Mimick <tt>CREATE TABLE AS</tt>. Create a table and fill it with data
  *     computed by a \c SELECT command.
@@ -211,9 +214,8 @@ LANGUAGE sql
 VOLATILE
 RETURNS NULL ON NULL INPUT
 AS $$
-    SELECT MADLIB_SCHEMA.internal_create_empty_table_as(FALSE,
+    SELECT MADLIB_SCHEMA.internal_create_table_as(FALSE,
         $1, $2, $3);
-    SELECT MADLIB_SCHEMA.insert_into($1, $2);
 $$;
 
 
@@ -225,9 +227,8 @@ LANGUAGE sql
 VOLATILE
 RETURNS NULL ON NULL INPUT
 AS $$
-    SELECT MADLIB_SCHEMA.internal_create_empty_table_as(FALSE,
+    SELECT MADLIB_SCHEMA.internal_create_table_as(FALSE,
         $1, $2, 'RANDOMLY');
-    SELECT MADLIB_SCHEMA.insert_into($1, $2);
 $$;
 
 
@@ -246,9 +247,8 @@ LANGUAGE sql
 VOLATILE
 RETURNS NULL ON NULL INPUT
 AS $$
-    SELECT MADLIB_SCHEMA.internal_create_empty_table_as(TRUE,
+    SELECT MADLIB_SCHEMA.internal_create_table_as(TRUE,
         $1, $2, $3);
-    SELECT MADLIB_SCHEMA.insert_into($1, $2);
 $$;
 
 
@@ -260,9 +260,8 @@ LANGUAGE sql
 VOLATILE
 RETURNS NULL ON NULL INPUT
 AS $$
-    SELECT MADLIB_SCHEMA.internal_create_empty_table_as(TRUE,
+    SELECT MADLIB_SCHEMA.internal_create_table_as(TRUE,
         $1, $2, 'RANDOMLY');
-    SELECT MADLIB_SCHEMA.insert_into($1, $2);
 $$;
 
 
@@ -279,9 +278,8 @@ LANGUAGE sql
 VOLATILE
 RETURNS NULL ON NULL INPUT
 AS $$
-    SELECT MADLIB_SCHEMA.internal_create_empty_table_as(TRUE,
+    SELECT MADLIB_SCHEMA.internal_create_table_as(TRUE,
         $1, $2, $3);
-    SELECT MADLIB_SCHEMA.insert_into($1, $2);
 $$;
 
 
@@ -293,7 +291,6 @@ LANGUAGE sql
 VOLATILE
 RETURNS NULL ON NULL INPUT
 AS $$
-    SELECT MADLIB_SCHEMA.internal_create_empty_table_as(TRUE,
+    SELECT MADLIB_SCHEMA.internal_create_table_as(TRUE,
         $1, $2, 'RANDOMLY');
-    SELECT MADLIB_SCHEMA.insert_into($1, $2);
 $$;

--- a/src/ports/greenplum/modules/compatibility/test/gp_comp.sql_in
+++ b/src/ports/greenplum/modules/compatibility/test/gp_comp.sql_in
@@ -72,3 +72,27 @@ SELECT MADLIB_SCHEMA.create_temporary_table_as(
     $$ SELECT * FROM run_some_non_select_stmnts() as x $$,
     'by (x)'
 );
+
+--
+-- Test with logistic regression
+--
+CREATE TABLE __madlib_gp_logreg_data AS
+SELECT
+    random() < 1 / (1 + exp(-MADLIB_SCHEMA.array_dot(
+        array[0.4, -1.0, 0.7]::DOUBLE PRECISION[], x))
+    ) AS y, x
+FROM (
+    SELECT
+        array[1, random(), random()]::DOUBLE PRECISION[] AS x
+    FROM generate_series(0,9) AS i
+) AS q
+DISTRIBUTED RANDOMLY;
+
+SELECT MADLIB_SCHEMA.create_temporary_table_as(
+    '__madlib_gp_compat_temporary_table_3', $$
+    SELECT * FROM MADLIB_SCHEMA.logregr('__madlib_gp_logreg_data', 'y', 'x')
+$$);
+
+SELECT MADLIB_SCHEMA.insert_into('__madlib_gp_compat_temporary_table_3', $$
+    SELECT * FROM MADLIB_SCHEMA.logregr('__madlib_gp_logreg_data', 'y', 'x')
+$$);

--- a/src/ports/postgres/modules/regress/logistic.sql_in
+++ b/src/ports/postgres/modules/regress/logistic.sql_in
@@ -427,3 +427,26 @@ CREATE FUNCTION MADLIB_SCHEMA.logregr(
 RETURNS MADLIB_SCHEMA.logregr_result AS
 $$SELECT MADLIB_SCHEMA.logregr($1, $2, $3, $4, $5, 0.0001);$$
 LANGUAGE sql VOLATILE;
+
+/**
+ * @brief Evaluate the usual logistic function in an under-/overflow-safe way
+ *
+ * In order for the outcome of exp(x) to be within the range of the minimum
+ * positive double-precision number (i.e., 2^(-1074)) and the maximum positive
+ * double-precision number (i.e., (1 + (1 - 2^52)) * 2^1023), x has to be within
+ * the natural logarithm of these numbers, so roughly in between -744 and 709.
+ * However, 1 + exp(x) will just evaluate to 1 if exp(x) is less than the
+ * machine epsilon (i.e., 2^(-52)) or, equivalently, if x is less than the
+ * natural logarithm of that; i.e., in any case if x is less than -37.
+ * Note that taking the reciprocal of the largest double-precision number will
+ * not cause an underflow. Hence, no further checks are necessary.
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.logistic(x DOUBLE PRECISION)
+RETURNS DOUBLE PRECISION
+LANGUAGE sql
+AS $$
+   SELECT CASE WHEN -$1 < -37 THEN 1
+               WHEN -$1 > 709 THEN 0
+               ELSE 1 / (1 + exp(-$1))
+          END;
+$$


### PR DESCRIPTION
These additions were the direct response to user requests. They should not be needed for GPDB4.2 any more, but they are needed for earlier versions.
