### PR TITLE
The bug that broke the unit tests fixed

### DIFF
--- a/methods/kernel_machines/src/pg_gp/online_sv.py_in
+++ b/methods/kernel_machines/src/pg_gp/online_sv.py_in
@@ -153,7 +153,7 @@ def svm_classification( madlib_schema, input_table, model_table, parallel, kerne
         result = result + [(model_table, summary[i]['id'], summary[i]['inds'], summary[i]['cum_err'], summary[i]['rho'], summary[i]['b'], summary[i]['nsvs'])];
 
     # Clean up temp storage of models
-    #plpy.execute('drop table svm_temp_result');
+    plpy.execute('drop table svm_temp_result');
 
     return result;
 


### PR DESCRIPTION
I accidentally commented out "plpy.execute('drop table svm_temp_result'); " in svm_classification() in
online_sv.py_in. That broke the install-check. The bug has been fixed:

madpack -p greenplum -c yuj18@$HOSTNAME:5432/madlib_test install-check
TEST CASE RESULT|Module: array_ops|array_ops.sql_in|PASS|Time: 38 milliseconds
TEST CASE RESULT|Module: bayes|bayes.sql_in|PASS|Time: 1192 milliseconds
TEST CASE RESULT|Module: compatibility|gp_comp.sql_in|PASS|Time: 262 milliseconds
TEST CASE RESULT|Module: plda|plda.sql_in|PASS|Time: 1715 milliseconds
TEST CASE RESULT|Module: quantile|quantile.sql_in|PASS|Time: 155 milliseconds
TEST CASE RESULT|Module: regress|linear.sql_in|PASS|Time: 430 milliseconds
TEST CASE RESULT|Module: regress|logistic.sql_in|PASS|Time: 1475 milliseconds
TEST CASE RESULT|Module: sketch|cm.sql_in|PASS|Time: 7768 milliseconds
TEST CASE RESULT|Module: sketch|fm.sql_in|PASS|Time: 1062 milliseconds
TEST CASE RESULT|Module: sketch|mfv.sql_in|PASS|Time: 253 milliseconds
TEST CASE RESULT|Module: sketch|support.sql_in|PASS|Time: 33 milliseconds
TEST CASE RESULT|Module: svd_mf|svdmf.sql_in|PASS|Time: 2649 milliseconds
TEST CASE RESULT|Module: svec|svec_test.sql_in|PASS|Time: 1936 milliseconds
TEST CASE RESULT|Module: assoc_rules|assoc_rules.sql_in|PASS|Time: 1007 milliseconds
TEST CASE RESULT|Module: conjugate_gradient|conj_grad.sql_in|PASS|Time: 304 milliseconds
TEST CASE RESULT|Module: data_profile|data_profile.sql_in|PASS|Time: 167 milliseconds
TEST CASE RESULT|Module: decision_tree|dec_trees.sql_in|PASS|Time: 2897 milliseconds
TEST CASE RESULT|Module: kmeans|kmeans.sql_in|PASS|Time: 2496 milliseconds
TEST CASE RESULT|Module: kernel_machines|kernel_mach.sql_in|PASS|Time: 6202 milliseconds
