### PR TITLE
k-means: Fixes for MADLIB-349, MADLIB-365, and others

### DIFF
--- a/methods/kmeans/src/pg_gp/kmeans.c
+++ b/methods/kmeans/src/pg_gp/kmeans.c
@@ -1,0 +1,186 @@
+#include <postgres.h>
+#include <utils/builtins.h>
+#include "../../../svec/src/pg_gp/sparse_vector.h"
+#include "../../../svec/src/pg_gp/operators.h"
+
+typedef enum {
+    L1NORM = 1,
+    L2NORM,
+    COSINE,
+    TANIMOTO
+} KMeansMetric;
+
+static
+inline
+int
+verify_arg_nonnull(PG_FUNCTION_ARGS, int inArgNo)
+{
+    if (PG_ARGISNULL(inArgNo))
+        ereport(ERROR,
+                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                 errmsg("function \"%s\" called with NULL argument",
+                    format_procedure(fcinfo->flinfo->fn_oid))));
+    return inArgNo;
+}
+
+static
+inline
+void
+get_svec_array_elms(ArrayType *inArrayType, Datum **outSvecArr, int *outLen)
+{
+    deconstruct_array(inArrayType,           /* array */
+                  ARR_ELEMTYPE(inArrayType), /* elmtype */
+                  -1,                        /* elmlen */
+                  false,                     /* elmbyval */
+                  'd',                       /* elmalign */
+                  outSvecArr,                /* elemsp */
+                  NULL,                      /* nullsp -- pass NULL, because we 
+                                                don't support NULLs */
+                  outLen);                   /* nelemsp */
+}
+
+static
+inline
+double
+svec_svec_distance(Datum inVec1, Datum inVec2, KMeansMetric inMetric)
+{
+    PGFunction metric_fn = NULL;
+
+    switch (inMetric)
+    {
+        case L1NORM: metric_fn = svec_svec_l1norm; break;
+        case L2NORM: metric_fn = svec_svec_l2norm; break;
+        case COSINE: metric_fn = svec_svec_angle; break;
+        case TANIMOTO: metric_fn = svec_svec_tanimoto_distance; break;
+        default:
+            ereport(ERROR,
+                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                 errmsg("invalid metric")));
+    }
+    
+    return DatumGetFloat8(DirectFunctionCall2(metric_fn, inVec1, inVec2));    
+}
+
+PG_FUNCTION_INFO_V1(internal_get_array_of_close_canopies);
+Datum
+internal_get_array_of_close_canopies(PG_FUNCTION_ARGS)
+{
+    SvecType       *svec;
+    Datum          *all_canopies;
+    int             num_all_canopies;
+    float8          threshold;
+    KMeansMetric    metric;
+    
+    ArrayType      *close_canopies_arr;
+    int4           *close_canopies;
+    int             num_close_canopies;
+    size_t          bytes;
+    
+    svec = PG_GETARG_SVECTYPE_P(verify_arg_nonnull(fcinfo, 0));
+    get_svec_array_elms(PG_GETARG_ARRAYTYPE_P(verify_arg_nonnull(fcinfo, 1)),
+        &all_canopies, &num_all_canopies);
+    threshold = PG_GETARG_FLOAT8(verify_arg_nonnull(fcinfo, 2));
+    metric = PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 3));
+    
+    close_canopies = (int4 *) palloc(sizeof(int4) * num_all_canopies);
+    num_close_canopies = 0;
+    for (int i = 0; i < num_all_canopies; i++) {
+        if (svec_svec_distance(PointerGetDatum(svec), all_canopies[i], metric)
+            < threshold)
+            close_canopies[num_close_canopies++] = i + 1 /* lower bound */;
+    }
+
+    bytes = ARR_OVERHEAD_NONULLS(1) + sizeof(int4) * num_close_canopies;
+    close_canopies_arr = (ArrayType *) palloc0(bytes);
+    SET_VARSIZE(close_canopies_arr, bytes);
+    ARR_ELEMTYPE(close_canopies_arr) = INT4OID;
+    ARR_NDIM(close_canopies_arr) = 1;
+    ARR_DIMS(close_canopies_arr)[0] = num_close_canopies;
+    ARR_LBOUND(close_canopies_arr)[0] = 1;
+    memcpy(ARR_DATA_PTR(close_canopies_arr), close_canopies,
+        sizeof(int4) * num_close_canopies);
+
+    PG_RETURN_ARRAYTYPE_P(close_canopies_arr);
+}
+
+PG_FUNCTION_INFO_V1(internal_kmeans_closest_centroid);
+Datum
+internal_kmeans_closest_centroid(PG_FUNCTION_ARGS) {
+    SvecType       *svec;
+    ArrayType      *canopy_ids_arr = NULL;
+    int4           *canopy_ids = NULL;
+    ArrayType      *centroids_arr;
+    Datum          *centroids;
+    int             num_centroids;
+    KMeansMetric    metric;
+
+    bool            indirect;
+    float8          distance, min_distance = INFINITY;
+    int             closest_centroid = 0;
+    int             cid;
+
+    svec = PG_GETARG_SVECTYPE_P(verify_arg_nonnull(fcinfo, 0));
+    if (PG_ARGISNULL(1)) {
+        indirect = false;
+    } else {
+        indirect = true;
+        canopy_ids_arr = PG_GETARG_ARRAYTYPE_P(1);
+        canopy_ids = (int4*) ARR_DATA_PTR(canopy_ids_arr);
+    }
+    centroids_arr = PG_GETARG_ARRAYTYPE_P(verify_arg_nonnull(fcinfo, 2));
+    get_svec_array_elms(centroids_arr, &centroids, &num_centroids);
+    if (!PG_ARGISNULL(1))
+        num_centroids = ARR_DIMS(canopy_ids_arr)[0];
+    metric = PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 3));
+
+    for (int i = 0; i < num_centroids; i++) {
+        cid = indirect ? canopy_ids[i] - ARR_LBOUND(canopy_ids_arr)[0] : i;
+        distance = svec_svec_distance(PointerGetDatum(svec), centroids[cid],
+            metric);
+        if (distance < min_distance) {
+            closest_centroid = cid;
+            min_distance = distance;
+        }
+    }
+    
+    PG_RETURN_INT32(closest_centroid + ARR_LBOUND(centroids_arr)[0]);
+}
+
+PG_FUNCTION_INFO_V1(internal_kmeans_canopy_transition);
+Datum
+internal_kmeans_canopy_transition(PG_FUNCTION_ARGS) {
+    ArrayType      *canopies_arr;
+    Datum          *canopies;
+    int             num_canopies;
+    SvecType       *point;
+    KMeansMetric    metric;
+    float8          threshold;
+    
+    canopies_arr = PG_GETARG_ARRAYTYPE_P(verify_arg_nonnull(fcinfo, 0));
+    get_svec_array_elms(canopies_arr, &canopies, &num_canopies);
+    point = PG_GETARG_SVECTYPE_P(verify_arg_nonnull(fcinfo, 1));
+    metric = PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 2));
+    threshold = PG_GETARG_FLOAT8(verify_arg_nonnull(fcinfo, 3));
+    
+    for (int i = 0; i < num_canopies; i++) {
+        if (svec_svec_distance(PointerGetDatum(point), canopies[i], metric)
+            < threshold)
+            PG_RETURN_ARRAYTYPE_P(canopies_arr);
+    }
+    
+    int idx = (ARR_NDIM(canopies_arr) == 0)
+        ? 1
+        : ARR_LBOUND(canopies_arr)[0] + ARR_DIMS(canopies_arr)[0];
+    return PointerGetDatum(
+        array_set(
+            canopies_arr, /* array: the initial array object (mustn't be NULL) */
+            1, /* nSubscripts: number of subscripts supplied */
+            &idx, /* indx[]: the subscript values */
+            PointerGetDatum(point), /* dataValue: the datum to be inserted at the given position */
+            false, /* isNull: whether dataValue is NULL */
+            -1, /* arraytyplen: pg_type.typlen for the array type */
+            -1, /* elmlen: pg_type.typlen for the array's element type */
+            false, /* elmbyval: pg_type.typbyval for the array's element type */
+            'd') /* elmalign: pg_type.typalign for the array's element type */
+        );
+}

--- a/methods/kmeans/src/pg_gp/kmeans.c
+++ b/methods/kmeans/src/pg_gp/kmeans.c
@@ -132,6 +132,7 @@ internal_get_array_of_close_canopies(PG_FUNCTION_ARGS)
                 PointerGetDatum(svec), all_canopies[i]) < threshold)
             close_canopies[num_close_canopies++] = i + 1 /* lower bound */;
     }
+    MemoryContextDelete(mem_context_for_function_calls);
 
     /* If we cannot find any close canopy, return NULL. Note that the result
      * we return will be passed to internal_kmeans_closest_centroid() and if the
@@ -199,6 +200,7 @@ internal_kmeans_closest_centroid(PG_FUNCTION_ARGS) {
             min_distance = distance;
         }
     }
+    MemoryContextDelete(mem_context_for_function_calls);
     
     PG_RETURN_INT32(closest_centroid + ARR_LBOUND(centroids_arr)[0]);
 }
@@ -227,6 +229,7 @@ internal_kmeans_canopy_transition(PG_FUNCTION_ARGS) {
             PointerGetDatum(point), canopies[i]) < threshold)
             PG_RETURN_ARRAYTYPE_P(canopies_arr);
     }
+    MemoryContextDelete(mem_context_for_function_calls);
     
     int idx = (ARR_NDIM(canopies_arr) == 0)
         ? 1
@@ -280,6 +283,7 @@ internal_remove_close_canopies(PG_FUNCTION_ARGS) {
         if (addIndexI)
             close_canopies[num_close_canopies++] = all_canopies[i];
     }
+    MemoryContextDelete(mem_context_for_function_calls);
     
     PG_RETURN_ARRAYTYPE_P(
         construct_array(

--- a/methods/svec/src/pg_gp/operators.c
+++ b/methods/svec/src/pg_gp/operators.c
@@ -719,11 +719,11 @@ Datum svec_svec_l1norm(PG_FUNCTION_ARGS)
 	PG_RETURN_FLOAT8(accum);
 }
 
-PG_FUNCTION_INFO_V1( svec_svec_cosine_distance );
+PG_FUNCTION_INFO_V1( svec_svec_angle );
 /**
  *  svec_svec_cosine_distance - Computes the cosine similarity between two SVECs.
  */
-Datum svec_svec_cosine_distance(PG_FUNCTION_ARGS)
+Datum svec_svec_angle(PG_FUNCTION_ARGS)
 {	
 	SvecType *svec1 = PG_GETARG_SVECTYPE_P(0);
 	SvecType *svec2 = PG_GETARG_SVECTYPE_P(1);
@@ -747,7 +747,7 @@ Datum svec_svec_cosine_distance(PG_FUNCTION_ARGS)
 		result = -1.0;
 	}
 
-	PG_RETURN_FLOAT8(result);
+	PG_RETURN_FLOAT8(acos(result));
 }
 
 PG_FUNCTION_INFO_V1( svec_svec_tanimoto_distance );
@@ -778,7 +778,7 @@ Datum svec_svec_tanimoto_distance(PG_FUNCTION_ARGS)
 		result = 0.0;
 	}
 	
-	PG_RETURN_FLOAT8(result);
+	PG_RETURN_FLOAT8(1. - result);
 }
 
 PG_FUNCTION_INFO_V1( svec_normalize );

--- a/methods/svec/src/pg_gp/operators.c
+++ b/methods/svec/src/pg_gp/operators.c
@@ -721,7 +721,7 @@ Datum svec_svec_l1norm(PG_FUNCTION_ARGS)
 
 PG_FUNCTION_INFO_V1( svec_svec_angle );
 /**
- *  svec_svec_cosine_distance - Computes the cosine similarity between two SVECs.
+ *  svec_svec_angle - Computes the angle between two SVECs.
  */
 Datum svec_svec_angle(PG_FUNCTION_ARGS)
 {	

--- a/methods/svec/src/pg_gp/operators.h
+++ b/methods/svec/src/pg_gp/operators.h
@@ -1,0 +1,9 @@
+#ifndef SPARSEVECTOR_OPERATORS_H
+#define SPARSEVECTOR_OPERATORS_H
+
+Datum svec_svec_l1norm(PG_FUNCTION_ARGS);
+Datum svec_svec_l2norm(PG_FUNCTION_ARGS);
+Datum svec_svec_angle(PG_FUNCTION_ARGS);
+Datum svec_svec_tanimoto_distance(PG_FUNCTION_ARGS);
+
+#endif

--- a/methods/svec/src/pg_gp/sql/svec_test.sql_in
+++ b/methods/svec/src/pg_gp/sql/svec_test.sql_in
@@ -161,9 +161,9 @@ select
 select MADLIB_SCHEMA.l1norm(result1, result2) from svec_svec;
 -- Calculate L2 norm from two sparse vectors
 select MADLIB_SCHEMA.l2norm(result1, result2) from svec_svec;
--- Calculate cosine similarity from two sparse vectors
-select MADLIB_SCHEMA.cosine_distance(result1, result2) from svec_svec;
--- Calculate cosine similarity from two sparse vectors
+-- Calculate angle between two sparse vectors
+select MADLIB_SCHEMA.angle(result1, result2) from svec_svec;
+-- Calculate tanimoto distance between two sparse vectors
 select MADLIB_SCHEMA.tanimoto_distance(result1, result2) from svec_svec;
 
 -- Calculate normalized vectors

--- a/methods/svec/src/pg_gp/svec.sql_in
+++ b/methods/svec/src/pg_gp/svec.sql_in
@@ -540,10 +540,10 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.svec_l1norm(MADLIB_SCHEMA.svec) RETURNS
 --!
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.svec_l1norm(float8[]) RETURNS float8 AS 'MODULE_PATHNAME', 'float8arr_l1norm' STRICT LANGUAGE C IMMUTABLE; 
 
---! Computes the Cosine distance between two SVECs.
+--! Computes the angle between two SVECs in radians.
 --!
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.cosine_distance(MADLIB_SCHEMA.svec,MADLIB_SCHEMA.svec) 
-RETURNS float8 AS 'MODULE_PATHNAME', 'svec_svec_cosine_distance' LANGUAGE C STRICT IMMUTABLE;
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.angle(MADLIB_SCHEMA.svec,MADLIB_SCHEMA.svec) 
+RETURNS float8 AS 'MODULE_PATHNAME', 'svec_svec_angle' LANGUAGE C STRICT IMMUTABLE;
 
 --! Computes the Tanimoto distance between two SVECs.
 --!

--- a/src/ports/postgres/modules/kmeans/kmeans.py_in
+++ b/src/ports/postgres/modules/kmeans/kmeans.py_in
@@ -428,7 +428,7 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
         else:
             t1 = rv[0]['t1'];
     elif t1 <= 0:
-        plpy.error( 'canopy threshold T1 can not be zero or negative')        
+        plpy.error( 'canopy threshold T1 cannot be zero or negative')        
         
     if t2 is None: 
         if rv[0]['t2'] is None:
@@ -436,7 +436,7 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
         else:
             t2 = rv[0]['t2'];
     elif t2 <= 0:
-        plpy.error( 'canopy threshold T2 can not be zero or negative')
+        plpy.error( 'canopy threshold T2 cannot be zero or negative')
     
     # Generate initial centroids using T2 (smaller)
     __run_quietly( 'DROP TABLE IF EXISTS TempArrayOfCentroids');
@@ -446,13 +446,12 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
             {madlib_schema}.internal_remove_close_canopies(
                 {madlib_schema}.kmeans_canopy(coords, {metric}, {t2}),
                 {metric},
-                {t1}
+                {t2}
             ) AS ccoords
         FROM {src_points}
         '''.format(
             madlib_schema = madlib_schema,
             metric = __metric_id(dist_metric),
-            t1 = str(float(t1)),
             t2 = str(float(t2)),
             src_points = src_points
     )
@@ -471,14 +470,14 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
     )
     plpy.execute( sql);
     
-    # Assign points to canopies using T1 + T2 (this is a slight deviation from
-    # McCallum et al.)
+    # Assign points to canopies using max(T1, 2 * T2) (this is a slight
+    # deviation from McCallum et al.)
     # Note: After combining all canopies from the segments, we removed canopies
-    # that were closer than T1 to some other canopy. With the triangle
+    # that were closer than T2 to some other canopy. With the triangle
     # inequality, all we can assure afterwards is that no point is farther away
-    # than T1 + T2 from its closest canopy: (In detail: Previously, the closest
+    # than 2 * T2 from its closest canopy: (In detail: Previously, the closest
     # canopy was T2 away, and that canopy was -- if it was removed -- at most
-    # T1 away from another canopy.)
+    # T2 away from another canopy.)
     __run_quietly( 'CREATE TEMP TABLE TempPoints0_Canopies (LIKE TempPoints0)')
     sql = '''
         INSERT INTO TempPoints0_Canopies
@@ -494,7 +493,7 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
         madlib_schema = madlib_schema,
         output_centroids = output_centroids,
         metric = __metric_id(dist_metric),
-        threshold = str(t1 + t2)
+        threshold = str(max(t1, 2 * t2))
     )
     
     plpy.execute( sql);
@@ -588,7 +587,7 @@ def kmeans( madlib_schema
     try:
         plpy.execute( "SELECT * FROM " + src_relation + " LIMIT 1")
     except:
-        plpy.error( 'source relation "%s" does not exist or can not be accessed' % src_relation )
+        plpy.error( 'source relation "%s" does not exist or cannot be accessed' % src_relation )
     info( ' * src_relation = %s' % src_relation)
 
     # Validate: src_col_data

--- a/src/ports/postgres/modules/kmeans/kmeans.py_in
+++ b/src/ports/postgres/modules/kmeans/kmeans.py_in
@@ -400,8 +400,8 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
         # T2 >> is the max value from 1st quantile (10 buckets)
         sql = '''
             SELECT 
-                max( CASE WHEN ntile = 10 THEN dist ELSE null END) as t1 
-                , min( CASE WHEN ntile = 1 THEN dist ELSE null END) as t2 
+                min( CASE WHEN ntile = 10 THEN dist ELSE null END) as t1 
+                , max( CASE WHEN ntile = 1 THEN dist ELSE null END) as t2 
             FROM 
             (
                 SELECT ntile(10) OVER( ORDER BY dist) as ntile, dist FROM 

--- a/src/ports/postgres/modules/kmeans/kmeans.py_in
+++ b/src/ports/postgres/modules/kmeans/kmeans.py_in
@@ -353,13 +353,13 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
            (e.g. 'cosine')  
     @param dist_func Name of the distance/similarity function 
            (e.g. 'cosine_distance')
-    @param t1 Smaller threshold for canopy clustering 
-    @param t2 Larger threshold for canopy clustering 
+    @param t1 Larger threshold for canopy clustering 
+    @param t2 Smaller threshold for canopy clustering 
     @param sample_pct Percent of the input data points to use for centroid 
            seeding
     """
     
-    # Find thresholds T1 and T2 (T1 < T2)
+    # Find thresholds T1 and T2 (T1 > T2)
     if t1 is None or t2 is None:
     
         # Allow the user to specify sample size 
@@ -396,12 +396,12 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
         plpy.execute( sql);
 
         # Calculate the cross distances >> and derive T1 and T2 
-        # T1 >> is the max value from 1st quantile (10 buckets)
-        # T2 >> is the min value from 10th quantile (10 buckets)
+        # T1 >> is the min value from 10th quantile (10 buckets)
+        # T2 >> is the max value from 1st quantile (10 buckets)
         sql = '''
             SELECT 
-                max( CASE WHEN ntile = 1 THEN dist ELSE null END) as t1 
-                , min( CASE WHEN ntile = 10 THEN dist ELSE null END) as t2 
+                max( CASE WHEN ntile = 10 THEN dist ELSE null END) as t1 
+                , min( CASE WHEN ntile = 1 THEN dist ELSE null END) as t2 
             FROM 
             (
                 SELECT ntile(10) OVER( ORDER BY dist) as ntile, dist FROM 
@@ -424,7 +424,7 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
     # Check canopy thresholds        
     if t1 is None: 
         if rv[0]['t1'] is None:
-            plpy.error( 'not enough data to generate canopy T1 threshold (T1<T2)')
+            plpy.error( 'not enough data to generate canopy T1 threshold (T1>T2)')
         else:
             t1 = rv[0]['t1'];
     elif t1 <= 0:
@@ -432,24 +432,24 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
         
     if t2 is None: 
         if rv[0]['t2'] is None:
-            plpy.error( 'not enough data to generate canopy T2 threshold (T1<T2)')
+            plpy.error( 'not enough data to generate canopy T2 threshold (T1>T2)')
         else:
             t2 = rv[0]['t2'];
     elif t2 <= 0:
         plpy.error( 'canopy threshold T2 can not be zero or negative')
     
-    # Generate initial centroids using T1 (smaller)
+    # Generate initial centroids using T2 (smaller)
     __run_quietly( 'DROP TABLE IF EXISTS TempArrayOfCentroids');
     sql = '''
         CREATE TEMP TABLE TempArrayOfCentroids AS
         SELECT 
-            {madlib_schema}.kmeans_canopy(coords, {metric}, {t1})
+            {madlib_schema}.kmeans_canopy(coords, {metric}, {t2})
                 AS ccoords
         FROM {src_points}
         '''.format(
             madlib_schema = madlib_schema,
             metric = __metric_id(dist_metric),
-            t1 = str(float(t1)),
+            t2 = str(float(t2)),
             src_points = src_points
     )
     __run_quietly( sql);
@@ -467,18 +467,18 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
     )
     plpy.execute( sql);
     
-    # Assign points to canopies using T2 (larger)
+    # Assign points to canopies using T1 (larger)
     __run_quietly( 'CREATE TEMP TABLE TempPoints0_Canopies (LIKE TempPoints0)')
     sql = '''
         INSERT INTO TempPoints0_Canopies
         SELECT p.pid, p.coords, p.cid,
-            {madlib_schema}.internal_get_array_of_close_canopies(p.coords, c.ccoords, {t2}, {metric})
+            {madlib_schema}.internal_get_array_of_close_canopies(p.coords, c.ccoords, {t1}, {metric})
         FROM TempPoints0 p, TempArrayOfCentroids c
     '''.format(
         madlib_schema = madlib_schema,
         output_centroids = output_centroids,
         metric = __metric_id(dist_metric),
-        t2 = str(t2)
+        t1 = str(t1)
     )
     
     plpy.execute( sql);
@@ -515,8 +515,8 @@ def kmeans( madlib_schema
     @param init_sample_pct Percent of the input data points to use for kmeans++ 
            centroid seeding (for kmeans++ only)
     @param k Number of initial centroids
-    @param t1 Smaller threshold for canopy clustering 
-    @param t2 Larger threshold for canopy clustering     
+    @param t1 Larger threshold for canopy clustering 
+    @param t2 Smaller threshold for canopy clustering     
     @param dist_metric Type of the distance/similarity metric (e.g. 'cosine')  
     @param max_iter Maximum number of iterations to execute
     @param conv_threshold Convergence threshold, expressed as percent of points 

--- a/src/ports/postgres/modules/kmeans/kmeans.py_in
+++ b/src/ports/postgres/modules/kmeans/kmeans.py_in
@@ -117,6 +117,16 @@ def __sample_bound( sample_size, population_size):
         
     return (sample_size + 14 + sqrt(196 + 28*sample_size)) / population_size;
 
+
+def __metric_id(dist_metric):
+    return {
+        'l1norm'  : 1,
+        'l2norm'  : 2,
+        'cosine'  : 3,
+        'tanimoto': 4
+    }[dist_metric]
+    
+
 # ----------------------------------------
 # Centroid initialization using random()
 # ----------------------------------------
@@ -426,46 +436,51 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
         else:
             t2 = rv[0]['t2'];
     elif t2 <= 0:
-        plpy.error( 'canopy threshold T2 can not be zero or negative')        
-        
+        plpy.error( 'canopy threshold T2 can not be zero or negative')
+    
     # Generate initial centroids using T1 (smaller)
+    __run_quietly( 'DROP TABLE IF EXISTS TempArrayOfCentroids');
+    sql = '''
+        CREATE TEMP TABLE TempArrayOfCentroids AS
+        SELECT 
+            {madlib_schema}.kmeans_canopy(coords, {metric}, {t1})
+                AS ccoords
+        FROM {src_points}
+        '''.format(
+            madlib_schema = madlib_schema,
+            metric = __metric_id(dist_metric),
+            t1 = str(float(t1)),
+            src_points = src_points
+    )
+    __run_quietly( sql);
+    
+    # unpivot centroids
     sql = '''
         INSERT INTO {output_centroids} (cid, coords)
-        SELECT row_number() OVER () AS cid, coords 
+        SELECT
+            generate_series(array_lower(ccoords, 1), array_upper(ccoords, 1)),
+            unnest(ccoords)
         FROM
-              ( SELECT unnest(canopies) as coords
-                FROM 
-                    ( SELECT 
-                        {madlib_schema}.kmeans_canopy( 
-                            coords, '{dist_metric}', {t1}
-                        ) as canopies
-                      FROM {src_points}
-                     ) q1
-               ) q2
-        '''.format(
+            TempArrayOfCentroids
+    '''.format(
             output_centroids = output_centroids
-            , madlib_schema = madlib_schema
-            , dist_metric = dist_metric
-            , t1 = str(float(t1))
-            , src_points = src_points
-        );
+    )
     plpy.execute( sql);
     
     # Assign points to canopies using T2 (larger)
     __run_quietly( 'CREATE TEMP TABLE TempPoints0_Canopies (LIKE TempPoints0)')
     sql = '''
         INSERT INTO TempPoints0_Canopies
-        SELECT p.pid, p.coords, p.cid, 
-            m4_ifdef(`__HAS_ORDERED_AGGREGATES__',,`{madlib_schema}.')array_agg(c.cid)
-        FROM TempPoints0 p, {output_centroids} c 
-        WHERE {dist_func} < {t2}
-        GROUP BY p.pid, p.coords, p.cid
+        SELECT p.pid, p.coords, p.cid,
+            {madlib_schema}.internal_get_array_of_close_canopies(p.coords, c.ccoords, {t2}, {metric})
+        FROM TempPoints0 p, TempArrayOfCentroids c
     '''.format(
-        output_centroids = output_centroids
-        , dist_func = dist_func.replace( '&&&', 'p.coords, c.coords')
-        , t2 = str(t2)
-        , madlib_schema = madlib_schema
-    );            
+        madlib_schema = madlib_schema,
+        output_centroids = output_centroids,
+        metric = __metric_id(dist_metric),
+        t2 = str(t2)
+    )
+    
     plpy.execute( sql);
     plpy.execute( 'DROP TABLE IF EXISTS TempPoints0');
     plpy.execute( 'ALTER TABLE TempPoints0_Canopies RENAME TO TempPoints0');
@@ -659,12 +674,12 @@ def kmeans( madlib_schema
     # Cosine
     elif dist_metric == 'cosine':
         dist_aggr = '%s.mean(%s.normalize(&&&))' % (madlib_schema, madlib_schema);
-        dist_func = 'acos(%s.cosine_distance(&&&))' % madlib_schema;
+        dist_func = '%s.angle(&&&)' % madlib_schema;
         info( ' * dist_metric = %s' % (dist_metric))
     # Tanimoto
     elif dist_metric == 'tanimoto':
         dist_aggr = '%s.mean(%s.normalize(&&&))' % (madlib_schema, madlib_schema);
-        dist_func = 'acos(%s.tanimoto_distance(&&&))' % madlib_schema;
+        dist_func = '%s.tanimoto_distance(&&&)' % madlib_schema;
         info( ' * dist_metric = %s' % (dist_metric))
     # Other 
     else: 
@@ -865,11 +880,9 @@ def kmeans( madlib_schema
             CREATE TEMP TABLE TempArrayOfCentroids AS
             SELECT
 m4_ifdef(`__HAS_ORDERED_AGGREGATES__', `
-                array_agg(cid ORDER BY cid) as cids,
                 array_agg(coords ORDER BY cid) as ccoords
             FROM {output_centroids}
 ', `
-                array(SELECT cid FROM {output_centroids} ORDER BY cid LIMIT ALL) as cids,
                 array(SELECT coords FROM {output_centroids} ORDER BY cid LIMIT ALL) as ccoords
 ')                
             '''.format(
@@ -888,14 +901,14 @@ m4_ifdef(`__HAS_ORDERED_AGGREGATES__', `
             canopies = 'p.canopies';
         else:
             # Compare with all centroids
-            canopies = 'arr.cids';
-            
+            canopies = 'NULL';
+        
         sql = '''
             INSERT INTO TempPoints{i}    
             SELECT
                 p.pid 
                 , p.coords
-                , {madlib_schema}.internal_kmeans_closest_centroid( p.coords, {canopies}, arr.ccoords, '{dist_metric}') 
+                , {madlib_schema}.internal_kmeans_closest_centroid( p.coords, {canopies}, arr.ccoords, {metric})
                 , p.canopies
             FROM 
                 TempPoints{previous_i} p CROSS JOIN TempArrayOfCentroids arr
@@ -903,7 +916,7 @@ m4_ifdef(`__HAS_ORDERED_AGGREGATES__', `
             i = str(i)
             , madlib_schema = madlib_schema
             , canopies = canopies
-            , dist_metric = dist_metric
+            , metric = __metric_id(dist_metric)
             , previous_i = str(i-1)
         );
         plpy.execute( sql);        
@@ -922,6 +935,7 @@ m4_ifdef(`__HAS_ORDERED_AGGREGATES__', `
                 GROUP BY cid
             ) AS t ON c.cid = t.cid''';
         __run_quietly( sql);        
+        
         plpy.execute( 'TRUNCATE TABLE ' + output_centroids );
         plpy.execute( 'INSERT INTO ' + output_centroids + ' SELECT * FROM ' \
                         + output_centroids + '_tmp');

--- a/src/ports/postgres/modules/kmeans/kmeans.py_in
+++ b/src/ports/postgres/modules/kmeans/kmeans.py_in
@@ -443,12 +443,16 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
     sql = '''
         CREATE TEMP TABLE TempArrayOfCentroids AS
         SELECT 
-            {madlib_schema}.kmeans_canopy(coords, {metric}, {t2})
-                AS ccoords
+            {madlib_schema}.internal_remove_close_canopies(
+                {madlib_schema}.kmeans_canopy(coords, {metric}, {t2}),
+                {metric},
+                {t1}
+            ) AS ccoords
         FROM {src_points}
         '''.format(
             madlib_schema = madlib_schema,
             metric = __metric_id(dist_metric),
+            t1 = str(float(t1)),
             t2 = str(float(t2)),
             src_points = src_points
     )
@@ -467,18 +471,30 @@ def __init_canopy(  madlib_schema, src_points, n, dist_metric, dist_func,
     )
     plpy.execute( sql);
     
-    # Assign points to canopies using T1 (larger)
+    # Assign points to canopies using T1 + T2 (this is a slight deviation from
+    # McCallum et al.)
+    # Note: After combining all canopies from the segments, we removed canopies
+    # that were closer than T1 to some other canopy. With the triangle
+    # inequality, all we can assure afterwards is that no point is farther away
+    # than T1 + T2 from its closest canopy: (In detail: Previously, the closest
+    # canopy was T2 away, and that canopy was -- if it was removed -- at most
+    # T1 away from another canopy.)
     __run_quietly( 'CREATE TEMP TABLE TempPoints0_Canopies (LIKE TempPoints0)')
     sql = '''
         INSERT INTO TempPoints0_Canopies
         SELECT p.pid, p.coords, p.cid,
-            {madlib_schema}.internal_get_array_of_close_canopies(p.coords, c.ccoords, {t1}, {metric})
+            {madlib_schema}.internal_get_array_of_close_canopies(
+                p.coords,
+                c.ccoords,
+                {threshold},
+                {metric}
+            )
         FROM TempPoints0 p, TempArrayOfCentroids c
     '''.format(
         madlib_schema = madlib_schema,
         output_centroids = output_centroids,
         metric = __metric_id(dist_metric),
-        t1 = str(t1)
+        threshold = str(t1 + t2)
     )
     
     plpy.execute( sql);
@@ -922,10 +938,12 @@ m4_ifdef(`__HAS_ORDERED_AGGREGATES__', `
         plpy.execute( sql);        
 
         # Refresh the Centroids table based on current assignments
+        # Note the coalesce: If there is a centroid which is currently not
+        # the closest centroid to any point, just keep its old position
         __run_quietly( 'DROP TABLE IF EXISTS ' + output_centroids + '_tmp');
         sql = '''
             CREATE TABLE ''' + output_centroids + '''_tmp AS
-            SELECT c.cid AS cid, t.coords AS coords
+            SELECT c.cid AS cid, coalesce(t.coords, c.coords) AS coords
             FROM ''' + output_centroids + ''' c LEFT OUTER JOIN
             (
                 SELECT 
@@ -989,21 +1007,24 @@ m4_ifdef(`__HAS_ORDERED_AGGREGATES__', `
         sql = '''
         SELECT
             sum(a) AS cost,
-            coalesce( avg( (b-a) / float8larger(a,b) ), 0) AS scoef
-        FROM
-            ( SELECT 
+            coalesce(avg(
+                CASE WHEN float8larger(a,b) = 0 THEN 0
+                     ELSE (b-a) / float8larger(a,b)
+                END), 0) AS scoef
+        FROM (
+            SELECT
                 pid, min(a)::float AS a, min(b)::float AS b
-            FROM
-                ( SELECT 
+            FROM (
+                SELECT
                     pid
                     , CASE WHEN p.cid = c.cid THEN {dist_func}
                       ELSE null END AS a
                     , CASE WHEN p.cid != c.cid THEN {dist_func}
                       ELSE null END AS b
                 FROM {output_points} p, {output_centroids} c
-                ) q1
+            )   q1
             GROUP BY pid
-            ) q2
+        ) q2
         '''.format(
             dist_func = dist_func.replace( '&&&', 'p.coords, c.coords')
             , output_points = output_points

--- a/src/ports/postgres/modules/kmeans/kmeans.sql_in
+++ b/src/ports/postgres/modules/kmeans/kmeans.sql_in
@@ -326,8 +326,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.internal_kmeans_closest_centroid(
 RETURNS INTEGER AS
 'MODULE_PATHNAME'
 LANGUAGE c
-IMMUTABLE
-STRICT;
+IMMUTABLE; /* This function must *not* be declared STRICT! */
 
 /**
  * @internal

--- a/src/ports/postgres/modules/kmeans/kmeans.sql_in
+++ b/src/ports/postgres/modules/kmeans/kmeans.sql_in
@@ -268,7 +268,7 @@ out_centorids | public.km_c
 
 [3] Omnia Ossama, Hoda M. O. Mokhtar, Mohamed E. El-Sharkawi: Clustering Moving 
     Objects Using Segments Slopes, pp. 43, 
-    http://airccse.org/journal/ijdms/papers/3111ijdms03.pdf	
+    http://airccse.org/journal/ijdms/papers/3111ijdms03.pdf
     
 [4] Andrew McCallum, Kamal Nigam, Lyle H. Ungar: Efﬁcient Clustering of
     High-Dimensional Data Sets with Application to Reference Matching
@@ -283,243 +283,67 @@ out_centorids | public.km_c
 
 /**
  * @internal
- * @brief Centroid assignment function. It computes distances between
- * a point and an array of centroids and returns the ID of the nearest centroid.
+ * @brief Given a point, find all canopies that are closer than threshold
+ * @param point The point
+ * @param allCanopies Array of canopies
+ * @param threshold Threshold distance below which a point is included in the
+ *     output array
+ * @param distMetric ID of the metric to use
+ * @return Array of positions in \c allCanopies that are close to the given
+ *     point
  */
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.internal_kmeans_closest_centroid( 
-    p_point         MADLIB_SCHEMA.SVEC
-    , p_cids        INTEGER[]
-    , p_ccoords     MADLIB_SCHEMA.SVEC[]
-    , p_dist_metric TEXT
-) 
-RETURNS INTEGER
-AS $$
-DECLARE
-    min_cid         INTEGER := 0;
-    min_val         FLOAT := NULL;
-    temp_val        FLOAT := NULL;
-BEGIN
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.internal_get_array_of_close_canopies( 
+    "point"               MADLIB_SCHEMA.SVEC,
+    "allCanopies"         MADLIB_SCHEMA.SVEC[],
+    "threshold"           FLOAT8,
+    "dist_metric"         INTEGER
+)
+RETURNS INTEGER[] AS
+'MODULE_PATHNAME'
+LANGUAGE c
+IMMUTABLE
+STRICT;
 
-    --
-    -- Pick your distance metrics and Loop over all centroids
-    --
-    -- Implementation comment:
-    -- IF statement is outside the loop in order to have a static SQL call to
-    -- the distance function and to minimize the number of comparisons of P_DIST_METRIC. 
-    -- Static SQL is better because we avoid SVEC parameters serialization, that
-    -- would be necessary with .
-    IF p_dist_metric = 'l1norm' THEN
-        FOR i IN 1..array_upper( p_cids, 1) LOOP        
-            temp_val := MADLIB_SCHEMA.l1norm( p_point, p_ccoords[p_cids[i]]);
-            IF ( temp_val < coalesce( min_val, temp_val + 1.0) ) THEN
-                min_val := temp_val;
-                min_cid := p_cids[i];
-            END IF;
-        END LOOP;
-    ELSIF p_dist_metric = 'l2norm' THEN
-        FOR i IN 1..array_upper( p_cids, 1) LOOP        
-            temp_val := MADLIB_SCHEMA.l2norm( p_point, p_ccoords[p_cids[i]]);
-            IF ( temp_val < coalesce( min_val, temp_val + 1.0) ) THEN
-                min_val := temp_val;
-                min_cid := p_cids[i];
-            END IF;
-        END LOOP;
-    ELSIF p_dist_metric = 'cosine' THEN
-        FOR i IN 1..array_upper( p_cids, 1) LOOP        
-            temp_val := acos( MADLIB_SCHEMA.cosine_distance( p_point, p_ccoords[p_cids[i]]));
-            IF ( temp_val < coalesce( min_val, temp_val + 1.0) ) THEN
-                min_val := temp_val;
-                min_cid := p_cids[i];
-            END IF;
-        END LOOP;
-    ELSIF p_dist_metric = 'tanimoto' THEN
-        FOR i IN 1..array_upper( p_cids, 1) LOOP        
-            temp_val := acos( MADLIB_SCHEMA.tanimoto_distance( p_point, p_ccoords[p_cids[i]]));
-            IF ( temp_val < coalesce( min_val, temp_val + 1.0) ) THEN
-                min_val := temp_val;
-                min_cid := p_cids[i];
-            END IF;
-        END LOOP;
-    ELSE
-        RAISE EXCEPTION 'Unknown distance metric: %', p_dist_metric;
-    END IF;            
-    
-    RETURN min_cid;
-END
-$$ LANGUAGE plpgsql IMMUTABLE;
 
 /**
  * @internal
- * @brief State variable data type for kmeans_canopy() 
+ * @brief Given a point, find the closest centroid
+ * @param point The point
+ * @param closeCentroids List of positions in the \c centroidCoordinates array
+ *     that should be considered. The distance to all other centroids is
+ *     conceptually infinity. If NULL, then all centroids in
+ *     \c centroidCoordinates are considered.
+ * @param centroidCoordinates Array of centroids
+ * @param distMetric ID of the metric to use
+ * @return The position in \c centroidCoordinates that is closest to \c point
  */
-CREATE TYPE MADLIB_SCHEMA.kmeans_canopy_type AS(
-    canopy_coords   MADLIB_SCHEMA.svec[]    -- coordinates of all canopies
-    , dist_metric   TEXT                    -- distance metric
-    , threshold     FLOAT                   -- threshold
-);
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.internal_kmeans_closest_centroid( 
+    "point"               MADLIB_SCHEMA.SVEC,
+    "closeCentroids"      INTEGER[],
+    "centroidCoordinates" MADLIB_SCHEMA.SVEC[],
+    "dist_metric"         INTEGER
+)
+RETURNS INTEGER AS
+'MODULE_PATHNAME'
+LANGUAGE c
+IMMUTABLE
+STRICT;
 
 /**
  * @internal
  * @brief Transition function for UDA:kmeans_canopy() 
  */
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.internal_kmeans_canopy_transition(
-    state           MADLIB_SCHEMA.kmeans_canopy_type
+    state           MADLIB_SCHEMA.svec[]
     , pcoords       MADLIB_SCHEMA.svec
-    , dist_metric   TEXT
-    , threshold     FLOAT
+    , dist_metric   INTEGER
+    , threshold     FLOAT8
 )
-RETURNS MADLIB_SCHEMA.kmeans_canopy_type 
-AS $$
-DECLARE 
-    i INTEGER;
-    distance FLOAT;
-BEGIN
-    -- Populate the initial state 
-    IF state is NULL THEN
-       state := ROW( ARRAY[pcoords]::MADLIB_SCHEMA.svec[], dist_metric, threshold);
-       RETURN state;
-    END IF;
-    -- If the new point falls under any existing canopy >> just move on & return current state
-    IF dist_metric = 'l1norm' THEN
-        FOR i IN 1 .. ARRAY_UPPER(state.canopy_coords, 1) LOOP
-            distance := MADLIB_SCHEMA.l1norm( pcoords, state.canopy_coords[i]);
-            IF(distance < threshold) THEN
-                RETURN state;
-            END IF;
-        END LOOP;
-    ELSIF dist_metric = 'l2norm' THEN
-        FOR i IN 1 .. ARRAY_UPPER(state.canopy_coords, 1) LOOP
-            distance := MADLIB_SCHEMA.l2norm( pcoords, state.canopy_coords[i]);
-            IF(distance < threshold) THEN
-                RETURN state;
-            END IF;
-        END LOOP;
-    ELSIF dist_metric = 'cosine' THEN
-        FOR i IN 1 .. ARRAY_UPPER(state.canopy_coords, 1) LOOP
-            distance := acos( MADLIB_SCHEMA.cosine_distance( pcoords, state.canopy_coords[i]));
-            IF(distance < threshold) THEN
-                RETURN state;
-            END IF;
-        END LOOP;
-    ELSIF dist_metric = 'tanimoto' THEN
-        FOR i IN 1 .. ARRAY_UPPER(state.canopy_coords, 1) LOOP
-            distance := acos( MADLIB_SCHEMA.tanimoto_distance( pcoords, state.canopy_coords[i]));
-            IF(distance < threshold) THEN
-                RETURN state;
-            END IF;
-        END LOOP;
-    ELSE
-        RAISE EXCEPTION 'Unknown distance metric: %', dist_metric;
-    END IF;     
-    -- If the new point does not fall under any existing canopy 
-    -- >> add it to the list of canopies
-    state.canopy_coords := ARRAY_APPEND(state.canopy_coords, pcoords);
-    RETURN state;
-END;
-$$ LANGUAGE plpgsql;
-
-/**
- * @internal
- * @brief Merge function for UDA:kmeans_canopy() 
- */
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.internal_kmeans_canopy_merge(
-    state1      MADLIB_SCHEMA.kmeans_canopy_type
-    , state2    MADLIB_SCHEMA.kmeans_canopy_type
-)
-RETURNS MADLIB_SCHEMA.kmeans_canopy_type 
-AS $$
-DECLARE 
-    i INTEGER;
-    j INTEGER;
-    overlap BOOLEAN;
-    distance DOUBLE PRECISION;
-BEGIN
-    -- If one side is NULL
-    IF ARRAY_UPPER(state1.canopy_coords, 1) IS NULL THEN
-       RETURN state2;
-    END IF;
-    IF ARRAY_UPPER(state2.canopy_coords, 1) IS NULL THEN
-       RETURN state1;
-    END IF;
-    -- Compare all canopies from both states and find overlaps (< 0.5 * threshold)
-    -- Keep track of the new state in STATE2
-    IF state1.dist_metric = 'l1norm' THEN
-        FOR i IN 1 .. ARRAY_UPPER(state1.canopy_coords, 1) LOOP
-            overlap := FALSE;
-            FOR j IN 1 .. ARRAY_UPPER(state2.canopy_coords, 1) LOOP
-                distance := MADLIB_SCHEMA.l1norm(state1.canopy_coords[i], state2.canopy_coords[j]);
-                IF (distance < 0.5 * state1.threshold) THEN
-                    overlap := TRUE;
-                    EXIT;
-                END IF;
-            END LOOP;
-            IF overlap = FALSE THEN
-                state2.canopy_coords := ARRAY_APPEND(state2.canopy_coords, state1.canopy_coords[i]);
-            END IF;
-        END LOOP;
-    ELSIF state1.dist_metric = 'l2norm' THEN
-        FOR i IN 1 .. ARRAY_UPPER(state1.canopy_coords, 1) LOOP
-            overlap := FALSE;
-            FOR j IN 1 .. ARRAY_UPPER(state2.canopy_coords, 1) LOOP
-                distance := MADLIB_SCHEMA.l2norm(state1.canopy_coords[i], state2.canopy_coords[j]);
-                IF (distance < 0.5 * state1.threshold) THEN
-                    overlap := TRUE;
-                    EXIT;
-                END IF;
-            END LOOP;
-            IF overlap = FALSE THEN
-                state2.canopy_coords := ARRAY_APPEND(state2.canopy_coords, state1.canopy_coords[i]);
-            END IF;
-        END LOOP;
-    ELSIF state1.dist_metric = 'cosine' THEN
-        FOR i IN 1 .. ARRAY_UPPER(state1.canopy_coords, 1) LOOP
-            overlap := FALSE;
-            FOR j IN 1 .. ARRAY_UPPER(state2.canopy_coords, 1) LOOP
-                distance := acos( MADLIB_SCHEMA.cosine_distance( state1.canopy_coords[i], state2.canopy_coords[j]));
-                IF (distance < 0.5 * state1.threshold) THEN
-                    overlap := TRUE;
-                    EXIT;
-                END IF;
-            END LOOP;
-            IF overlap = FALSE THEN
-                state2.canopy_coords := ARRAY_APPEND(state2.canopy_coords, state1.canopy_coords[i]);
-            END IF;
-        END LOOP;
-    ELSIF state1.dist_metric = 'tanimoto' THEN
-        FOR i IN 1 .. ARRAY_UPPER(state1.canopy_coords, 1) LOOP
-            overlap := FALSE;
-            FOR j IN 1 .. ARRAY_UPPER(state2.canopy_coords, 1) LOOP
-                distance := acos( MADLIB_SCHEMA.tanimoto_distance( state1.canopy_coords[i], state2.canopy_coords[j]));
-                IF (distance < 0.5 * state1.threshold) THEN
-                    overlap := TRUE;
-                    EXIT;
-                END IF;
-            END LOOP;
-            IF overlap = FALSE THEN
-                state2.canopy_coords := ARRAY_APPEND(state2.canopy_coords, state1.canopy_coords[i]);
-            END IF;
-        END LOOP;
-    ELSE
-        RAISE EXCEPTION 'Unknown distance metric: %', state1.dist_metric;
-    END IF;       -- Done
-    RETURN state2;
-END;
-$$ LANGUAGE plpgsql;
-
-/**
- * @internal
- * @brief Finalize function for UDA:kmeans_canopy() 
- */
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.internal_kmeans_canopy_finalize(
-    state MADLIB_SCHEMA.kmeans_canopy_type
-)
-RETURNS MADLIB_SCHEMA.svec[] 
-AS $$
-DECLARE 
-BEGIN
-    RETURN state.canopy_coords;
-END;
-$$ LANGUAGE plpgsql;
+RETURNS MADLIB_SCHEMA.svec[] AS 
+'MODULE_PATHNAME'
+LANGUAGE c
+IMMUTABLE
+STRICT;
 
 /**
  * @internal
@@ -527,14 +351,15 @@ $$ LANGUAGE plpgsql;
  */
 CREATE AGGREGATE MADLIB_SCHEMA.kmeans_canopy(
     MADLIB_SCHEMA.svec  -- new point coordinates
-    , TEXT              -- distance metric
-    , FLOAT             -- threshold (T1)
-) 
-(
-    STYPE = MADLIB_SCHEMA.kmeans_canopy_type
-    , SFUNC = MADLIB_SCHEMA.internal_kmeans_canopy_transition
-    m4_ifdef(`GREENPLUM',`,prefunc = MADLIB_SCHEMA.internal_kmeans_canopy_merge')
-    , FINALFUNC = MADLIB_SCHEMA.internal_kmeans_canopy_finalize  
+    , INTEGER           -- distance metric
+    , FLOAT8            -- threshold (T1)
+) (
+    stype = MADLIB_SCHEMA.svec[],
+    sfunc = MADLIB_SCHEMA.internal_kmeans_canopy_transition,
+m4_ifdef(`__GREENPLUM__', `
+    prefunc = array_cat,
+')
+    initcond = '{}'
 );
 
 /**

--- a/src/ports/postgres/modules/kmeans/kmeans.sql_in
+++ b/src/ports/postgres/modules/kmeans/kmeans.sql_in
@@ -363,6 +363,27 @@ m4_ifdef(`__GREENPLUM__', `
 
 /**
  * @internal
+ * @brief After merging canopies, remove those that are close to each other.
+ *    This is essentilly a pivoted version of kmeans_canopy
+ *
+ * @param all_canopies The array of all canopies (their coordinates)
+ * @param dist_metric ID of the metric to use
+ * @param threshold The threshold distance below which we drop canopies
+ * @returns The pruned array of canopies
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.internal_remove_close_canopies(
+    "all_canopies"  MADLIB_SCHEMA.svec[],
+    "dist_metric"   INTEGER,
+    "threshold"     FLOAT8
+)
+RETURNS MADLIB_SCHEMA.svec[] AS 
+'MODULE_PATHNAME'
+LANGUAGE c
+IMMUTABLE
+STRICT;
+
+/**
+ * @internal
  * @brief Kmeans result data type
  */
 CREATE TYPE MADLIB_SCHEMA.kmeans_result AS (


### PR DESCRIPTION
This is a fix for the following k-means issues:

[MADLIB-349](http://jira.madlib.net/browse/MADLIB-349):
- All pgsql code converted to C code
- array_agg is now only used on "small" relations (it's use induced GroupAggregates which were problematic).
- The initial canopy assignment is now done using an aggregate function where it used to be an expensive cross join between points and centroids (worse, we used to perform a GroupAggregate and not a HashAggregate on this cross product)
- Distance computation now entirely in C functions (in the case of cosine sim. and Tanimoto, the _distance_ caluclation consisted of calling a C function plus some transformation in pgsql).

[MADLIB-366](http://jira.madlib.net/browse/MADLIB-366):
- For canopy clustering, we now assume T1>T2 like in the original paper

Others:
- Fixed bug in canopy merge function where a canopy could be removed if the distance to other canopies was less than .5 \* T1. This could lead to points disappearing (if their distance to the closest canopy was > T2 afterwards, which could happen after just one merge step if T1 > 1.5 \* T2)
- Tanimoto "distance" is now "1 - Tanimoto similarity" and not "acos(Tanimoto similarity)" any more

Note:
This pull request fixes the most urgent issues. It does not address other concerns (of which the author of these lines has many).
