### PR TITLE
Cast of float array to sparse vector cannot handle null values, take two

### DIFF
--- a/methods/svec/src/pg_gp/SparseData.h
+++ b/methods/svec/src/pg_gp/SparseData.h
@@ -149,7 +149,7 @@ double *sdata_to_float8arr(SparseData sdata);
 int64 *sdata_index_to_int64arr(SparseData sdata);
 SparseData float8arr_to_sdata(double *array, int count);
 SparseData position_to_sdata(double *array, int64 *array_pos, int count, int64 end, double base_val);
-SparseData arr_to_sdata(char *array, size_t width, Oid type_of_data, int count);
+SparseData arr_to_sdata(char *array, size_t width, Oid type_of_data, int count, bits8 *bitmap);
 SparseData posit_to_sdata(char *array, int64* array_pos, size_t width, Oid type_of_data, int count, int64 end, char *base_val);
 
 /* Some functions for accessing and changing elements of a SparseData */

--- a/methods/svec/src/pg_gp/operators.c
+++ b/methods/svec/src/pg_gp/operators.c
@@ -933,6 +933,10 @@ PG_FUNCTION_INFO_V1( svec_cast_float8arr );
 Datum svec_cast_float8arr(PG_FUNCTION_ARGS) {
 	ArrayType *A_PG = PG_GETARG_ARRAYTYPE_P(0);
 	SvecType *output_svec;
+	float8 *array_temp;
+	bits8 *bitmap;
+	int bitmask;
+	int i,j;
 
 	if (ARR_ELEMTYPE(A_PG) != FLOAT8OID)
 		ereport(ERROR,
@@ -942,20 +946,44 @@ Datum svec_cast_float8arr(PG_FUNCTION_ARGS) {
 		ereport(ERROR,
 			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 			 errmsg("svec_cast_float8arr only defined over 1 dimensional arrays")));
-	
-	if (ARR_NULLBITMAP(A_PG))
-		ereport(ERROR,
-			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			 errmsg("svec_cast_float8arr does not allow null bitmaps on arrays")));
 
 	/* Extract array */
 	int dimension = ARR_DIMS(A_PG)[0];
 	float8 *array = (float8 *)ARR_DATA_PTR(A_PG);
-		
+
+	/* If the data array has NULLs, then we need to create an array to
+	 * store the NULL values as NVP values defined in float_specials.h.
+	 */
+	if (ARR_HASNULL(A_PG)) {
+		array_temp = array;
+		array = (double *)palloc(sizeof(float8) * dimension);
+		bitmap = ARR_NULLBITMAP(A_PG);
+		bitmask = 1;
+		j = 0;
+		for (i=0; i<dimension; i++) {
+			if (bitmap && (*bitmap & bitmask) == 0) // if NULL
+				array[i] = NVP;
+			else {
+				array[i] = array_temp[j];
+				j++;
+			}
+			if (bitmap) { // advance bitmap pointer
+				bitmask <<= 1;
+				if (bitmask == 0x100) {
+					bitmap++;
+					bitmask = 1;
+				}
+			}
+		}
+	 }
+
 	/* Create the output SVEC */
 	SparseData sdata = float8arr_to_sdata(array,dimension);
 	output_svec = svec_from_sparsedata(sdata,true);
 	
+	if (ARR_HASNULL(A_PG))
+		pfree(array);
+
 	PG_RETURN_SVECTYPE_P(output_svec);
 }
 

--- a/methods/svec/src/pg_gp/operators.c
+++ b/methods/svec/src/pg_gp/operators.c
@@ -933,10 +933,7 @@ PG_FUNCTION_INFO_V1( svec_cast_float8arr );
 Datum svec_cast_float8arr(PG_FUNCTION_ARGS) {
 	ArrayType *A_PG = PG_GETARG_ARRAYTYPE_P(0);
 	SvecType *output_svec;
-	float8 *array_temp;
-	bits8 *bitmap;
-	int bitmask;
-	int i,j;
+	SparseData sdata;
 
 	if (ARR_ELEMTYPE(A_PG) != FLOAT8OID)
 		ereport(ERROR,
@@ -951,38 +948,20 @@ Datum svec_cast_float8arr(PG_FUNCTION_ARGS) {
 	int dimension = ARR_DIMS(A_PG)[0];
 	float8 *array = (float8 *)ARR_DATA_PTR(A_PG);
 
-	/* If the data array has NULLs, then we need to create an array to
-	 * store the NULL values as NVP values defined in float_specials.h.
+	/*
+	 * If Array contains NULLs, then let arr_to_sdata deal with it.
 	 */
-	if (ARR_HASNULL(A_PG)) {
-		array_temp = array;
-		array = (double *)palloc(sizeof(float8) * dimension);
-		bitmap = ARR_NULLBITMAP(A_PG);
-		bitmask = 1;
-		j = 0;
-		for (i=0; i<dimension; i++) {
-			if (bitmap && (*bitmap & bitmask) == 0) // if NULL
-				array[i] = NVP;
-			else {
-				array[i] = array_temp[j];
-				j++;
-			}
-			if (bitmap) { // advance bitmap pointer
-				bitmask <<= 1;
-				if (bitmask == 0x100) {
-					bitmap++;
-					bitmask = 1;
-				}
-			}
-		}
-	 }
+	if (ARR_HASNULL(A_PG))
+		sdata = arr_to_sdata((char *) array,
+							 sizeof(float8),
+							 FLOAT8OID,
+							 dimension,
+							 ARR_NULLBITMAP(A_PG));
+	else
+		sdata = float8arr_to_sdata(array, dimension);
 
 	/* Create the output SVEC */
-	SparseData sdata = float8arr_to_sdata(array,dimension);
 	output_svec = svec_from_sparsedata(sdata,true);
-	
-	if (ARR_HASNULL(A_PG))
-		pfree(array);
 
 	PG_RETURN_SVECTYPE_P(output_svec);
 }

--- a/methods/svec/src/pg_gp/sql/svec_test.sql_in
+++ b/methods/svec/src/pg_gp/sql/svec_test.sql_in
@@ -182,6 +182,8 @@ select MADLIB_SCHEMA.svec_median(MADLIB_SCHEMA.svec_agg(a)) from (select generat
 select MADLIB_SCHEMA.svec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::MADLIB_SCHEMA.svec);
 select MADLIB_SCHEMA.svec_median('{9960,9926,10053,9993,10080,10050,9938,9941,10030,10029}:{1,9,8,7,6,5,4,3,2,0}'::MADLIB_SCHEMA.svec::float8[]);
 
+-- Test for svec cast from float8arr
+select '{0,0,1,1,2,0,0,0,0,0}'::float8[]::MADLIB_SCHEMA.svec, '{0,0,NULL,NULL,2,0,0,NULL,NULL,NULL}'::float8[]::MADLIB_SCHEMA.svec;
 -- This vfunction test svec creation from position array
 select MADLIB_SCHEMA.svec_cast_positions_float8arr('{1,2,4,6,2,5}'::INT8[], '{.2,.3,.4,.5,.3,.1}'::FLOAT8[], 10000, 0.0);
 


### PR DESCRIPTION
I tried to put together aojwang's fix to use makeInplaceSparseData, but it turned out that I was wrong. It is for index/values set and casting float array doesn't have index. I changed my mind to modify underlying arr_to_sdata to let it accept NULL bitmap, so that double memory copies of array isn't needed.
