### PR TITLE
Fixes for madlib-341/381/382

### DIFF
--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -1,14 +1,11 @@
-/* ----------------------------------------------------------------------- *//** 
+/*
  *
  * @file decision_tree.sql_in
  *
  * @brief decision tree APIs and main controller written in PL/PGSQL
+ *
  * @date Dec. 22 2011
- *
- * @sa For a brief introduction to decision trees, see the
- *     module description \ref grp_dectree.
- *
- *//* ----------------------------------------------------------------------- */
+ */
 
 m4_include(`SQLCommon.m4')
 
@@ -28,9 +25,7 @@ m4_ifelse(
     `m4_define(`__POSTGRESQL_PRE_9_0__')'
 )
 
-/**
-@addtogroup grp_dectree
-
+/*
 @about
 
 This module provides an implementation of the C4.5 decision tree algorithm. 
@@ -91,8 +86,8 @@ of the following form:
   This will create the MADLIB_SCHEMA.tree table storing an abstract object 
   (representing the model) used for further classification. Column names:
   <pre>    
- id | tree_location | feature |    probability    |    ebp_coeff     | maxclass |    split_gain     | live | cat_size | parent_id |     jump      | is_feature_cont | split_value 
-----+---------------+---------+-------------------+------------------+----------+-------------------+------+----------+-----------+---------------+-----------------+-------------
+ id | tree_location | feature |    probability    | ebp_coeff | maxclass |    split_gain     | live | cat_size | parent_id | lmc_nid | lmc_fval | is_feature_cont | split_value 
+----+---------------+---------+-------------------+-----------+----------+-------------------+------+----------+-----------+---------+----------+-----------------+-------------
                                                      ...</pre>    
     
 - Run the classification function using the learned model: 
@@ -156,16 +151,16 @@ CONTEXT:  PL/pgSQL function "c45_train" line 70 at assignment
 -# Check few rows from the tree model table:
 \verbatim
 testdb=# select * from madlib.trained_tree_infogain order by id;
- id | tree_location | feature |    probability    |    ebp_coeff     | maxclass |    split_gain     | live | cat_size | parent_id |     jump      | is_feature_cont | split_value 
-----+---------------+---------+-------------------+------------------+----------+-------------------+------+----------+-----------+---------------+-----------------+-------------
-  1 | {0}           |       3 | 0.642857142857143 | 7.87584209442139 |        2 | 0.171033941880327 |    0 |       14 |         0 | [2:4]={2,3,4} | f               |            
-  2 | {0,1}         |       4 |                 1 | 1.75063467025757 |        2 |                 0 |    0 |        4 |         1 |               | f               |            
-  3 | {0,2}         |       4 |               0.6 | 3.74199032783508 |        2 | 0.673011667009257 |    0 |        5 |         1 | [2:3]={5,6}   | f               |            
-  4 | {0,3}         |       2 |               0.6 | 3.74199032783508 |        1 | 0.673011667009257 |    0 |        5 |         1 | [2:3]={7,8}   | t               |          70
-  5 | {0,2,1}       |       4 |                 1 | 1.60752332210541 |        2 |                 0 |    0 |        3 |         3 |               | f               |            
-  6 | {0,2,2}       |       4 |                 1 | 1.36754441261292 |        1 |                 0 |    0 |        2 |         3 |               | f               |            
-  7 | {0,3,1}       |       4 |                 1 | 1.36754441261292 |        2 |                 0 |    0 |        2 |         4 |               | f               |            
-  8 | {0,3,2}       |       4 |                 1 | 1.60752332210541 |        1 |                 0 |    0 |        3 |         4 |               | f               |            
+ id | tree_location | feature |    probability    | ebp_coeff | maxclass |    split_gain     | live | cat_size | parent_id | lmc_nid | lmc_fval | is_feature_cont | split_value 
+----+---------------+---------+-------------------+-----------+----------+-------------------+------+----------+-----------+---------+----------+-----------------+-------------
+  1 | {0}           |       3 | 0.642857142857143 |         1 |        2 | 0.171033941880327 |    0 |       14 |         0 |       2 |        1 | f               |            
+  2 | {0,1}         |       4 |                 1 |         1 |        2 |                 0 |    0 |        4 |         1 |         |          | f               |            
+  3 | {0,2}         |       4 |               0.6 |         1 |        2 | 0.673011667009257 |    0 |        5 |         1 |       5 |        1 | f               |            
+  4 | {0,3}         |       2 |               0.6 |         1 |        1 | 0.673011667009257 |    0 |        5 |         1 |       7 |        1 | t               |          70
+  5 | {0,2,1}       |       4 |                 1 |         1 |        2 |                 0 |    0 |        3 |         3 |         |          | f               |            
+  6 | {0,2,2}       |       4 |                 1 |         1 |        1 |                 0 |    0 |        2 |         3 |         |          | f               |            
+  7 | {0,3,1}       |       4 |                 1 |         1 |        2 |                 0 |    0 |        2 |         4 |         |          | f               |            
+  8 | {0,3,2}       |       4 |                 1 |         1 |        1 |                 0 |    0 |        3 |         4 |         |          | f               |            
 (8 rows)
 
 \endverbatim
@@ -1330,44 +1325,6 @@ m4_changequote(>>>`<<<, >>>'<<<)
 END
 $$ LANGUAGE PLPGSQL;
 
-DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__jump_aggr_sfunc
-    (
-    INT[], 
-    INT, 
-    INT
-    ) CASCADE;
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__jump_aggr_sfunc
-    (
-    INT[], 
-    INT, 
-    INT
-    ) 
-RETURNS INT[] AS $$
-DECLARE
-	temp INT[];
-BEGIN
-	temp = $1;
-	temp[$2+1] = $3;
-	
-	RETURN temp;
-END
-$$ LANGUAGE PLPGSQL;
-
-DROP AGGREGATE IF EXISTS MADLIB_SCHEMA.__jump_aggr
-    (
-    INT, 
-    INT
-    );
-CREATE AGGREGATE MADLIB_SCHEMA.__jump_aggr
-    (
-    INT, 
-    INT
-    ) 
-(
-  SFUNC=MADLIB_SCHEMA.__jump_aggr_sfunc,
-  STYPE=INT[]
-);
-
 
 /*
  *   For training one decision tree, we need some internal tables
@@ -1455,11 +1412,21 @@ BEGIN
     --      live:           Indication that the branch is still growing. 1 means "live". 
     --      cat_size:       Number of data point at this node.
     --      parent_id:      Id of the parent branch.
-    --      jump:           Location of children for each feature value. 
-    --                      Result such as [2:3]={2,3}, should be read: 
-    --                      jump['feature value'+1], so in this case there were no 
-    --                      0-value points for this feature. For value 1 jump to 2; 
-    --                      for value 2 jump to 3;
+    --      lmc_nid:        Leftmost child (lmc) node id of the node represented by the current row.
+    --      lmc_fval:       The feature value which leads to the lmc node.    
+    --                      An example of getting all the child nodes' ids and condition values
+    --                      1. Get the right most node id
+    --                      SELECT DISTINCT ON(parent_id) id FROM tree_table WHERE parent_id = $pid ORDER BY parent_id, id desc
+    --                      INTO max_child_nid;
+    --                      2. Get child nodes' ids and condition values by a while loop
+    --                      node_count = 1;
+    --                      WHILE (lmc_nid IS NOT NULL) AND (0 < node_count AND lmc_nid <= max_child_nid) LOOP
+    --                          ...
+    --                          lmc_nid  = lmc_nid  + 1;
+    --                          lmc_fval = lmc_fval + 1; 
+    --                          SELECT COUNT(id) FROM tree_table WHERE id = $lmc_nid AND parent_id = $pid 
+    --                          INTO node_count;        
+    --                      END LOOP;
     --      is_feature_cont: It specifies whether the selected feature is a continuous feature.
     --      split_value:    For continuous feature, it specifies the split value. Otherwise, 
     --                      it is of no meaning and fixed to 0.    
@@ -1477,7 +1444,8 @@ BEGIN
     	live            INT,
     	cat_size        INT,
     	parent_id       INT,
-    	jump            INT[],
+    	lmc_nid         INT,
+    	lmc_fval        INT,
         is_feature_cont BOOLEAN,
         split_value     FLOAT
 	) m4_ifdef(`__GREENPLUM__', `DISTRIBUTED BY (id)');
@@ -1498,7 +1466,8 @@ BEGIN
     	live            INT,
     	cat_size        INT,
     	parent_id       INT,
-    	jump            INT[],
+        lmc_nid         INT,
+        lmc_fval        INT,
         is_feature_cont BOOLEAN,
         split_value     FLOAT    
 	) m4_ifdef(`__GREENPLUM__', `DISTRIBUTED BY (id)');';
@@ -1640,7 +1609,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
                               (
                                   Select parent_id  
                                   FROM % 
-                                  WHERE jump IS NOT NULL
+                                  WHERE lmc_nid IS NOT NULL
                               ) and id <> 1
                       );',
                   ARRAY[
@@ -1716,7 +1685,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
 
         SELECT MADLIB_SCHEMA.__format
             (
-                'UPDATE % t1 SET jump = NULL, maxclass = t2.maxclass 
+                'UPDATE % t1 SET lmc_nid = NULL, lmc_fval = NULL, maxclass = t2.maxclass 
                  FROM selected_parent_ids_rep t2
                  WHERE t1.id = t2.parent_id;',
                 tree_table_name
@@ -1795,7 +1764,7 @@ BEGIN
                         FROM % 
                         WHERE parent_id NOT IN 
                             (
-                            Select parent_id  FROM % WHERE jump IS NOT NULL
+                            Select parent_id  FROM % WHERE lmc_nid IS NOT NULL
                             )  and id <> 1
                     ) m 
                     GROUP BY m.parent_id
@@ -1831,7 +1800,7 @@ BEGIN
         SELECT MADLIB_SCHEMA.__format
             (
                 'UPDATE %  
-                SET jump = NULL 
+                SET lmc_nid = NULL, lmc_fval = NULL 
                 WHERE id IN 
                     (SELECT parent_id FROM selected_parent_ids_ebp)',
                 tree_table_name
@@ -1857,43 +1826,38 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__generate_final_tree
     ) 
 RETURNS void AS $$
 DECLARE
-    tree_size INTEGER;
+    tree_size   INTEGER;
+    curstmt     TEXT;
 BEGIN
-    TRUNCATE auxiliary_tree_info;
-    TRUNCATE auxiliary_tree_info2;
-    
-    EXECUTE 'DELETE FROM tree_internal WHERE COALESCE(cat_size,0) = 0';
-    
-    EXECUTE 'SELECT count(*) FROM tree_internal' INTO tree_size;
-    EXECUTE 'INSERT INTO auxiliary_tree_info (id, parent_id, new_id) SELECT id, 
-            MAX(parent_id), ('||tree_size||'+1) - count(1) 
-            OVER(ORDER BY id DESC ROWS UNBOUNDED PRECEDING) FROM tree_internal GROUP BY id';
-            
-    EXECUTE 'INSERT INTO auxiliary_tree_info2 (id, parent_id, new_id) 
-            SELECT  g2.id,g.new_id,g2.new_id FROM auxiliary_tree_info g, 
-            auxiliary_tree_info g2  WHERE g.id = g2.parent_id';
-    
-    TRUNCATE auxiliary_tree_info;
     EXECUTE 'TRUNCATE '||result_tree_table_name||';';
     
-    EXECUTE 'INSERT INTO '|| result_tree_table_name||' SELECT n.new_id, 
-            g.tree_location, g.feature, g.probability, 
-            g.ebp_coeff,g.maxclass, g.split_gain, g.live, g.cat_size, 
-            n.parent_id, g.jump, g.is_feature_cont, g.split_value 
-            FROM tree_internal g, auxiliary_tree_info2 n WHERE n.id = g.id';
-            
-    EXECUTE 'INSERT INTO '||result_tree_table_name
-            ||' SELECT * FROM tree_internal WHERE id = 1';
-            
-    TRUNCATE tree_internal;
-    EXECUTE 'INSERT INTO tree_internal (id, jump) SELECT parent_id, 
-            MADLIB_SCHEMA.__jump_aggr(tree_location[array_upper(tree_location,1)], id) FROM '
-            ||result_tree_table_name||' GROUP BY parent_id';
-            
-    TRUNCATE auxiliary_tree_info2;
-    EXECUTE 'UPDATE '||result_tree_table_name||' k 
-            SET jump = g.jump FROM tree_internal g WHERE g.id = k.id';
-    TRUNCATE tree_internal;
+    -- populate result tree table with the rows in tree_internal
+    EXECUTE ' INSERT INTO ' || 
+            result_tree_table_name || 
+            ' SELECT *  FROM tree_internal WHERE COALESCE(cat_size,0) > 0';
+    
+    -- for each node, find the left most child node id and the feature value, and
+    -- update the node's lmc_nid and lmc_fval column     
+    SELECT MADLIB_SCHEMA.__format
+            (
+                'UPDATE % k
+                 SET lmc_nid = g.lmc_nid, lmc_fval = g.lmc_fval
+                 FROM  
+                    (
+                    SELECT DISTINCT ON(parent_id) parent_id,
+                           id as lmc_nid, 
+                           tree_location[array_upper(tree_location,1)] as lmc_fval
+                    FROM %
+                    ORDER BY parent_id, id
+                    ) g
+                WHERE k.id = g.parent_id',
+                ARRAY[
+                    result_tree_table_name,
+                    result_tree_table_name
+                    ]
+            )
+    INTO curstmt;   
+    EXECUTE curstmt;
 END
 $$ LANGUAGE PLPGSQL;
 
@@ -2311,7 +2275,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
 END
 $$ LANGUAGE PLPGSQL;
 
-/**
+/*
  * @brief Train a decision tree model. User must specify all those data with that 
  *        long form function.
  *
@@ -2352,11 +2316,12 @@ $$ LANGUAGE PLPGSQL;
  *                                      Exit value may be 1 if number of branches reached before termination condition is met.
  *  - <tt>cat_size INT</tt>             Number of data point at this node.
  *  - <tt>parent_id INT</tt>            Id of the parent branch.
- *  - <tt>jump INT[]</tt>               Location of children for each feature value. Notice 
- *                                      that assuming that the data is sparse we can have value 0 - representing 
- *                                      no value. Result such as [2:3]={2,3}, should be read: 
- *                                      jump['feature value'+1], so in this case there were no 0-value points for 
- *                                      this feature. For value 1 jump to 2; for value 2 jump to 3;
+ *  - <tt>lmc_nid</tt>                  Leftmost child (lmc) node id of the node represented by the current row.
+ *  - <tt>lmc_fval</tt>                 The feature value which leads to the leftmost child (lmc) node.
+                                        Since the child nodes' ids are continuous integer values, they can be deduced 
+                                        by the lmc_nid and lmc_fval. For example, assume that the left most child node id is i (lmc_nid = i), 
+                                        and the feature value which leads to the lmc is j (lmc_fval = j). Given a feature value x, then it will
+                                        lead to the node whose id is i + x - j.
  *  - <tt>is_feature_cont BOOLEAN</tt>  It specifies whether the selected feature is a continuous feature.
  *  - <tt>split_value FLOAT</tt>        For continuous feature, it specifies the split value. Otherwise, 
  *     it is fixed to 0.
@@ -2616,7 +2581,7 @@ BEGIN
 END
 $$ LANGUAGE PLPGSQL;
 
-/**
+/*
  * @brief Another C45 train algorithm in short form
  *
  * @param the same as the ones accepted by the long form 
@@ -2667,7 +2632,7 @@ BEGIN
 END
 $$ LANGUAGE PLPGSQL;
 
-/**
+/*
  * @brief Another C45 train algorithm in short form
  *
  * @param the same as the ones accepted by the long form 
@@ -2720,7 +2685,7 @@ BEGIN
 END
 $$ LANGUAGE PLPGSQL;
 
-/**
+/*
  * @brief   Display the trained decision tree model with rules
  *
  * @param   tree_table_name     Name of the table containing the tree's information
@@ -2791,11 +2756,11 @@ BEGIN
     classtable_name = MADLIB_SCHEMA.__get_classtable_name(metatable_name);
     class_column_name = MADLIB_SCHEMA.__get_class_column_name(metatable_name);
     
-    EXECUTE 'SELECT id, maxclass, probability, cat_size, jump FROM ' || tree_table_name || ' WHERE id = 1' 
+    EXECUTE 'SELECT id, maxclass, probability, cat_size, lmc_nid, lmc_fval FROM ' || tree_table_name || ' WHERE id = 1' 
     INTO rec;
     
     -- in case the root node is leaf
-    IF (rec.jump IS NULL) THEN
+    IF (rec.lmc_nid IS NULL) THEN
         RETURN NEXT 'All instances will be classified to class ' || 
                      MADLIB_SCHEMA.__get_class_value(rec.maxclass, metatable_name) ||
                      ' [' || (rec.probability * rec.cat_size)::BIGINT || '/' || rec.cat_size || ']'; 
@@ -2811,7 +2776,7 @@ BEGIN
          WHERE id IN
             (SELECT DISTINCT feature
              FROM %
-             WHERE jump IS NOT NULL
+             WHERE lmc_nid IS NOT NULL
             )',
         metatable_name,
         tree_table_name
@@ -2887,7 +2852,7 @@ BEGIN
          FROM 
             (SELECT id, maxclass, tree_location, probability, cat_size
              FROM %
-             WHERE jump IS NULL
+             WHERE lmc_nid IS NULL
             ) n1
             LEFT JOIN
             (SELECT % as class, key
@@ -2918,7 +2883,7 @@ BEGIN
         (
         'CREATE TEMP TABLE c45_gen_rules_internode AS
         SELECT 
-            jump[key + 1] AS id,
+            lmc_nid + (key - lmc_fval) AS id,
             CASE WHEN (id = 1) THEN
                     ''  if '' || fname || COALESCE(MADLIB_SCHEMA.__to_char(split_value), MADLIB_SCHEMA.__to_char(fval), ''NULL'') 
                  ELSE
@@ -2927,17 +2892,21 @@ BEGIN
             array_to_string(tree_location, '''') || key AS location,
             0  AS rlid                                  
         FROM
-            (SELECT id, feature, tree_location, jump, split_value 
+            (SELECT id, feature, tree_location, lmc_nid, lmc_fval, split_value 
              FROM %
-             WHERE jump IS NOT NULL
+             WHERE lmc_nid IS NOT NULL
             ) n1
             LEFT JOIN
             (%) n2
             ON n1.feature = n2.fid
-        WHERE n1.jump[n2.key + 1] IS NOT NULL 
+        WHERE
+            (lmc_nid + key - lmc_fval) IN (SELECT id from %)
         m4_ifdef(`GREENPLUM', `DISTRIBUTED BY (location)')',
-        tree_table_name,
-        union_stmt
+        ARRAY[
+            tree_table_name,
+            union_stmt,
+            tree_table_name
+            ]
         )
     INTO curstmt;    
     EXECUTE curstmt;
@@ -2970,7 +2939,7 @@ BEGIN
     RETURN;
 END $$ LANGUAGE PLPGSQL;
 
-/**
+/*
  * @brief   Display the trained decision tree model with rules
  *
  * @param   tree_table_name     Name of the table containing the tree's information
@@ -3340,23 +3309,38 @@ DECLARE
     ret                     TEXT := '';
     tree_location           INT[];
     feature                 INT;
-    jump                    INT[];
+    lmc_nid                 INT;
+    lmc_fval                INT;
     maxclass                INT;
     cat_size                INT;
     is_feature_cont         BOOLEAN;
     temp_split_value        FLOAT;
     index                   INT;
     curr_value              INT;
+    node_count              INT;
+    max_child_nid           INT;
     probability             FLOAT;
+    curstmt                 TEXT;
 BEGIN
     IF (id IS NULL OR id <= 0) THEN
         RETURN ret;
     END IF;
+
+    SELECT MADLIB_SCHEMA.__format
+            (
+                'SELECT tree_location, feature, lmc_nid, lmc_fval,is_feature_cont, 
+                        split_value, maxclass,cat_size,probability
+                 FROM %
+                 WHERE id = %',
+                 ARRAY[
+                    tree_table,
+                    MADLIB_SCHEMA.__to_char(id)
+                 ]
+             )
+    INTO curstmt;
     
-    EXECUTE 'select tree_location, feature, jump,is_feature_cont, split_value,
-        maxclass,cat_size,probability from '
-        || tree_table || ' where id =' || id ||';' INTO tree_location, feature,jump, 
-        is_feature_cont,temp_split_value,maxclass, cat_size, probability; 
+    EXECUTE curstmt INTO tree_location, feature, lmc_nid, lmc_fval, is_feature_cont, 
+                         temp_split_value, maxclass, cat_size, probability;  
 
     curr_value = tree_location[array_upper(tree_location,1)];
 
@@ -3403,20 +3387,40 @@ BEGIN
         depth >= max_depth) THEN
         RETURN ret;
     END IF;
-
-    index = array_lower(jump,1);
-    WHILE index <= array_upper(jump,1) LOOP
+    
+    SELECT MADLIB_SCHEMA.__format
+            (
+                'SELECT DISTINCT ON(parent_id) id
+                 FROM %
+                 WHERE parent_id = %
+                 ORDER BY parent_id, id desc',
+                ARRAY[
+                    tree_table,
+                    MADLIB_SCHEMA.__to_char(id)
+                    ]
+            )
+    INTO curstmt;   
+    EXECUTE curstmt INTO max_child_nid;
+    
+    -- if current node has children, then recursively display
+    node_count = 1;
+    WHILE (lmc_nid IS NOT NULL) AND (0 < node_count AND lmc_nid <= max_child_nid) LOOP
         ret = ret || MADLIB_SCHEMA.__display_tree_no_ordered_aggr(
                             tree_table, 
-                            jump[index], 
+                            lmc_nid, 
                             feature, 
-                            depth+1, 
+                            depth + 1, 
                             is_feature_cont, 
                             temp_split_value, 
                             metatable_name,
                             max_depth);
-        index = index +1;
-    END LOOP; 
+                                    
+        lmc_nid = lmc_nid + 1;
+        
+        EXECUTE ' SELECT COUNT(id) FROM ' || tree_table ||
+                ' WHERE id = ' || lmc_nid || ' AND parent_id = ' || id
+                INTO node_count;        
+    END LOOP;
 
     RETURN ret;
 END $$ LANGUAGE PLPGSQL;
@@ -3506,6 +3510,7 @@ m4_ifdef(>>>__HAS_ORDERED_AGGREGATES__<<<, >>>
     RETURN MADLIB_SCHEMA.__c45_display_no_ordered_aggr(tree_table,max_depth);
 <<<)
 m4_changequote(>>>`<<<, >>>'<<<)
+
 END $$ LANGUAGE PLPGSQL;
 
 /*
@@ -3699,7 +3704,36 @@ BEGIN
             RAISE INFO 'new_depth: %', curr_level;
         END IF;
 
-        EXECUTE 'INSERT INTO ' || result_table_name ||' SELECT * FROM '|| 
+        -- if the node (whose id is "jump") doesn't exist, 
+        -- then insert them into result table 
+        -- (be classified to max_class of its corrsponding node)
+        SELECT MADLIB_SCHEMA.__format(
+            'INSERT INTO %(id, jump, class, prob, parent_id, leaf_id) 
+             SELECT id, 0, class, prob, parent_id, leaf_id
+             FROM %
+             WHERE jump NOT IN (SELECT id FROM %)',
+            ARRAY[
+                result_table_name,
+                table_names[table_pick],
+                tree_table_name
+                ]
+            ) 
+        INTO curstmt;
+        EXECUTE curstmt;
+        
+        -- delete from the being classified data table
+        SELECT MADLIB_SCHEMA.__format(
+            'DELETE FROM %
+             WHERE jump NOT IN (SELECT id FROM %)',
+            ARRAY[
+                table_names[table_pick],
+                tree_table_name
+                ]
+            ) 
+        INTO curstmt;
+        EXECUTE curstmt;
+                
+        EXECUTE 'INSERT INTO ' || result_table_name || ' SELECT * FROM ' || 
             table_names[(table_pick) % 2 + 1] ||' WHERE jump = 0;';
         EXECUTE 'TRUNCATE '|| table_names[(table_pick) % 2 + 1] ||';';
         EXECUTE 'SELECT count(id) FROM '||result_table_name||';' INTO size_finished;
@@ -3724,15 +3758,19 @@ BEGIN
             'INSERT INTO %
             SELECT pt.id, 
             CASE WHEN (is_feature_cont) THEN 
-                    COALESCE(gt.jump[
-                                     CASE WHEN (gt.split_value < farray[gt.feature]) THEN
-                                        3
-                                     ELSE
-                                        2
-                                     END
-                                    ], 0)
+                    CASE WHEN (gt.lmc_nid IS NULL) THEN
+                        0
+                    ELSE
+                        gt.lmc_nid + 
+                        float8lt(gt.split_value, farray[gt.feature])::INT4 + 1 -
+                        gt.lmc_fval
+                    END
                 ELSE 
-                    COALESCE(gt.jump[farray[gt.feature] + 1],0) 
+                    CASE WHEN (gt.lmc_nid IS NULL) THEN
+                        0
+                    ELSE                    
+                        gt.lmc_nid + farray[gt.feature] - gt.lmc_fval
+                    END
                 END as newjump,
             gt.maxclass, gt.probability, gt.parent_id, gt.id 
             FROM (
@@ -3742,7 +3780,7 @@ BEGIN
                 ON t1.id = t2.id
             ) AS pt,
             (
-                SELECT jump, maxclass,feature, probability, parent_id, id, is_feature_cont, split_value
+                SELECT lmc_nid, lmc_fval, maxclass,feature, probability, parent_id, id, is_feature_cont, split_value
                 FROM % 
                 WHERE array_upper(tree_location,1) = %
             ) AS gt
@@ -3758,7 +3796,7 @@ BEGIN
             )
         INTO curstmt;     
         EXECUTE curstmt;
-         
+
     END LOOP;
 
     EXECUTE 'INSERT INTO '||result_table_name||' SELECT * FROM '|| 

--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -1,11 +1,14 @@
-/*
+/* ----------------------------------------------------------------------- *//** 
  *
  * @file decision_tree.sql_in
  *
  * @brief decision tree APIs and main controller written in PL/PGSQL
- *
  * @date Dec. 22 2011
- */
+ *
+ * @sa For a brief introduction to decision trees, see the
+ *     module description \ref grp_dectree.
+ *
+ *//* ----------------------------------------------------------------------- */
 
 m4_include(`SQLCommon.m4')
 
@@ -25,7 +28,9 @@ m4_ifelse(
     `m4_define(`__POSTGRESQL_PRE_9_0__')'
 )
 
-/*
+/**
+@addtogroup grp_dectree
+
 @about
 
 This module provides an implementation of the C4.5 decision tree algorithm. 
@@ -2275,7 +2280,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
 END
 $$ LANGUAGE PLPGSQL;
 
-/*
+/**
  * @brief Train a decision tree model. User must specify all those data with that 
  *        long form function.
  *
@@ -2581,7 +2586,7 @@ BEGIN
 END
 $$ LANGUAGE PLPGSQL;
 
-/*
+/**
  * @brief Another C45 train algorithm in short form
  *
  * @param the same as the ones accepted by the long form 
@@ -2632,7 +2637,7 @@ BEGIN
 END
 $$ LANGUAGE PLPGSQL;
 
-/*
+/**
  * @brief Another C45 train algorithm in short form
  *
  * @param the same as the ones accepted by the long form 
@@ -2685,7 +2690,7 @@ BEGIN
 END
 $$ LANGUAGE PLPGSQL;
 
-/*
+/**
  * @brief   Display the trained decision tree model with rules
  *
  * @param   tree_table_name     Name of the table containing the tree's information
@@ -2939,7 +2944,7 @@ BEGIN
     RETURN;
 END $$ LANGUAGE PLPGSQL;
 
-/*
+/**
  * @brief   Display the trained decision tree model with rules
  *
  * @param   tree_table_name     Name of the table containing the tree's information
@@ -3465,7 +3470,7 @@ BEGIN
         0, metatable_name,max_depth);
 END $$ LANGUAGE PLPGSQL;
 
-/*
+/**
  * @brief Display the trained decision tree model with human readable format
  *
  * @param tree_table Name of the table containing the tree's information
@@ -3513,7 +3518,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
 
 END $$ LANGUAGE PLPGSQL;
 
-/*
+/**
  * @brief Display the whole trained decision tree model with human readable format
  *
  * @param tree_table Name of the table containing the tree's information
@@ -3813,7 +3818,7 @@ END
 $$ LANGUAGE PLPGSQL;
    
     
-/*
+/**
  * @brief Classify data points using trained decision tree model
  *
  * @param classification_table_name     Name of the table/view with the source data
@@ -3875,7 +3880,7 @@ BEGIN
 END
 $$ LANGUAGE PLPGSQL;
 
-/*
+/**
  * @brief   Classify the data with no verbosity
  *  
  * @param classification_table_name     Name of the table/view with the source data
@@ -3917,7 +3922,7 @@ BEGIN
     RETURN ret;
 END $$ LANGUAGE PLPGSQL;
 
-/*
+/**
  * @brief   Check the accuracy of the decision tree alogrithom 
  * 
  * @param tree_table_name           Name of trained tree
@@ -4034,7 +4039,7 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL;
 
-/*
+/**
  * @brief Cleanup the trained tree table and any relevant tables
  *
  * @param result_tree_table_name Name of the table containing the tree's information

--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -1477,25 +1477,6 @@ BEGIN
         split_value     FLOAT    
 	) m4_ifdef(`__GREENPLUM__', `DISTRIBUTED BY (id)');';
 
-    -- These two auxiliary internal tables help to
-    -- remove redundant tree nodes and move the useful
-    -- node to the final tree table.
-	DROP TABLE IF EXISTS auxiliary_tree_info CASCADE;
-	CREATE TEMP TABLE auxiliary_tree_info
-	(
-		id          INT,
-		new_id      INT,
-		parent_id   INT
-	) m4_ifdef(`__GREENPLUM__', `DISTRIBUTED BY (id)');
-
-	DROP TABLE IF EXISTS auxiliary_tree_info2 CASCADE;
-	CREATE TEMP TABLE auxiliary_tree_info2
-	(
-		id          INT,
-		new_id      INT,
-		parent_id   INT
-	) m4_ifdef(`__GREENPLUM__', `DISTRIBUTED BY (id)');
-
 END 
 $$ LANGUAGE PLPGSQL;
 
@@ -3774,44 +3755,15 @@ BEGIN
         IF(verbosity) THEN  
             RAISE INFO 'new_depth: %', curr_level;
         END IF;
-
-        -- if the node (whose id is "jump") doesn't exist, 
-        -- then insert them into result table 
-        -- (be classified to max_class of its corrsponding node)
-        SELECT MADLIB_SCHEMA.__format(
-            'INSERT INTO %(id, jump, class, prob, parent_id, leaf_id) 
-             SELECT id, 0, class, prob, parent_id, leaf_id
-             FROM %
-             WHERE jump NOT IN (SELECT id FROM %)',
-            ARRAY[
-                result_table_name,
-                table_names[table_pick],
-                tree_table_name
-                ]
-            ) 
-        INTO curstmt;
-        EXECUTE curstmt;
         
-        -- delete from the being classified data table
-        SELECT MADLIB_SCHEMA.__format(
-            'DELETE FROM %
-             WHERE jump NOT IN (SELECT id FROM %)',
-            ARRAY[
-                table_names[table_pick],
-                tree_table_name
-                ]
-            ) 
-        INTO curstmt;
-        EXECUTE curstmt;
-                
-        EXECUTE 'INSERT INTO ' || result_table_name || ' SELECT * FROM ' || 
-            table_names[(table_pick) % 2 + 1] ||' WHERE jump = 0;';
-        EXECUTE 'TRUNCATE '|| table_names[(table_pick) % 2 + 1] ||';';
+        table_pick = table_pick % 2 + 1; 
+        
+        EXECUTE 'TRUNCATE '|| table_names[table_pick] ||';';
         EXECUTE 'SELECT count(id) FROM '||result_table_name||';' INTO size_finished;
+        
         IF(verbosity) THEN  
             RAISE INFO 'size_finished %', size_finished;
-        END IF;            
-        table_pick = table_pick % 2 + 1; 
+        END IF;       
         
         EXECUTE 'SELECT count(*) FROM '|| table_names[(table_pick) % 2 + 1] ||';' 
             INTO remains_to_classify;
@@ -3868,6 +3820,34 @@ BEGIN
         INTO curstmt;     
         EXECUTE curstmt;
 
+        -- if the node (whose id is "jump") doesn't exist, 
+        -- then insert them into result table 
+        -- (be classified to max_class of its corrsponding node)
+        SELECT MADLIB_SCHEMA.__format(
+            'INSERT INTO %(id, jump, class, prob, parent_id, leaf_id) 
+             SELECT id, 0, class, prob, parent_id, leaf_id
+             FROM %
+             WHERE jump NOT IN (SELECT id FROM %)',
+            ARRAY[
+                result_table_name,
+                table_names[table_pick],
+                tree_table_name
+                ]
+            ) 
+        INTO curstmt;
+        EXECUTE curstmt;
+        
+        -- delete from the being classified data table
+        SELECT MADLIB_SCHEMA.__format(
+            'DELETE FROM %
+             WHERE jump NOT IN (SELECT id FROM %)',
+            ARRAY[
+                table_names[table_pick],
+                tree_table_name
+                ]
+            ) 
+        INTO curstmt;
+        EXECUTE curstmt;
     END LOOP;
 
     EXECUTE 'INSERT INTO '||result_table_name||' SELECT * FROM '|| 

--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -2281,8 +2281,7 @@ END
 $$ LANGUAGE PLPGSQL;
 
 /**
- * @brief Train a decision tree model. User must specify all those data with that 
- *        long form function.
+ * @brief This is the long form API of training tree with all specified parameters. 
  *
  * @param split_criterion_name      This parameter specifies which split criterion 
  *                                  should be used for tree construction and pruning. 
@@ -2295,6 +2294,7 @@ $$ LANGUAGE PLPGSQL;
  * @param id_col_name               Name of the column containing id of each point.
  * @param class_col_name            Name of the column containing correct class of each point.
  * @param confidence_level          A statistical confidence interval of the resubstitution error.
+ * @param how2handle_missing_value  The way to handle missing value. The valid value is 'explicit' or 'ignore'. 
  * @param max_num_iter              Max number of branches to follow (e.g. 2000)
  * @param max_tree_depth            Maximum decision tree depth 
  * @param min_percent_mode          Specifies the minimum number of cases required in a child node
@@ -2302,38 +2302,35 @@ $$ LANGUAGE PLPGSQL;
  *                                  a further split to be possible.
  * @param verbosity                 If True (or 1) will run in verbose mode
  *
- * @return Table MADLIB_SCHEMA.tree:
- *  - <tt>id SERIAL</tt> - Tree node id
- *  - <tt>tree_location INT[]</tt>      Set of values that lead to this branch. 
+ * @return The columns of trained tree table:
+ *  - <tt>id SERIAL</tt>              - Tree node id
+ *  - <tt>tree_location INT[]</tt>    - Set of values that lead to this branch. 
  *                                      0 is the initial point (no value). But this path does not specify which 
  *                                      feature was used for the branching.
- *  - <tt>feature INT</tt>              Which element of the feature vector was used for 
+ *  - <tt>feature INT</tt>            - Which element of the feature vector was used for 
  *                                      branching at this node. Notice that this feature is not used in the current 
- *     <tt>tree_location</tt>           it will be added in the next step.
- *  - <tt>probability FLOAT</tt>        If forced to make a call for a dominant class 
+ *     <tt>tree_location</tt>         - it will be added in the next step.
+ *  - <tt>probability FLOAT</tt>      - If forced to make a call for a dominant class 
  *                                      at a given point this would be the confidence of the call  
  *                                      (this is only an estimated value).
- *  - <tt>maxclass INTEGER</tt>         If forced to make a call for a dominant class 
+ *  - <tt>maxclass INTEGER</tt>       - If forced to make a call for a dominant class 
  *                                      at a given point this is the selected class.
- *  - <tt>split_gain FLOAT</tt>         Information gain computed using entropy (at this 
+ *  - <tt>split_gain FLOAT</tt>       - Information gain computed using entropy (at this 
  *                                      node), also used to determine termination of the branch.
- *  - <tt>live INT</tt>                 Indication that the branch is still growing. 1 means "live". 
+ *  - <tt>live INT</tt>               - Indication that the branch is still growing. 1 means "live". 
  *                                      Exit value may be 1 if number of branches reached before termination condition is met.
- *  - <tt>cat_size INT</tt>             Number of data point at this node.
- *  - <tt>parent_id INT</tt>            Id of the parent branch.
- *  - <tt>lmc_nid</tt>                  Leftmost child (lmc) node id of the node represented by the current row.
- *  - <tt>lmc_fval</tt>                 The feature value which leads to the leftmost child (lmc) node.
+ *  - <tt>cat_size INT</tt>           - Number of data point at this node.
+ *  - <tt>parent_id INT</tt>          - Id of the parent branch.
+ *  - <tt>lmc_nid</tt>                - Leftmost child (lmc) node id of the node represented by the current row.
+ *  - <tt>lmc_fval</tt>               - The feature value which leads to the leftmost child (lmc) node.
                                         Since the child nodes' ids are continuous integer values, they can be deduced 
                                         by the lmc_nid and lmc_fval. For example, assume that the left most child node id is i (lmc_nid = i), 
                                         and the feature value which leads to the lmc is j (lmc_fval = j). Given a feature value x, then it will
                                         lead to the node whose id is i + x - j.
- *  - <tt>is_feature_cont BOOLEAN</tt>  It specifies whether the selected feature is a continuous feature.
- *  - <tt>split_value FLOAT</tt>        For continuous feature, it specifies the split value. Otherwise, 
- *     it is fixed to 0.
+ *  - <tt>is_feature_cont BOOLEAN</tt>- It specifies whether the selected feature is a continuous feature.
+ *  - <tt>split_value FLOAT</tt>      - For continuous feature, it specifies the split value. Otherwise, 
+ *                                      it is fixed to 0.
  *
- * @note This function starts an iterative algorithm. It is not an aggregate
- *       function. Source and column names have to be passed as strings (due to
- *       limitations of the SQL syntax).
  */
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.c45_train
     (
@@ -2587,23 +2584,54 @@ END
 $$ LANGUAGE PLPGSQL;
 
 /**
- * @brief Another C45 train algorithm in short form
+ * @brief C45 train algorithm in short form.
  *
- * @param the same as the ones accepted by the long form 
+ * @param split_criterion_name      This parameter specifies which split criterion 
+ *                                  should be used for tree construction and pruning. 
+ *                                  The valid values are infogain, gainratio, or gini.
+ * @param training_table_name       Name of the table/view with the source data
+ * @param result_tree_table_name    The name of the table where the resulting DT will be stored.
  *
- * @return the same as the one returned by the long form
- *
- * @note  
- *      validation_table_name:      NULL 
- *      continuous_feature_names:   NULL
- *      id_col_name Name:           'id'
- *      class_col_name Name:        'class'
- *      confidence_level:           25
- *      max_num_iter:               2000
- *      max_tree_depth:             10 
- *      min_percent_mode:           0.001
- *      min_percent_split:          0.01 
- *      verbosity:                  0
+ * @return The columns of trained tree table:
+ *  - <tt>id SERIAL</tt>              - Tree node id
+ *  - <tt>tree_location INT[]</tt>    - Set of values that lead to this branch. 
+ *                                      0 is the initial point (no value). But this path does not specify which 
+ *                                      feature was used for the branching.
+ *  - <tt>feature INT</tt>            - Which element of the feature vector was used for 
+ *                                      branching at this node. Notice that this feature is not used in the current 
+ *     <tt>tree_location</tt>         - it will be added in the next step.
+ *  - <tt>probability FLOAT</tt>      - If forced to make a call for a dominant class 
+ *                                      at a given point this would be the confidence of the call  
+ *                                      (this is only an estimated value).
+ *  - <tt>maxclass INTEGER</tt>       - If forced to make a call for a dominant class 
+ *                                      at a given point this is the selected class.
+ *  - <tt>split_gain FLOAT</tt>       - Information gain computed using entropy (at this 
+ *                                      node), also used to determine termination of the branch.
+ *  - <tt>live INT</tt>               - Indication that the branch is still growing. 1 means "live". 
+ *                                      Exit value may be 1 if number of branches reached before termination condition is met.
+ *  - <tt>cat_size INT</tt>           - Number of data point at this node.
+ *  - <tt>parent_id INT</tt>          - Id of the parent branch.
+ *  - <tt>lmc_nid</tt>                - Leftmost child (lmc) node id of the node represented by the current row.
+ *  - <tt>lmc_fval</tt>               - The feature value which leads to the leftmost child (lmc) node.
+                                        Since the child nodes' ids are continuous integer values, they can be deduced 
+                                        by the lmc_nid and lmc_fval. For example, assume that the left most child node id is i (lmc_nid = i), 
+                                        and the feature value which leads to the lmc is j (lmc_fval = j). Given a feature value x, then it will
+                                        lead to the node whose id is i + x - j.
+ *  - <tt>is_feature_cont BOOLEAN</tt>- It specifies whether the selected feature is a continuous feature.
+ *  - <tt>split_value FLOAT</tt>      - For continuous feature, it specifies the split value. Otherwise, 
+ *                                      it is fixed to 0.
+ * @note Fixed parameter list: 
+ *      - <tt>validation_table_name</tt>    - NULL 
+ *      - <tt>continuous_feature_names</tt> - NULL
+ *      - <tt>id_col_name Name</tt>         - 'id'
+ *      - <tt>class_col_name Name</tt>      - 'class'
+ *      - <tt>confidence_level</tt>         - 25
+ *      - <tt>how2handle_missing_value</tt> - 'explicit'
+ *      - <tt>max_num_iter</tt>             - 2000
+ *      - <tt>max_tree_depth</tt>           - 10 
+ *      - <tt>min_percent_mode</tt>         - 0.001
+ *      - <tt>min_percent_split</tt>        - 0.01 
+ *      - <tt>verbosity</tt>                - 0
  */
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.c45_train
     (
@@ -2638,18 +2666,56 @@ END
 $$ LANGUAGE PLPGSQL;
 
 /**
- * @brief Another C45 train algorithm in short form
+ * @brief C45 train algorithm in short form.
  *
- * @param the same as the ones accepted by the long form 
+ * @param split_criterion_name      This parameter specifies which split criterion 
+ *                                  should be used for tree construction and pruning. 
+ *                                  The valid values are infogain, gainratio, or gini.
+ * @param training_table_name       Name of the table/view with the source data
+ * @param result_tree_table_name    The name of the table where the resulting DT will be stored.
+ * @param validation_table_name     The validation table used for pruning tree. 
+ * @param continuous_feature_names  A comma-separated list of the names of the features whose values are continuous. 
+ * @param feature_col_names         A comma-separated list of names of the table columns, each of which defines a feature.
+ * @param id_col_name               Name of the column containing id of each point.
+ * @param class_col_name            Name of the column containing correct class of each point.
+ * @param confidence_level          A statistical confidence interval of the resubstitution error.
+ * @param how2handle_missing_value  The way to handle missing value. The valid value is 'explicit' or 'ignore'. 
  *
- * @return the same as the one returned by the long form
+ * @return The columns of trained tree table:
+ *  - <tt>id SERIAL</tt>              - Tree node id
+ *  - <tt>tree_location INT[]</tt>    - Set of values that lead to this branch. 
+ *                                      0 is the initial point (no value). But this path does not specify which 
+ *                                      feature was used for the branching.
+ *  - <tt>feature INT</tt>            - Which element of the feature vector was used for 
+ *                                      branching at this node. Notice that this feature is not used in the current 
+ *     <tt>tree_location</tt>         - it will be added in the next step.
+ *  - <tt>probability FLOAT</tt>      - If forced to make a call for a dominant class 
+ *                                      at a given point this would be the confidence of the call  
+ *                                      (this is only an estimated value).
+ *  - <tt>maxclass INTEGER</tt>       - If forced to make a call for a dominant class 
+ *                                      at a given point this is the selected class.
+ *  - <tt>split_gain FLOAT</tt>       - Information gain computed using entropy (at this 
+ *                                      node), also used to determine termination of the branch.
+ *  - <tt>live INT</tt>               - Indication that the branch is still growing. 1 means "live". 
+ *                                      Exit value may be 1 if number of branches reached before termination condition is met.
+ *  - <tt>cat_size INT</tt>           - Number of data point at this node.
+ *  - <tt>parent_id INT</tt>          - Id of the parent branch.
+ *  - <tt>lmc_nid</tt>                - Leftmost child (lmc) node id of the node represented by the current row.
+ *  - <tt>lmc_fval</tt>               - The feature value which leads to the leftmost child (lmc) node.
+                                        Since the child nodes' ids are continuous integer values, they can be deduced 
+                                        by the lmc_nid and lmc_fval. For example, assume that the left most child node id is i (lmc_nid = i), 
+                                        and the feature value which leads to the lmc is j (lmc_fval = j). Given a feature value x, then it will
+                                        lead to the node whose id is i + x - j.
+ *  - <tt>is_feature_cont BOOLEAN</tt>- It specifies whether the selected feature is a continuous feature.
+ *  - <tt>split_value FLOAT</tt>      - For continuous feature, it specifies the split value. Otherwise, 
+ *                                      it is fixed to 0.
+ * @note Fixed parameter list: 
+ *      - <tt>max_num_iter</tt>             - 2000
+ *      - <tt>max_tree_depth</tt>           - 10 
+ *      - <tt>min_percent_mode</tt>         - 0.001
+ *      - <tt>min_percent_split</tt>        - 0.01 
+ *      - <tt>verbosity</tt>                - 0
  *
- * @note     
- *      max_num_iter:      			2000
- *      max_tree_depth:     		10 
- *      min_percent_mode:   		0.001
- *      min_percent_split:  		0.01 
- *      verbosity:          		0
  */
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.c45_train
     (
@@ -2691,7 +2757,7 @@ END
 $$ LANGUAGE PLPGSQL;
 
 /**
- * @brief   Display the trained decision tree model with rules
+ * @brief   Display the trained decision tree model with rules.
  *
  * @param   tree_table_name     Name of the table containing the tree's information
  * @param   verbosity           If >= 1 will run in verbose mode
@@ -3471,7 +3537,7 @@ BEGIN
 END $$ LANGUAGE PLPGSQL;
 
 /**
- * @brief Display the trained decision tree model with human readable format
+ * @brief Display the trained decision tree model with human readable format.
  *
  * @param tree_table Name of the table containing the tree's information
  * @param max_depth  The max depth to be displayed. If null, this function will show all levels.
@@ -3519,7 +3585,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
 END $$ LANGUAGE PLPGSQL;
 
 /**
- * @brief Display the whole trained decision tree model with human readable format
+ * @brief Display the whole trained decision tree model with human readable format.
  *
  * @param tree_table Name of the table containing the tree's information
  *                    
@@ -3819,17 +3885,17 @@ $$ LANGUAGE PLPGSQL;
    
     
 /**
- * @brief Classify data points using trained decision tree model
+ * @brief Classify dataset using trained decision tree model.
  *
- * @param classification_table_name     Name of the table/view with the source data
  * @param tree_table_name               Name of trained tree
+ * @param classification_table_name     Name of the table/view with the source data
  * @param result_table_name             Name of result table
  * @param verbosity                     If set to 't' will use verbose mode
  *
- * @return Table columns:
- *  - <tt>id INT</tt>       Point id.
- *  - <tt>class INT</tt>    Class prediction. 
- *  - <tt>prob FLOAT</tt>   Probability of the predicted class.
+ * @return The columns of classified table:
+ *  - <tt>id INT</tt>     - Record id.
+ *  - <tt>class INT</tt>  - Predicted class. 
+ *  - <tt>prob FLOAT</tt> - Probability of the predicted class.
  */
 DROP FUNCTION IF EXISTS MADLIB_SCHEMA.c45_classify
     (
@@ -3881,16 +3947,16 @@ END
 $$ LANGUAGE PLPGSQL;
 
 /**
- * @brief   Classify the data with no verbosity
+ * @brief Classify dataset using trained decision tree model.
  *  
  * @param classification_table_name     Name of the table/view with the source data
  * @param tree_table_name               Name of trained tree
  * @param result_table_name             Name of result table
  *
- * @return Table MADLIB_SCHEMA.classified_points:
- *  - <tt>id INT</tt>       Point id.
- *  - <tt>class INT</tt>    Class prediction. 
- *  - <tt>prob FLOAT</tt>   Probability of the predicted class.
+ * @return The columns of classified table:
+ *  - <tt>id INT</tt>     - Record id.
+ *  - <tt>class INT</tt>  - Predicted class. 
+ *  - <tt>prob FLOAT</tt> - Probability of the predicted class.
  */
 DROP FUNCTION IF EXISTS MADLIB_SCHEMA.c45_classify
     (
@@ -3923,11 +3989,12 @@ BEGIN
 END $$ LANGUAGE PLPGSQL;
 
 /**
- * @brief   Check the accuracy of the decision tree alogrithom 
+ * @brief Check the accuracy of the decision tree model. 
  * 
  * @param tree_table_name           Name of trained tree
  * @param scoring_table_name        Name of the table/view with the source data
  * @param verbosity                 If set to 't' will use verbose mode 
+ *
  * @return The estimated accuracy information.
  */
 DROP FUNCTION IF EXISTS MADLIB_SCHEMA.c45_score
@@ -4040,11 +4107,11 @@ END;
 $$ LANGUAGE PLPGSQL;
 
 /**
- * @brief Cleanup the trained tree table and any relevant tables
+ * @brief Cleanup the trained tree table and any relevant tables.
  *
  * @param result_tree_table_name Name of the table containing the tree's information
  *
- * @return BOOLEAN value indicating the status of that cleanup operation.
+ * @return The status of that cleanup operation.
  *
  */
 DROP FUNCTION IF EXISTS  MADLIB_SCHEMA.c45_clean

--- a/methods/decision_tree/src/pg_gp/utility.sql_in
+++ b/methods/decision_tree/src/pg_gp/utility.sql_in
@@ -1431,6 +1431,7 @@ $$ LANGUAGE PLPGSQL;
 
 /*
  * @brief check if the input table has unsupported data type or not
+ *        check if the id column of input table has duplicated value or not
  * @param full_table_name <schema name>.<table name> 
  * @param feature_columns one array including all feature names
  * @param id_column the name of the id column        
@@ -1526,39 +1527,31 @@ BEGIN
                          DATE, TIME, TIMETZ, TIMESTAMP, TIMESTAMPTZ, and INTERVAL', 
                          rec.atttypid::regtype;
     END IF;
-        
-    RETURN;
-END
-$$ LANGUAGE PLPGSQL;    
 
-
-/*
- * @brief check if the input table has unsupported data type or not
- * @param full_table_name <schema name>.<table name> 
- *
- * @return if the table has unsupported data types, then raise exception
- *         otherwise return nothing
- *
- * NOTE: All the supported type are hardcoded in the function body     
- */
-DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__validate_input_table
-    (
-    full_table_name     TEXT
-    );
-
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__validate_input_table    
-    (
-    full_table_name     TEXT
-    )
-RETURNS void AS $$  
-BEGIN
-    PERFORM MADLIB_SCHEMA.__validate_input_table
-                        (
-                            full_table_name,
-                            NULL,
-                            NULL,
-                            NULL
-                        );     
+    SELECT MADLIB_SCHEMA.__format
+            ('SELECT % AS n
+              FROM % 
+              GROUP BY %
+              HAVING COUNT(%) > 1
+              LIMIT 1',
+              ARRAY[
+                id_column,
+                full_table_name,
+                id_column,
+                id_column
+                ]
+            )
+    INTO stmt;
+    
+    EXECUTE stmt INTO rec;
+    
+    -- check if the id column has duplicated value
+    PERFORM MADLIB_SCHEMA.__assert
+                (
+                    rec IS NULL,
+                    'The training table ' || full_table_name || ' must not have duplicated id'
+                );
+                        
     RETURN;
 END
 $$ LANGUAGE PLPGSQL;    
@@ -1822,13 +1815,6 @@ DECLARE
 BEGIN
     exec_begin = clock_timestamp();
 
-    PERFORM MADLIB_SCHEMA.__validate_input_table
-        (
-            MADLIB_SCHEMA.__get_schema_name(input_table_name)   ||
-            '.'                                                 ||
-            MADLIB_SCHEMA.__strip_schema_name(input_table_name)
-        );
-                
     SELECT MADLIB_SCHEMA.__format
         ('SELECT column_name FROM MADLIB_SCHEMA.% WHERE column_type=''i'';',
         metatable_name)
@@ -1836,6 +1822,16 @@ BEGIN
     
     EXECUTE curstmt INTO id_column_name;
     
+    PERFORM MADLIB_SCHEMA.__validate_input_table
+        (
+            MADLIB_SCHEMA.__get_schema_name(input_table_name)   ||
+            '.'                                                 ||
+            MADLIB_SCHEMA.__strip_schema_name(input_table_name),
+            NULL,
+            id_column_name,
+            NULL
+        );
+                
     SELECT MADLIB_SCHEMA.__format
         ('SELECT column_name, table_name FROM MADLIB_SCHEMA.% WHERE is_cont ORDER BY id;',
         metatable_name)


### PR DESCRIPTION
1. madlib-341: Check duplicated id values in training/classification table. (utility.sql_in).
2. madlib-381/382: Out of memory FOR C45_TRAIN on GPDB4.1. (decision_tree.sql_in).
3. Add an additional star (/**) to the classify, score, display, clean API.
4. Refine documentation for public API.
