### PR TITLE
Fix for madlib-317: DT will create global table and it has privelege issue

### DIFF
--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -695,7 +695,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
                         ) AS t1
                     CROSS JOIN
                     (
-                        SELECT key FROM MADLIB_SCHEMA.%
+                        SELECT key FROM %
                     ) as t2
                 ) AS n1 
                 LEFT JOIN % n2   
@@ -779,7 +779,7 @@ BEGIN
     SELECT MADLIB_SCHEMA.__format
         (
         'SELECT table_name 
-        FROM MADLIB_SCHEMA.% 
+        FROM % 
         WHERE column_type = ''c''',
         metatable_name
         )
@@ -790,7 +790,7 @@ BEGIN
     SELECT MADLIB_SCHEMA.__format
         (
             'SELECT id, column_name, is_cont 
-            FROM MADLIB_SCHEMA.% 
+            FROM % 
             WHERE column_type = ''f'' ORDER BY id',
             metatable_name
         )
@@ -913,7 +913,7 @@ BEGIN
     SELECT MADLIB_SCHEMA.__format
         (
         'SELECT table_name 
-        FROM MADLIB_SCHEMA.% 
+        FROM % 
         WHERE column_type = ''c''',
         metatable_name
         )
@@ -987,7 +987,7 @@ BEGIN
     SELECT MADLIB_SCHEMA.__format
         (
             'SELECT id, column_name, is_cont 
-            FROM MADLIB_SCHEMA.% 
+            FROM % 
             WHERE column_type = ''f'' ORDER BY id',
             metatable_name
         )
@@ -1612,7 +1612,7 @@ BEGIN
         'SELECT COUNT(*) 
          FROM %
          WHERE % NOT IN
-            (SELECT % FROM MADLIB_SCHEMA.% WHERE % IS NOT NULL)',
+            (SELECT % FROM % WHERE % IS NOT NULL)',
         ARRAY[
             validation_table,
             class_col_name,
@@ -2623,8 +2623,8 @@ BEGIN
                 (
                 tree_table_name,
                 training_table_name,
-                null,
-                null,
+                training_metatable_name,
+                training_encoded_table_name,
                 validation_table_name,
                 how2handle_missing_value,
                 split_criterion,
@@ -2647,13 +2647,6 @@ BEGIN
         h2hmv_routine_id,
         verbosity > 0
         );
-    
-    PERFORM  MADLIB_SCHEMA.__set_encode_and_metatable_name
-                ( 
-                tree_table_name, 
-                training_metatable_name,
-                training_encoded_table_name
-                );
                 
     IF(verbosity > 0) THEN
             RAISE INFO 'After encoding: %', clock_timestamp() - exec_begin;
@@ -2921,7 +2914,7 @@ BEGIN
         (
         'SELECT id, column_name, table_name, is_cont
          FROM 
-            MADLIB_SCHEMA.% n1
+            % n1
          WHERE id IN
             (SELECT DISTINCT feature
              FROM %
@@ -2955,7 +2948,7 @@ BEGIN
             SELECT MADLIB_SCHEMA.__format
                 (
                 'SELECT % as fid, key, ''% = ''::TEXT as fname, MADLIB_SCHEMA.__to_char(%) as fval
-                 FROM MADLIB_SCHEMA.%
+                 FROM %
                  WHERE key IS NOT NULL',
                 ARRAY[
                     MADLIB_SCHEMA.__to_char(rec.id),
@@ -3005,7 +2998,7 @@ BEGIN
             ) n1
             LEFT JOIN
             (SELECT % as class, key
-             FROM MADLIB_SCHEMA.% 
+             FROM % 
              WHERE key IS NOT NULL
             ) n2
             ON n1.maxclass = n2.key 
@@ -3280,8 +3273,6 @@ BEGIN
             );   
             
     metatable_name = MADLIB_SCHEMA.__get_metatable_name( tree_table );
-    -- We removed the schema when storing the metatable's name. 
-    metatable_name = 'MADLIB_SCHEMA.'||metatable_name;
  
     -- This table is used for tree display.
     -- It is filled with the original information before
@@ -3329,7 +3320,7 @@ BEGIN
     EXECUTE 'SELECT column_name,table_name FROM '||metatable_name||
             ' WHERE column_type=''c'' LIMIT 1;'
             INTO result_rec;
-    table_name = 'MADLIB_SCHEMA.'||result_rec.table_name;
+    table_name = result_rec.table_name;
     
     IF (table_name IS NOT NULL) THEN
         -- Convert back for the class column.
@@ -3362,7 +3353,6 @@ BEGIN
     FOR result_rec IN EXECUTE (curr_stmt) LOOP
         feature_name = result_rec.column_name;
         table_name = result_rec.table_name;
-        table_name = 'MADLIB_SCHEMA.'||table_name;
         SELECT MADLIB_SCHEMA.__format(
             'UPDATE auxiliary_tree_display n 
              SET curr_value = MADLIB_SCHEMA.__to_char(m.%) 

--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -2369,7 +2369,11 @@ $$ LANGUAGE PLPGSQL;
  * @param id_col_name               Name of the column containing id of each point.
  * @param class_col_name            Name of the column containing correct class of each point.
  * @param confidence_level          A statistical confidence interval of the resubstitution error.
- * @param how2handle_missing_value The way to handle missing value. The valid value is 'explicit' or 'ignore'.
+ * @param how2handle_missing_value  The way to handle missing value. The valid value is 'explicit' or 'ignore'.
+ * @param target_schema_name        Name of the schema in which result tree table, encoded table, and other auxiliary tables (such as data info table,
+ *                                  key-value table, etc.) will be put. 
+ *                                  If the result tree table name contains schema name, then it must be the same with the target schema name.
+ *                                  Otherwise, the result tree table will be under the target schema.
  * @param max_num_iter              Max number of branches to follow (e.g. 2000)
  * @param max_tree_depth            Maximum decision tree depth 
  * @param min_percent_mode          Specifies the minimum number of cases required in a child node
@@ -2397,7 +2401,8 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.c45_train
     id_col_name                 TEXT, 
     class_col_name              TEXT, 
     confidence_level            FLOAT,
-    how2handle_missing_value    TEXT, 
+    how2handle_missing_value    TEXT,
+    target_schema_name          TEXT, 
     max_num_iter                INT, 
     max_tree_depth              INT, 
     min_percent_mode            FLOAT,
@@ -2414,6 +2419,7 @@ DECLARE
     training_encoded_table_name     TEXT;
     training_metatable_name         TEXT;
     h2hmv_routine_id                INT := 1;  
+    ts_name                         TEXT;
     ret                             MADLIB_SCHEMA.c45_train_result;
 BEGIN   
     exec_begin = clock_timestamp();
@@ -2422,7 +2428,7 @@ BEGIN
         -- get rid of the messages whose severity level is lower than 'WARNING'
         SET client_min_messages = WARNING;
     END IF;
-    
+
     PERFORM MADLIB_SCHEMA.__assert
         (
             (split_criterion IS NOT NULL)   AND
@@ -2488,16 +2494,51 @@ BEGIN
         );
 
     PERFORM MADLIB_SCHEMA.__assert
+        (
+            (target_schema_name IS NOT NULL) AND
+            (MADLIB_SCHEMA.__schema_exists(target_schema_name)),
+            'the specified target schema' || coalesce('<' || target_schema_name || '> does not exist', ' is NULL')
+        );
+    
+    ts_name = lower(btrim(target_schema_name, ' '));
+
+    PERFORM MADLIB_SCHEMA.__assert
             (
-                (result_tree_table_name IS NOT NULL) AND
-                (
-                 NOT MADLIB_SCHEMA.__table_exists
+                result_tree_table_name IS NOT NULL,
+                'the specified result tree table name is NULL'
+            );
+                    
+    -- extract the schema name from result tree table name
+    -- if there is no schema name in the tree table, then we will use the target schema name as
+    -- its schema. Otherwise, the schema name of tree table must be the same with target schema name
+    tree_table_name = btrim(split_part(result_tree_table_name, '.', 2), ' ');
+    IF (tree_table_name = '' OR tree_table_name IS NULL) THEN
+        tree_table_name     = btrim(result_tree_table_name, ' ');
+        tree_schema_name    = ts_name;
+    ELSE
+        tree_table_name     = MADLIB_SCHEMA.__strip_schema_name(result_tree_table_name);
+        tree_schema_name    = MADLIB_SCHEMA.__get_schema_name(result_tree_table_name);
+    END IF;
+
+    PERFORM MADLIB_SCHEMA.__assert
+        (
+            tree_schema_name = ts_name,
+            'the schema name of result tree table must be the same with target schema name'
+        );
+            
+    PERFORM MADLIB_SCHEMA.__assert
+            (
+                NOT MADLIB_SCHEMA.__table_exists
                     (
-                        MADLIB_SCHEMA.__get_schema_name(result_tree_table_name),
-                        MADLIB_SCHEMA.__strip_schema_name(result_tree_table_name)
+                        tree_schema_name,
+                        tree_table_name
                     )
-                ),
-                'the specified result tree table' || coalesce('<' || result_tree_table_name || '> exists', ' is NULL')
+                ,
+                'the specified result tree table<'  || 
+                tree_schema_name                    ||
+                '.'                                 ||
+                tree_table_name                     || 
+                '> exists' 
             );   
 
     -- the maximum length of an identifier 63
@@ -2508,12 +2549,12 @@ BEGIN
     PERFORM MADLIB_SCHEMA.__assert
         (
             length(
-                MADLIB_SCHEMA.__get_schema_name(result_tree_table_name) || 
-                '_'                                                     || 
-                MADLIB_SCHEMA.__strip_schema_name(result_tree_table_name)) <= 58,
+                tree_schema_name      || 
+                '_'                   || 
+                tree_table_name) <= 58,
             'the maximum length of ''<tree table schema name>_<tree table name>'' is 58'
         );
-                    
+
     PERFORM MADLIB_SCHEMA.__assert
             (
                 (confidence_level IS NOT NULL)      AND 
@@ -2564,17 +2605,6 @@ BEGIN
     ELSE
         h2hmv_routine_id = 2;
     END IF;
-    
-    PERFORM MADLIB_SCHEMA.__insert_into_traininginfo
-                (
-                result_tree_table_name,
-                training_table_name,
-                null,
-                null,
-                validation_table_name,
-                how2handle_missing_value,
-                split_criterion
-                );
 
     cont_feature_col_names = MADLIB_SCHEMA.__csvstr_to_array(continuous_feature_names);
     
@@ -2582,16 +2612,25 @@ BEGIN
         RAISE INFO 'continuous features:%', cont_feature_col_names;
     END IF;
     
-    tree_table_name = MADLIB_SCHEMA.__strip_schema_name(result_tree_table_name);
-    tree_schema_name = MADLIB_SCHEMA.__get_schema_name(result_tree_table_name);
-    
-    IF(verbosity > 0) THEN
-        RAISE INFO 'table name after strip schema:%',tree_table_name;
-    END IF;
-    
-    training_encoded_table_name = 'MADLIB_SCHEMA.' || tree_schema_name || '_' ||tree_table_name || '_ed';
-    training_metatable_name =  tree_schema_name || '_' || tree_table_name || '_di';
- 
+    -- the encoded table and meta table will be under the specified schema (target_schema_name) 
+    training_encoded_table_name = ts_name || '.' || tree_schema_name || '_' ||tree_table_name || '_ed';
+    training_metatable_name =  ts_name || '.' || tree_schema_name || '_' || tree_table_name || '_di';
+
+    -- add the schema name to the tree table name
+    tree_table_name = tree_schema_name || '.' || tree_table_name;
+            
+    PERFORM MADLIB_SCHEMA.__insert_into_traininginfo
+                (
+                tree_table_name,
+                training_table_name,
+                null,
+                null,
+                validation_table_name,
+                how2handle_missing_value,
+                split_criterion,
+                ts_name
+                );
+                 
     IF(verbosity > 0) THEN
         RAISE INFO 'Before encoding: %', clock_timestamp() - exec_begin;
     END IF; 
@@ -2611,7 +2650,7 @@ BEGIN
     
     PERFORM  MADLIB_SCHEMA.__set_encode_and_metatable_name
                 ( 
-                result_tree_table_name, 
+                tree_table_name, 
                 training_metatable_name,
                 training_encoded_table_name
                 );
@@ -2623,11 +2662,11 @@ BEGIN
 
     ret = MADLIB_SCHEMA.__train_tree
             (
-            split_criterion ,
-            training_encoded_table_name ,
+            split_criterion,
+            training_encoded_table_name,
             training_metatable_name,
-            result_tree_table_name ,
-            validation_table_name , 
+            tree_table_name,
+            validation_table_name, 
             'id', 
             'class', 
             confidence_level,
@@ -2647,69 +2686,6 @@ BEGIN
 END
 $$ LANGUAGE PLPGSQL;
 
-/**
- * @brief C45 train algorithm in short form.
- *
- * @param split_criterion_name This parameter specifies which split criterion
- * should be used for tree construction and pruning.
- * The valid values are infogain, gainratio, or gini.
- * @param training_table_name Name of the table/view with the source data
- * @param result_tree_table_name The name of the table where the resulting DT will be stored.
- *
- * @return
- * - <tt>training_set_size</tt> - Number of items in the training set
- * - <tt>tree_nodes</tt> - Number of nodes in the resulting tree
- * - <tt>cost_time</tt> - Time spent training the tree
- * - <tt>split_criterion</tt> - Split criterion used to build the tree.
- *
- * This will also create the output table with name specified via 'result_tree_table_name'.
- * The result table can be queried directly or displayed using c45_display.
- *
- * @note  
- * This calls the long form of C45 with the following default parameters:
- * - validation_table_name := NULL
- * - continuous_feature_names := NULL
- * - id_column_name := 'id'
- * - class_column_name := 'class'
- * - confidence_level = 25
- * - how2handle_missing_value = 'explicit'
- * - max_num_iter := 2000
- * - max_tree_deapth := 10
- * - min_percent_mode := 0.001
- * - min_percent_split := 0.01
- * - verbosity := false
- */
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.c45_train
-    (
-    split_criterion         TEXT,
-    training_table_name     TEXT, 
-    result_tree_table_name  TEXT
-    ) 
-RETURNS MADLIB_SCHEMA.c45_train_result AS $$
-DECLARE
-    ret MADLIB_SCHEMA.c45_train_result;
-BEGIN   
-    ret = MADLIB_SCHEMA.c45_train(
-        split_criterion,
-        training_table_name, 
-        result_tree_table_name,
-        null,
-        null,       
-        null,
-        'id',
-        'class',
-        25,
-        'explicit',
-        2000,
-        10,
-        0.001,
-        0.01,
-        0           
-    );
-    
-    RETURN ret;
-END
-$$ LANGUAGE PLPGSQL;
 
 /**
  * @brief C45 train algorithm in short form.
@@ -2738,6 +2714,7 @@ $$ LANGUAGE PLPGSQL;
  *
  * @note     
  * This calls the long form of C45 with the following default parameters:
+ * - target_schema_name := <schema name of result tree table> 
  * - max_num_iter := 2000
  * - max_tree_deapth := 10
  * - min_percent_mode := 0.001
@@ -2759,8 +2736,19 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.c45_train
     ) 
 RETURNS MADLIB_SCHEMA.c45_train_result AS $$
 DECLARE
-    ret MADLIB_SCHEMA.c45_train_result;
-BEGIN   
+    ret                 MADLIB_SCHEMA.c45_train_result;
+    tree_schema_name    TEXT;
+BEGIN
+    -- extract the schema name of result tree table
+    -- use it as the target schema name
+    tree_schema_name = MADLIB_SCHEMA.__get_schema_name(result_tree_table_name);
+    PERFORM MADLIB_SCHEMA.__assert
+        (
+            (tree_schema_name IS NOT NULL) AND
+            (MADLIB_SCHEMA.__schema_exists(tree_schema_name)),
+            'the schema name' || coalesce('<' || tree_schema_name || '> does not exist', ' is NULL')
+        );
+           
     ret = MADLIB_SCHEMA.c45_train
             (
             split_criterion,
@@ -2773,6 +2761,7 @@ BEGIN
             class_col_name , 
             confidence_level,
             how2handle_missing_value,
+            tree_schema_name,
             2000,
             10,
             0.001,
@@ -2782,6 +2771,68 @@ BEGIN
     RETURN ret;
 END
 $$ LANGUAGE PLPGSQL;
+
+
+/**
+ * @brief C45 train algorithm in short form.
+ *
+ * @param split_criterion_name This parameter specifies which split criterion
+ * should be used for tree construction and pruning.
+ * The valid values are infogain, gainratio, or gini.
+ * @param training_table_name Name of the table/view with the source data
+ * @param result_tree_table_name The name of the table where the resulting DT will be stored.
+ *
+ * @return
+ * - <tt>training_set_size</tt> - Number of items in the training set
+ * - <tt>tree_nodes</tt> - Number of nodes in the resulting tree
+ * - <tt>cost_time</tt> - Time spent training the tree
+ * - <tt>split_criterion</tt> - Split criterion used to build the tree.
+ *
+ * This will also create the output table with name specified via 'result_tree_table_name'.
+ * The result table can be queried directly or displayed using c45_display.
+ *
+ * @note  
+ * This calls the above short form of C45 with the following default parameters:
+ * - validation_table_name := NULL
+ * - continuous_feature_names := NULL
+ * - id_column_name := 'id'
+ * - class_column_name := 'class'
+ * - confidence_level := 25
+ * - how2handle_missing_value := 'explicit'
+ * - target_schema_name := <schema name of result tree table> 
+ * - max_num_iter := 2000
+ * - max_tree_deapth := 10
+ * - min_percent_mode := 0.001
+ * - min_percent_split := 0.01
+ * - verbosity := false
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.c45_train
+    (
+    split_criterion         TEXT,
+    training_table_name     TEXT, 
+    result_tree_table_name  TEXT
+    ) 
+RETURNS MADLIB_SCHEMA.c45_train_result AS $$
+DECLARE
+    ret MADLIB_SCHEMA.c45_train_result;
+BEGIN   
+    ret = MADLIB_SCHEMA.c45_train(
+        split_criterion,
+        training_table_name, 
+        result_tree_table_name,
+        null,
+        null,       
+        null,
+        'id',
+        'class',
+        25,
+        'explicit'
+    );
+    
+    RETURN ret;
+END
+$$ LANGUAGE PLPGSQL;
+
 
 /**
  * @brief Display the trained decision tree model with rules.
@@ -4098,7 +4149,6 @@ BEGIN
                 'the specified tree table' || coalesce('<' || result_tree_table_name || '> does not exists', ' is NULL')
             ); 
                                     
-                
     IF (MADLIB_SCHEMA.__table_exists('MADLIB_SCHEMA', 'training_info')) THEN
         metatable_name = MADLIB_SCHEMA.__get_metatable_name(result_tree_table_name);
         

--- a/methods/decision_tree/src/pg_gp/sql/dec_trees.sql_in
+++ b/methods/decision_tree/src/pg_gp/sql/dec_trees.sql_in
@@ -559,7 +559,7 @@ declare
 begin 
 
 	train_result = MADLIB_SCHEMA.c45_train(method,training_set,tree_name,
-        validation_set,cont_features,null,'id',class_column, 100,missing_operation,30000,tree_dep,0,0,0);
+        validation_set,cont_features,null,'id',class_column, 100,missing_operation,'MADLIB_SCHEMA', 30000,tree_dep,0,0,0);
    
 	score_accuracy = MADLIB_SCHEMA.c45_score(tree_name,score_set,'f');
     -- For those two datasets, we should not get an accuracy lower than 0.9

--- a/methods/decision_tree/src/pg_gp/utility.sql_in
+++ b/methods/decision_tree/src/pg_gp/utility.sql_in
@@ -295,6 +295,46 @@ BEGIN
 END
 $$ LANGUAGE PLPGSQL;
 
+
+/*
+ * @brief Test if the specified schema exists or not
+ * @param schema_name   schema name
+ *
+ */
+DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__schema_exists
+    (
+    schema_name  TEXT
+    );
+    
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__schema_exists
+    (
+    schema_name  TEXT
+    ) 
+RETURNS BOOLEAN AS $$
+DECLARE
+    curstmt         TEXT := '';
+    result          INT  := 0;
+    schema_name_c   TEXT := '';
+BEGIN
+    PERFORM MADLIB_SCHEMA.__assert
+        (schema_name IS NOT NULL, 'Schema name must not be null!');
+    
+    schema_name_c = btrim(lower(schema_name), ' ');
+    
+    SELECT MADLIB_SCHEMA.__format('SELECT COUNT(c.oid)
+        FROM pg_catalog.pg_namespace c
+        WHERE btrim(c.nspname, '' '') = ''%'';',
+        schema_name_c
+        )
+        INTO curstmt;
+    
+    EXECUTE curstmt INTO result;
+    
+    RETURN result >= 1;
+END
+$$ LANGUAGE PLPGSQL;
+
+
 /*
  * @brief Test if the specified table exists or not
  * @param schema_name   schema name of the table
@@ -448,6 +488,47 @@ BEGIN
 END
 $$ LANGUAGE PLPGSQL;
 
+
+/*
+ * @brief assert if the specified table exists
+ * @param qualified_table_name  the fullly qualified table name
+ * @param existence ture        if assert table exists, otherwise false
+ *
+ */
+DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__assert
+    (
+    qualified_table_name     TEXT,
+    existence                BOOLEAN
+    );
+    
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__assert
+    (
+    qualified_table_name     TEXT,
+    existence                BOOLEAN
+    ) 
+RETURNS void AS $$
+DECLARE
+    err_msg     TEXT;
+BEGIN
+    IF (existence) THEN
+        err_msg = 'assertion failure. Table: ''' || qualified_table_name || ''' does not exist';
+    ELSE
+        err_msg = 'assertion failure. Table: ''' || qualified_table_name || ''' already exists';
+    END IF;
+    
+    PERFORM MADLIB_SCHEMA.__assert
+        (
+        MADLIB_SCHEMA.__table_exists
+            (
+                MADLIB_SCHEMA.__get_schema_name(qualified_table_name), 
+                MADLIB_SCHEMA.__strip_schema_name(qualified_table_name)
+            ) = existence, 
+        err_msg
+        );
+END
+$$ LANGUAGE PLPGSQL;
+
+
 /*
  * This is a global table to store information for various tree training.
  */
@@ -461,9 +542,51 @@ CREATE TABLE MADLIB_SCHEMA.training_info
     validation_table_name       TEXT,
     how2handle_missing_value    TEXT,
     split_criterion             TEXT,
+    target_schema_name          TEXT,
     PRIMARY KEY (tree_table_name)
     ) m4_ifdef(`__GREENPLUM__', `DISTRIBUTED BY (tree_table_name)');
-GRANT ALL PRIVILEGES ON MADLIB_SCHEMA.training_info TO PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON MADLIB_SCHEMA.training_info TO PUBLIC;
+
+/*
+ * @brief get the target schema name
+ * @param tree_table tree table name
+ *
+ */
+DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__get_target_schema_name
+    (
+    tree_table TEXT 
+    );            
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__get_target_schema_name
+    (
+    tree_table TEXT 
+    ) 
+RETURNS TEXT AS $$
+DECLARE
+    schema_name TEXT := '';
+BEGIN
+
+    PERFORM MADLIB_SCHEMA.__assert
+            (
+                MADLIB_SCHEMA.__get_schema_name(tree_table),
+                MADLIB_SCHEMA.__strip_schema_name(tree_table),
+                't'
+            );     
+    
+    PERFORM MADLIB_SCHEMA.__assert
+            (
+                'MADLIB_SCHEMA',
+                'training_info',
+                't'
+            ); 
+            
+    SELECT target_schema_name 
+    FROM MADLIB_SCHEMA.training_info 
+    WHERE tree_table_name = tree_table 
+    INTO schema_name;
+    
+    RETURN schema_name;
+end
+$$ LANGUAGE PLPGSQL;
 
 /*
  * @brief get the meta table name by the tree table name
@@ -506,39 +629,6 @@ BEGIN
 end
 $$ LANGUAGE PLPGSQL;
 
-/*
- * @brief get the class table name by the metatable name
- * @param metatable_name name of metatable
- *
- */
-DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__get_classtable_name
-    (
-    metatable_name TEXT 
-    );            
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__get_classtable_name
-    (
-    metatable_name TEXT 
-    ) 
-RETURNS TEXT AS $$
-DECLARE
-    classtable_name TEXT;
-BEGIN
-
-    PERFORM MADLIB_SCHEMA.__assert
-            (
-                'MADLIB_SCHEMA',
-                metatable_name,
-                't'
-            ); 
-            
-    EXECUTE ' SELECT table_name 
-              FROM MADLIB_SCHEMA.' || metatable_name ||
-            ' WHERE column_type = ''c'';'  
-    INTO classtable_name;
-    
-    RETURN classtable_name;
-end
-$$ LANGUAGE PLPGSQL;
 
 /*
  * @brief get the encoding table name by tree table name
@@ -613,31 +703,38 @@ $$ LANGUAGE PLPGSQL;
 
 
 /*
- * @brief get the feature column's name
- * @param tree_table tree table name         
- *  
- * @return the name of feature column
+ * @brief get the class table name by the metatable name
+ * @param metatable_name name of metatable
+ *
  */
-DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__get_feature_column_name
+DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__get_classtable_name
     (
-    tree_table TEXT
+    metatable_name TEXT 
     );            
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__get_feature_column_name
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__get_classtable_name
     (
-    tree_table TEXT
+    metatable_name TEXT 
     ) 
 RETURNS TEXT AS $$
 DECLARE
-    feature_name TEXT;
+    classtable_name TEXT;
 BEGIN
-    SELECT feature_col_names 
-    FROM   MADLIB_SCHEMA.training_info 
-    WHERE  tree_table_name = tree_table 
-    INTO   feature_name;
-        
-    RETURN feature_name;
+
+    PERFORM MADLIB_SCHEMA.__assert
+            (
+                metatable_name,
+                't'
+            ); 
+            
+    EXECUTE ' SELECT table_name 
+              FROM ' || metatable_name ||
+            ' WHERE column_type = ''c'';'  
+    INTO classtable_name;
+    
+    RETURN classtable_name;
 end
 $$ LANGUAGE PLPGSQL;
+
 
 /*
  * @brief Remove the trained tree from training info table 
@@ -679,7 +776,8 @@ DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__insert_into_traininginfo
     training_encoded_table_name TEXT,
     validation_table_name       TEXT,
     how2handle_missing_value    TEXT,
-    split_criterion             TEXT  
+    split_criterion             TEXT,
+    target_schema_name          TEXT
     );
                
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__insert_into_traininginfo
@@ -690,7 +788,8 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__insert_into_traininginfo
     training_encoded_table_name TEXT,
     validation_table_name       TEXT,
     how2handle_missing_value    TEXT,
-    split_criterion             TEXT  
+    split_criterion             TEXT,  
+    target_schema_name          TEXT
     )
 RETURNS void AS $$
 BEGIN
@@ -702,7 +801,8 @@ BEGIN
                         training_encoded_table_name,
                         validation_table_name,
                         how2handle_missing_value,
-                        split_criterion
+                        split_criterion,
+                        target_schema_name
                         );
 end
 $$ LANGUAGE PLPGSQL;
@@ -760,7 +860,7 @@ BEGIN
     IF( str_val is null or str_val = '' ) THEN
         str_val = trim(both ' ' FROM full_name);
     END IF;
-    RETURN str_val;
+    RETURN lower(str_val);
 end
 $$ LANGUAGE PLPGSQL;
 
@@ -789,68 +889,67 @@ BEGIN
     ELSE
         ret_val = btrim(split_part(full_name, '.', 1), ' ');
     END IF;
-    RETURN ret_val;
+    RETURN lower(ret_val);
 end
 $$ LANGUAGE PLPGSQL;
 
 
 /*
  * @brief Drop the metatable and all the KV tables
- * @param table_name the metatable name
+ * @param metatable_name the fully qualified metatable name
  *
- * @note MADLIB_SCHEMA will be added to the table_name automatically
  */
 DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__drop_metatable
     (
-    table_name TEXT
+    metatable_name TEXT
     );
 
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__drop_metatable 
     (
-    table_name TEXT
+    metatable_name TEXT
     )
 RETURNS void AS $$
 DECLARE
     curstmt TEXT;
     name    TEXT;
 BEGIN
-    IF ( table_name is NULL ) THEN
+    IF (metatable_name is NULL ) THEN
         RETURN;
     END IF;
     
-    PERFORM MADLIB_SCHEMA.__assert('MADLIB_SCHEMA', table_name, 't');
+    PERFORM MADLIB_SCHEMA.__assert(metatable_name, 't');
     
     SELECT MADLIB_SCHEMA.__format
             (
-            'SELECT table_name FROM MADLIB_SCHEMA.% 
+            'SELECT table_name FROM % 
             WHERE table_name IS NOT NULL AND length(trim(table_name, '' '')) > 1',
-            table_name
+            metatable_name
             ) 
     INTO curstmt;
         
     FOR name IN EXECUTE curstmt LOOP
-        PERFORM MADLIB_SCHEMA.__assert('MADLIB_SCHEMA', name, 't');
-        EXECUTE 'DROP TABLE MADLIB_SCHEMA.' || name || ' CASCADE;';
+        PERFORM MADLIB_SCHEMA.__assert(name, 't');
+        EXECUTE 'DROP TABLE ' || name || ' CASCADE;';
     END LOOP;
     
-    EXECUTE 'DROP TABLE MADLIB_SCHEMA.' || table_name || ' CASCADE;';
+    EXECUTE 'DROP TABLE ' || metatable_name || ' CASCADE;';
 end
 $$ LANGUAGE PLPGSQL;
 
 
 /*
  * @brief Create the metatable 
- * @param table_name the metatable name  
+ * @param metatable_name the fully qualified metatable name  
  *
  */
 DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__create_metatable
     (
-    table_name TEXT
+    metatable_name TEXT
     );
 
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__create_metatable 
     (
-    table_name TEXT
+    metatable_name TEXT
     )
 RETURNS void AS $$
 DECLARE
@@ -860,15 +959,15 @@ BEGIN
     -- the maximum length of an identifier is 63
     PERFORM MADLIB_SCHEMA.__assert
         (
-            length(MADLIB_SCHEMA.__strip_schema_name(table_name)) <= 63, 
-            'The maximum length of ' || table_name || ' is 63'
+            length(MADLIB_SCHEMA.__strip_schema_name(metatable_name)) <= 63, 
+            'The maximum length of ' || MADLIB_SCHEMA.__strip_schema_name(metatable_name) || ' is 63'
         );
         
     -- must not be existence
-    PERFORM MADLIB_SCHEMA.__assert('MADLIB_SCHEMA', table_name, 'f');
+    PERFORM MADLIB_SCHEMA.__assert(metatable_name, 'f');
     -- 'f' for feature, 'c' for class, 'i' for id
     -- 't' for continuous value, 'f' for discrete value
-    EXECUTE 'CREATE TABLE MADLIB_SCHEMA.'|| table_name || E'(
+    EXECUTE 'CREATE TABLE '|| metatable_name || E'(
         id SERIAL,
         column_name TEXT,
         column_type CHAR,    
@@ -921,7 +1020,7 @@ BEGIN
         'column type must be ''f'', ''i'' or ''c''');
     
     SELECT MADLIB_SCHEMA.__format(
-        'INSERT INTO MADLIB_SCHEMA.% VALUES(default, ''%'', ''%'', ''%'', ''%'', %);',
+        'INSERT INTO % VALUES(default, ''%'', ''%'', ''%'', ''%'', %);',
         ARRAY[
         metatable_name, 
         column_name, 
@@ -963,7 +1062,7 @@ BEGIN
     SELECT MADLIB_SCHEMA.__format
         (
         'SELECT num_dist_value 
-        FROM MADLIB_SCHEMA.% WHERE column_type=''f'' AND id = %;',
+        FROM % WHERE column_type=''f'' AND id = %;',
         metatable_name,
         MADLIB_SCHEMA.__to_char(feature_id)
         )
@@ -997,7 +1096,7 @@ BEGIN
     SELECT MADLIB_SCHEMA.__format
         (
         'SELECT COUNT(*) 
-        FROM MADLIB_SCHEMA.% WHERE column_type=''f'';',
+        FROM % WHERE column_type=''f'';',
         metatable_name
         )
         INTO curstmt; 
@@ -1032,7 +1131,7 @@ BEGIN
     SELECT MADLIB_SCHEMA.__format
         (
         'SELECT table_name 
-        FROM MADLIB_SCHEMA.% WHERE column_type=''c'';',
+        FROM % WHERE column_type=''c'';',
         metatable_name
         )
         INTO curstmt; 
@@ -1042,7 +1141,7 @@ BEGIN
     SELECT MADLIB_SCHEMA.__format
         (
         'SELECT COUNT(key)
-        FROM MADLIB_SCHEMA.%',
+        FROM %',
         class_table_name
         ) INTO curstmt;
     
@@ -1077,7 +1176,7 @@ DECLARE
 BEGIN
     SELECT MADLIB_SCHEMA.__format(
             'SELECT  id 
-             FROM    MADLIB_SCHEMA.% 
+             FROM    % 
              WHERE   column_name=''%'' AND column_type = ''f'' 
              LIMIT   1;',
             metatable_name,
@@ -1117,7 +1216,7 @@ DECLARE
 BEGIN
     SELECT MADLIB_SCHEMA.__format(
             'SELECT column_name 
-             FROM   MADLIB_SCHEMA.% 
+             FROM   % 
              WHERE  id = % AND column_type = ''f'';',
             metatable_name,
             MADLIB_SCHEMA.__to_char(feature_index)
@@ -1154,7 +1253,7 @@ DECLARE
 BEGIN
     FOR name IN EXECUTE 
         ('SELECT column_name 
-          FROM   MADLIB_SCHEMA.' || metatable_name || ' ' ||
+          FROM   ' || metatable_name || ' ' ||
          'WHERE  column_type = ''f'' ORDER BY id;'
         )
         LOOP
@@ -1189,7 +1288,7 @@ DECLARE
 BEGIN
     FOR name IN EXECUTE 
         ('SELECT column_name 
-          FROM   MADLIB_SCHEMA.' || metatable_name || ' ' ||
+          FROM   ' || metatable_name || ' ' ||
          'WHERE  column_type = ''f'' ORDER BY id;'
         )
         LOOP
@@ -1236,7 +1335,7 @@ BEGIN
     IF (column_type = 'c') THEN
         SELECT MADLIB_SCHEMA.__format(
             'SELECT ARRAY[column_name, table_name] 
-             FROM   MADLIB_SCHEMA.% 
+             FROM   % 
              WHERE  column_type = ''c'';',
             metatable_name
             )
@@ -1244,7 +1343,7 @@ BEGIN
     ELSE
         SELECT MADLIB_SCHEMA.__format(
             'SELECT ARRAY[column_name, table_name] 
-             FROM   MADLIB_SCHEMA.% 
+             FROM   % 
              WHERE  id = % AND column_type = ''%'';',
             metatable_name,
             MADLIB_SCHEMA.__to_char(column_index),
@@ -1260,14 +1359,14 @@ BEGIN
     
     IF (key IS NULL ) THEN
         SELECT MADLIB_SCHEMA.__format(
-            'SELECT % FROM MADLIB_SCHEMA.% WHERE key IS NULL;',
+            'SELECT % FROM % WHERE key IS NULL;',
             names[1],
             names[2]
         )
         INTO curstmt;        
     ELSE
         SELECT MADLIB_SCHEMA.__format(
-            'SELECT MADLIB_SCHEMA.__to_char(%) FROM MADLIB_SCHEMA.% WHERE key = %;',
+            'SELECT MADLIB_SCHEMA.__to_char(%) FROM % WHERE key = %;',
             names[1],
             names[2],
             MADLIB_SCHEMA.__to_char(key)
@@ -1340,14 +1439,13 @@ DECLARE
 BEGIN
     PERFORM MADLIB_SCHEMA.__assert
         (
-            'MADLIB_SCHEMA',
             metatable_name,
             't'
         );
         
     SELECT MADLIB_SCHEMA.__format(
             'SELECT column_name 
-             FROM   MADLIB_SCHEMA.% 
+             FROM   % 
              WHERE  column_type = ''i'' LIMIT 1',
             metatable_name
         )
@@ -1381,14 +1479,13 @@ DECLARE
 BEGIN
     PERFORM MADLIB_SCHEMA.__assert
         (
-            'MADLIB_SCHEMA',
             metatable_name,
             't'
         );
         
     SELECT MADLIB_SCHEMA.__format(
             'SELECT column_name 
-             FROM   MADLIB_SCHEMA.% 
+             FROM   % 
              WHERE  column_type = ''c'' LIMIT 1',
             metatable_name
         )
@@ -1431,6 +1528,7 @@ $$ LANGUAGE PLPGSQL;
 
 /*
  * @brief check if the input table has unsupported data type or not
+ *        check if the id column of input table has duplicated value or not
  * @param full_table_name <schema name>.<table name> 
  * @param feature_columns one array including all feature names
  * @param id_column the name of the id column        
@@ -1526,39 +1624,31 @@ BEGIN
                          DATE, TIME, TIMETZ, TIMESTAMP, TIMESTAMPTZ, and INTERVAL', 
                          rec.atttypid::regtype;
     END IF;
-        
-    RETURN;
-END
-$$ LANGUAGE PLPGSQL;    
 
-
-/*
- * @brief check if the input table has unsupported data type or not
- * @param full_table_name <schema name>.<table name> 
- *
- * @return if the table has unsupported data types, then raise exception
- *         otherwise return nothing
- *
- * NOTE: All the supported type are hardcoded in the function body     
- */
-DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__validate_input_table
-    (
-    full_table_name     TEXT
-    );
-
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__validate_input_table    
-    (
-    full_table_name     TEXT
-    )
-RETURNS void AS $$  
-BEGIN
-    PERFORM MADLIB_SCHEMA.__validate_input_table
-                        (
-                            full_table_name,
-                            NULL,
-                            NULL,
-                            NULL
-                        );     
+    SELECT MADLIB_SCHEMA.__format
+            ('SELECT % AS n
+              FROM % 
+              GROUP BY %
+              HAVING COUNT(%) > 1
+              LIMIT 1',
+              ARRAY[
+                id_column,
+                full_table_name,
+                id_column,
+                id_column
+                ]
+            )
+    INTO stmt;
+    
+    EXECUTE stmt INTO rec;
+    
+    -- check if the id column has duplicated value
+    PERFORM MADLIB_SCHEMA.__assert
+                (
+                    rec IS NULL,
+                    'The training table ' || full_table_name || ' must not have duplicated id'
+                );
+                        
     RETURN;
 END
 $$ LANGUAGE PLPGSQL;    
@@ -1649,6 +1739,7 @@ DECLARE
     col_index           INT := 1;
     contcol_stmt        TEXT := '';
     contcol_stmt_quote  TEXT := '';
+    -- the key-value tables will have the same schema with meta table
     coltable_name       TEXT := rtrim(metatable_name, 'di');
     exec_begin          TIMESTAMP;
 BEGIN
@@ -1663,7 +1754,7 @@ BEGIN
             id_column_name,
             class_column_name
         );
-        
+    
     PERFORM MADLIB_SCHEMA.__create_metatable(metatable_name);
     
     IF (cont_column_names IS NOT NULL) THEN  
@@ -1822,22 +1913,25 @@ DECLARE
 BEGIN
     exec_begin = clock_timestamp();
 
-    PERFORM MADLIB_SCHEMA.__validate_input_table
-        (
-            MADLIB_SCHEMA.__get_schema_name(input_table_name)   ||
-            '.'                                                 ||
-            MADLIB_SCHEMA.__strip_schema_name(input_table_name)
-        );
-                
     SELECT MADLIB_SCHEMA.__format
-        ('SELECT column_name FROM MADLIB_SCHEMA.% WHERE column_type=''i'';',
+        ('SELECT column_name FROM % WHERE column_type=''i'';',
         metatable_name)
         INTO curstmt; 
     
     EXECUTE curstmt INTO id_column_name;
     
+    PERFORM MADLIB_SCHEMA.__validate_input_table
+        (
+            MADLIB_SCHEMA.__get_schema_name(input_table_name)   ||
+            '.'                                                 ||
+            MADLIB_SCHEMA.__strip_schema_name(input_table_name),
+            NULL,
+            id_column_name,
+            NULL
+        );
+                
     SELECT MADLIB_SCHEMA.__format
-        ('SELECT column_name, table_name FROM MADLIB_SCHEMA.% WHERE is_cont ORDER BY id;',
+        ('SELECT column_name, table_name FROM % WHERE is_cont ORDER BY id;',
         metatable_name)
         INTO curstmt; 
         
@@ -1871,7 +1965,7 @@ BEGIN
         
     SELECT MADLIB_SCHEMA.__format
         ('SELECT column_name, column_type, table_name 
-          FROM   MADLIB_SCHEMA.% 
+          FROM   % 
           WHERE  (column_type <> ''i'') AND (NOT is_cont) ORDER BY id',
         metatable_name)
         INTO curstmt; 
@@ -2080,7 +2174,7 @@ BEGIN
             EXECUTE curstmt INTO min_val;
     
             SELECT MADLIB_SCHEMA.__format(
-                'CREATE TABLE MADLIB_SCHEMA.%(key) AS SELECT % m4_ifdef(`__GREENPLUM__', `DISTRIBUTED BY (key)')', 
+                'CREATE TABLE %(key) AS SELECT % m4_ifdef(`__GREENPLUM__', `DISTRIBUTED BY (key)')', 
                 coltable_name2,
                 MADLIB_SCHEMA.__to_char(min_val)) 
                 INTO curstmt;
@@ -2111,7 +2205,7 @@ BEGIN
     ELSE
          IF (h2hmv_routine_id = 2) THEN
              SELECT MADLIB_SCHEMA.__format(
-                'SELECT key FROM MADLIB_SCHEMA.% LIMIT 1', 
+                'SELECT key FROM % LIMIT 1', 
                 coltable_name2) 
                 INTO curstmt;
                 
@@ -2220,7 +2314,7 @@ BEGIN
     
     IF (is_persistent) THEN
         SELECT MADLIB_SCHEMA.__format
-            ('INSERT INTO MADLIB_SCHEMA.% VALUES(null, null)',
+            ('INSERT INTO % VALUES(null, null)',
             coltable_name)
         INTO curstmt;
        
@@ -2290,11 +2384,11 @@ BEGIN
     -- For each column, we will create a table for it. 
     -- The table stores the key->value, and distributed by value for parallelism                            
     IF (is_persistent) THEN
-        EXECUTE 'DROP TABLE IF EXISTS MADLIB_SCHEMA.' || coltable_name || ';';
+        EXECUTE 'DROP TABLE IF EXISTS ' || coltable_name || ';';
                 
         -- create table with columns: key, value
         SELECT MADLIB_SCHEMA.__format(
-            'CREATE TABLE MADLIB_SCHEMA.% (%, key)  
+            'CREATE TABLE % (%, key)  
             AS SELECT DISTINCT %, 1 FROM %   
             m4_ifdef(`__GREENPLUM__', `DISTRIBUTED BY(%)');', 
             ARRAY[
@@ -2312,7 +2406,7 @@ BEGIN
         EXECUTE curstmt;
         
         SELECT MADLIB_SCHEMA.__format(
-            'SELECT % FROM MADLIB_SCHEMA.% ORDER BY %',
+            'SELECT % FROM % ORDER BY %',
             column_name,
             coltable_name,
             column_name)
@@ -2329,26 +2423,26 @@ BEGIN
                 
                 IF (name IS NULL) THEN
                     SELECT MADLIB_SCHEMA.__format(
-                    'UPDATE MADLIB_SCHEMA.%  SET key=% WHERE % IS NULL',
+                    'UPDATE %  SET key=% WHERE % IS NULL',
                     coltable_name, temp, column_name)
                     INTO curstmt;
                 ELSE
                     SELECT MADLIB_SCHEMA.__format(
-                        'UPDATE MADLIB_SCHEMA.% SET key = % WHERE %=''%'';',
+                        'UPDATE % SET key = % WHERE %=''%'';',
                         coltable_name,
-			             temp,
+                         temp,
                         column_name,
                         name)
                         INTO curstmt;
                 END IF;
-		
-		      EXECUTE curstmt;
-		      
+        
+              EXECUTE curstmt;
+              
             ELSE
                 -- we call "replace" function twice to escape the string "'" and "\" 
                 SELECT MADLIB_SCHEMA.__format
                     (
-                    'UPDATE MADLIB_SCHEMA.% SET key=% WHERE %=E''%'';',
+                    'UPDATE % SET key=% WHERE %=E''%'';',
                     coltable_name,
                     MADLIB_SCHEMA.__to_char(index),
                     column_name,
@@ -2441,7 +2535,7 @@ m4_ifdef(>>>__GREENPLUM_PRE_4_1__<<<, >>>
     SELECT MADLIB_SCHEMA.__format
         ('CREATE TEMP TABLE c45_update_discrete_col_table(id, key) AS
           SELECT % as id, key
-          FROM % t LEFT JOIN MADLIB_SCHEMA.% k ON (t.% = k.% OR (t.% IS NULL AND k.% IS NULL))
+          FROM % t LEFT JOIN % k ON (t.% = k.% OR (t.% IS NULL AND k.% IS NULL))
           DISTRIBUTED BY (id)',
           ARRAY[
            id_column_name,
@@ -2468,7 +2562,7 @@ m4_ifdef(>>>__GREENPLUM_PRE_4_1__<<<, >>>
     INTO from_stmt;          
 <<<, >>>
     SELECT MADLIB_SCHEMA.__format
-                ('FROM MADLIB_SCHEMA.% s, % p 
+                ('FROM % s, % p 
                   WHERE (s.% = p.% OR (s.% is NULL AND p.% is NULL)) AND %.id=p.%',
                   ARRAY[
                   coltable_name,


### PR DESCRIPTION
1. Add an additional parameter "target_schema_name" to the c45_train function. 

```
CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.c45_train
    (
    split_criterion             TEXT,
    training_table_name         TEXT, 
    result_tree_table_name      TEXT,
    validation_table_name       TEXT, 
    continuous_feature_names    TEXT, 
    feature_col_names           TEXT, 
    id_col_name                 TEXT, 
    class_col_name              TEXT, 
    confidence_level            FLOAT,
    how2handle_missing_value    TEXT, 
    target_schema_name          TEXT
    max_num_iter                INT, 
    max_tree_depth              INT, 
    min_percent_mode            FLOAT,
    min_percent_split           FLOAT, 
    verbosity                   INT
    )
```
1. Put the "training_info" table to the MADLIB_SCHEMA. And store the "target_schema_name" in the training_info table.
2. If the result tree table name contains schema name, then it must be the same with the target schema name.
   Otherwise, the result tree table will be under the target schema.
3. Put the trained tree table and auxiliary tables (such as encoded table, data info table, key-value tables, etc.) to the "target_schema_name" schema.
