### PR TITLE
Fix for madlib-416: The decision tree algorithm does not accept temporary tables as training set

### DIFF
--- a/methods/decision_tree/src/pg_gp/decision_tree.c
+++ b/methods/decision_tree/src/pg_gp/decision_tree.c
@@ -9,13 +9,19 @@
 
 #include <float.h>
 #include <math.h>
+#include <stdlib.h>
+#include <time.h>
 
 #include "postgres.h"
 #include "fmgr.h"
 #include "utils/array.h"
+#include "utils/lsyscache.h"
+#include "utils/builtins.h"
 #include "catalog/pg_type.h"
+#include "catalog/namespace.h"
 #include "nodes/execnodes.h"
 #include "nodes/nodes.h"
+#include "funcapi.h"
 
 #ifndef NO_PG_MODULE_MAGIC
 PG_MODULE_MAGIC;
@@ -1324,3 +1330,21 @@ Datum scv_aggr_ffunc(PG_FUNCTION_ARGS)
     PG_RETURN_ARRAYTYPE_P(result_array);
 }
 PG_FUNCTION_INFO_V1(scv_aggr_ffunc);
+
+Datum table_exists(PG_FUNCTION_ARGS)
+{
+    text*           input;
+    List*           names;
+    char*           relname;
+    Oid             relid;
+
+    if (PG_ARGISNULL(0))
+        PG_RETURN_BOOL(false);
+    
+    input   =  PG_GETARG_TEXT_PP(0);
+    relname =  text_to_cstring(input); 
+    names = stringToQualifiedNameList(relname, "table_exists");
+    relid = RangeVarGetRelid(makeRangeVarFromNameList(names), true);
+    PG_RETURN_BOOL(OidIsValid(relid));
+}
+PG_FUNCTION_INFO_V1(table_exists);

--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -2448,8 +2448,7 @@ BEGIN
             training_table_name IS NOT NULL AND
             MADLIB_SCHEMA.__table_exists
                 (
-                    MADLIB_SCHEMA.__get_schema_name(training_table_name),
-                    MADLIB_SCHEMA.__strip_schema_name(training_table_name)
+                    training_table_name
                 ),
             'the specified training table' || coalesce('<' || training_table_name || '> does not exist', ' is NULL')
         );
@@ -2458,8 +2457,7 @@ BEGIN
         (
             MADLIB_SCHEMA.__column_exists
                 (
-                    MADLIB_SCHEMA.__get_schema_name(training_table_name),
-                    MADLIB_SCHEMA.__strip_schema_name(training_table_name),
+                    training_table_name,
                     lower(btrim(id_col_name, ' '))
                 ),
             'the specified training table<' || training_table_name || '> does not have column ''' || id_col_name || ''''
@@ -2469,8 +2467,7 @@ BEGIN
         (
             MADLIB_SCHEMA.__column_exists
                 (
-                    MADLIB_SCHEMA.__get_schema_name(training_table_name),
-                    MADLIB_SCHEMA.__strip_schema_name(training_table_name),
+                    training_table_name,
                     lower(btrim(class_col_name, ' '))
                 ),
             'the specified training table<' || training_table_name || '> does not have column ''' || class_col_name || ''''
@@ -2481,8 +2478,7 @@ BEGIN
             validation_table_name IS NULL OR
             MADLIB_SCHEMA.__table_exists
                 (
-                    MADLIB_SCHEMA.__get_schema_name(validation_table_name),
-                    MADLIB_SCHEMA.__strip_schema_name(validation_table_name)
+                    validation_table_name
                 ),
              'the specified validation table<' || validation_table_name || '> does not exist'
         );
@@ -2493,8 +2489,7 @@ BEGIN
                 (
                  NOT MADLIB_SCHEMA.__table_exists
                     (
-                        MADLIB_SCHEMA.__get_schema_name(result_tree_table_name),
-                        MADLIB_SCHEMA.__strip_schema_name(result_tree_table_name)
+                        result_tree_table_name
                     )
                 ),
                 'the specified result tree table' || coalesce('<' || result_tree_table_name || '> exists', ' is NULL')
@@ -2829,8 +2824,7 @@ BEGIN
                 (
                  MADLIB_SCHEMA.__table_exists
                     (
-                        MADLIB_SCHEMA.__get_schema_name(tree_table_name),
-                        MADLIB_SCHEMA.__strip_schema_name(tree_table_name)
+                        tree_table_name
                     )
                 ),
                 'the specified tree table' || coalesce('<' || tree_table_name || '> does not exists', ' is NULL')
@@ -3557,8 +3551,7 @@ BEGIN
                 (
                  MADLIB_SCHEMA.__table_exists
                     (
-                        MADLIB_SCHEMA.__get_schema_name(tree_table),
-                        MADLIB_SCHEMA.__strip_schema_name(tree_table)
+                        tree_table
                     )
                 ),
                 'the specified tree table' || coalesce('<' || tree_table || '> does not exists', ' is NULL')
@@ -3644,15 +3637,22 @@ DECLARE
     table_names             TEXT[] = '{classified_instance_ping,classified_instance_pong}';
 BEGIN
     time_stamp = clock_timestamp();
-
+    
+    -- Move the block to the beginning in case we need remove some temp tables
+    IF (is_result_temp) THEN
+        create_text = 'CREATE TEMP TABLE ';
+        EXECUTE 'DROP TABLE IF EXISTS '||result_table_name;
+    ELSE
+        create_text = 'CREATE TABLE ';
+    END IF;
+    
     PERFORM MADLIB_SCHEMA.__assert
             (
                 (classification_table_name IS NOT NULL) AND
                 (
                  MADLIB_SCHEMA.__table_exists
                     (
-                        MADLIB_SCHEMA.__get_schema_name(classification_table_name),
-                        MADLIB_SCHEMA.__strip_schema_name(classification_table_name)
+                        classification_table_name
                     )
                 ),
                 'the specified classification table' || coalesce('<' || classification_table_name || '> does not exists', ' is NULL')
@@ -3664,8 +3664,7 @@ BEGIN
                 (
                  MADLIB_SCHEMA.__table_exists
                     (
-                        MADLIB_SCHEMA.__get_schema_name(tree_table_name),
-                        MADLIB_SCHEMA.__strip_schema_name(tree_table_name)
+                        tree_table_name
                     )
                 ),
                 'the specified tree table' || coalesce('<' || tree_table_name || '> does not exists', ' is NULL')
@@ -3677,8 +3676,7 @@ BEGIN
                 (
                  NOT MADLIB_SCHEMA.__table_exists
                     (
-                        MADLIB_SCHEMA.__get_schema_name(result_table_name),
-                        MADLIB_SCHEMA.__strip_schema_name(result_table_name)
+                        result_table_name
                     )
                 ),
                 'the specified result table' || coalesce('<' || result_table_name || '> exists', ' is NULL')
@@ -3730,13 +3728,6 @@ BEGIN
         parent_id   INT,
         leaf_id     INT
     ) m4_ifdef(`__GREENPLUM__', `DISTRIBUTED BY (jump)');
-    
-    IF (is_result_temp) THEN
-        create_text = 'CREATE TEMP TABLE ';
-        EXECUTE 'DROP TABLE IF EXISTS '||result_table_name;
-    ELSE
-        create_text = 'CREATE TABLE ';
-    END IF;
     
     EXECUTE create_text || result_table_name || E'
     (
@@ -3988,8 +3979,7 @@ BEGIN
                 (
                  MADLIB_SCHEMA.__table_exists
                     (
-                        MADLIB_SCHEMA.__get_schema_name(tree_table_name),
-                        MADLIB_SCHEMA.__strip_schema_name(tree_table_name)
+                        tree_table_name
                     )
                 ),
                 'the specified tree table' || coalesce('<' || tree_table_name || '> does not exist', ' is NULL')
@@ -4001,8 +3991,7 @@ BEGIN
                 (
                  MADLIB_SCHEMA.__table_exists
                     (
-                        MADLIB_SCHEMA.__get_schema_name(scoring_table_name),
-                        MADLIB_SCHEMA.__strip_schema_name(scoring_table_name)
+                        scoring_table_name
                     )
                 ),
                 'the specified scoring table' || coalesce('<' || scoring_table_name || '> does not exist', ' is NULL')
@@ -4012,8 +4001,7 @@ BEGIN
         (
             MADLIB_SCHEMA.__column_exists
                 (
-                    MADLIB_SCHEMA.__get_schema_name(scoring_table_name),
-                    MADLIB_SCHEMA.__strip_schema_name(scoring_table_name),
+                    scoring_table_name,
                     MADLIB_SCHEMA.__get_class_column_name(MADLIB_SCHEMA.__get_metatable_name(tree_table_name))
                 ),
             'the specified scoring table<' || scoring_table_name || '> does not have class column'
@@ -4091,15 +4079,14 @@ BEGIN
                 (
                  MADLIB_SCHEMA.__table_exists
                     (
-                        MADLIB_SCHEMA.__get_schema_name(result_tree_table_name),
-                        MADLIB_SCHEMA.__strip_schema_name(result_tree_table_name)
+                        result_tree_table_name
                     )
                 ),
                 'the specified tree table' || coalesce('<' || result_tree_table_name || '> does not exists', ' is NULL')
             ); 
                                     
                 
-    IF (MADLIB_SCHEMA.__table_exists('MADLIB_SCHEMA', 'training_info')) THEN
+    IF (MADLIB_SCHEMA.__table_exists('MADLIB_SCHEMA.training_info')) THEN
         metatable_name = MADLIB_SCHEMA.__get_metatable_name(result_tree_table_name);
         
         IF( metatable_name IS NOT NULL) THEN

--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -3645,6 +3645,12 @@ DECLARE
 BEGIN
     time_stamp = clock_timestamp();
 
+    -- At function beginning, we need clear temp tables.
+    -- Otherwise, assertion below may fail.
+    IF (is_result_temp) THEN
+        EXECUTE 'DROP TABLE IF EXISTS '||result_table_name;
+    END IF;
+
     PERFORM MADLIB_SCHEMA.__assert
             (
                 (classification_table_name IS NOT NULL) AND
@@ -3733,7 +3739,6 @@ BEGIN
     
     IF (is_result_temp) THEN
         create_text = 'CREATE TEMP TABLE ';
-        EXECUTE 'DROP TABLE IF EXISTS '||result_table_name;
     ELSE
         create_text = 'CREATE TABLE ';
     END IF;

--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -3645,12 +3645,6 @@ DECLARE
 BEGIN
     time_stamp = clock_timestamp();
 
-    -- At function beginning, we need clear temp tables.
-    -- Otherwise, assertion below may fail.
-    IF (is_result_temp) THEN
-        EXECUTE 'DROP TABLE IF EXISTS '||result_table_name;
-    END IF;
-
     PERFORM MADLIB_SCHEMA.__assert
             (
                 (classification_table_name IS NOT NULL) AND
@@ -3739,6 +3733,7 @@ BEGIN
     
     IF (is_result_temp) THEN
         create_text = 'CREATE TEMP TABLE ';
+        EXECUTE 'DROP TABLE IF EXISTS '||result_table_name;
     ELSE
         create_text = 'CREATE TABLE ';
     END IF;

--- a/methods/decision_tree/src/pg_gp/sql/dec_trees.sql_in
+++ b/methods/decision_tree/src/pg_gp/sql/dec_trees.sql_in
@@ -611,13 +611,8 @@ SELECT MADLIB_SCHEMA.dt_test('MADLIB_SCHEMA.golf_dt_test','gini','temperature,hu
              humidity:  <= 70  : class( Play)   num_elements(2)  predict_prob(1)
              humidity:  > 70  : class( Do not Play)   num_elements(3)  predict_prob(1)');
 
--- create temp table and verify Decision tree works well with temp tables.
-DROP TABLE IF EXISTS golf_dt_test_temp;
-CREATE TEMP TABLE golf_dt_test_temp as SELECT * FROM MADLIB_SCHEMA.golf_dt_test;
-DROP TABLE IF EXISTS MADLIB_SCHEMA.golf_dt_test;
-
-SELECT MADLIB_SCHEMA.dt_test('golf_dt_test_temp','gainratio','temperature,humidity',
-    'class','golf_dt_test_temp','golf_dt_test_temp',10,'explicit',
+SELECT MADLIB_SCHEMA.dt_test('MADLIB_SCHEMA.golf_dt_test','gainratio','temperature,humidity',
+    'class','MADLIB_SCHEMA.golf_dt_test','MADLIB_SCHEMA.golf_dt_test',10,'explicit',
     'Root Node  : class( Play)   num_elements(14)  predict_prob(0.642857142857143)                                          
          temperature:  <= 83  : class( Play)   num_elements(13)  predict_prob(0.692307692307692)                            
              temperature:  <= 80  : class( Play)   num_elements(11)  predict_prob(0.636363636363636)                        
@@ -636,7 +631,7 @@ SELECT MADLIB_SCHEMA.dt_test('golf_dt_test_temp','gainratio','temperature,humidi
                  temperature:  > 75  : class( Do not Play)   num_elements(1)  predict_prob(1)                               
              temperature:  > 80  : class( Play)   num_elements(2)  predict_prob(1)                                          
          temperature:  > 83  : class( Do not Play)   num_elements(1)  predict_prob(1)');
-DROP TABLE IF EXISTS golf_dt_test_temp;
+DROP TABLE IF EXISTS MADLIB_SCHEMA.golf_dt_test;
 
 SELECT MADLIB_SCHEMA.dt_test('MADLIB_SCHEMA.crx_dt_test','gini','A2,A3,A8,A11,A14,A15',
     'a16','MADLIB_SCHEMA.crx_dt_test','MADLIB_SCHEMA.crx_dt_test',10,'ignore',

--- a/methods/decision_tree/src/pg_gp/sql/dec_trees.sql_in
+++ b/methods/decision_tree/src/pg_gp/sql/dec_trees.sql_in
@@ -611,8 +611,13 @@ SELECT MADLIB_SCHEMA.dt_test('MADLIB_SCHEMA.golf_dt_test','gini','temperature,hu
              humidity:  <= 70  : class( Play)   num_elements(2)  predict_prob(1)
              humidity:  > 70  : class( Do not Play)   num_elements(3)  predict_prob(1)');
 
-SELECT MADLIB_SCHEMA.dt_test('MADLIB_SCHEMA.golf_dt_test','gainratio','temperature,humidity',
-    'class','MADLIB_SCHEMA.golf_dt_test','MADLIB_SCHEMA.golf_dt_test',10,'explicit',
+-- create temp table and verify Decision tree works well with temp tables.
+DROP TABLE IF EXISTS golf_dt_test_temp;
+CREATE TEMP TABLE golf_dt_test_temp as SELECT * FROM MADLIB_SCHEMA.golf_dt_test;
+DROP TABLE IF EXISTS MADLIB_SCHEMA.golf_dt_test;
+
+SELECT MADLIB_SCHEMA.dt_test('golf_dt_test_temp','gainratio','temperature,humidity',
+    'class','golf_dt_test_temp','golf_dt_test_temp',10,'explicit',
     'Root Node  : class( Play)   num_elements(14)  predict_prob(0.642857142857143)                                          
          temperature:  <= 83  : class( Play)   num_elements(13)  predict_prob(0.692307692307692)                            
              temperature:  <= 80  : class( Play)   num_elements(11)  predict_prob(0.636363636363636)                        
@@ -631,7 +636,7 @@ SELECT MADLIB_SCHEMA.dt_test('MADLIB_SCHEMA.golf_dt_test','gainratio','temperatu
                  temperature:  > 75  : class( Do not Play)   num_elements(1)  predict_prob(1)                               
              temperature:  > 80  : class( Play)   num_elements(2)  predict_prob(1)                                          
          temperature:  > 83  : class( Do not Play)   num_elements(1)  predict_prob(1)');
-DROP TABLE IF EXISTS MADLIB_SCHEMA.golf_dt_test;
+DROP TABLE IF EXISTS golf_dt_test_temp;
 
 SELECT MADLIB_SCHEMA.dt_test('MADLIB_SCHEMA.crx_dt_test','gini','A2,A3,A8,A11,A14,A15',
     'a16','MADLIB_SCHEMA.crx_dt_test','MADLIB_SCHEMA.crx_dt_test',10,'ignore',

--- a/methods/decision_tree/src/pg_gp/sql/dec_trees.sql_in
+++ b/methods/decision_tree/src/pg_gp/sql/dec_trees.sql_in
@@ -611,7 +611,10 @@ SELECT MADLIB_SCHEMA.dt_test('MADLIB_SCHEMA.golf_dt_test','gini','temperature,hu
              humidity:  <= 70  : class( Play)   num_elements(2)  predict_prob(1)
              humidity:  > 70  : class( Do not Play)   num_elements(3)  predict_prob(1)');
 
-SELECT MADLIB_SCHEMA.dt_test('MADLIB_SCHEMA.golf_dt_test','gainratio','temperature,humidity',
+-- Verify the algorithm works well with temporary tables.
+DROP TABLE IF EXISTS golf_temp;
+CREATE TEMP TABLE golf_temp AS SELECT * FROM MADLIB_SCHEMA.golf_dt_test;
+SELECT MADLIB_SCHEMA.dt_test('golf_temp','gainratio','temperature,humidity',
     'class','MADLIB_SCHEMA.golf_dt_test','MADLIB_SCHEMA.golf_dt_test',10,'explicit',
     'Root Node  : class( Play)   num_elements(14)  predict_prob(0.642857142857143)                                          
          temperature:  <= 83  : class( Play)   num_elements(13)  predict_prob(0.692307692307692)                            
@@ -631,6 +634,7 @@ SELECT MADLIB_SCHEMA.dt_test('MADLIB_SCHEMA.golf_dt_test','gainratio','temperatu
                  temperature:  > 75  : class( Do not Play)   num_elements(1)  predict_prob(1)                               
              temperature:  > 80  : class( Play)   num_elements(2)  predict_prob(1)                                          
          temperature:  > 83  : class( Do not Play)   num_elements(1)  predict_prob(1)');
+DROP TABLE IF EXISTS golf_temp;
 DROP TABLE IF EXISTS MADLIB_SCHEMA.golf_dt_test;
 
 SELECT MADLIB_SCHEMA.dt_test('MADLIB_SCHEMA.crx_dt_test','gini','A2,A3,A8,A11,A14,A15',

--- a/methods/decision_tree/src/pg_gp/utility.sql_in
+++ b/methods/decision_tree/src/pg_gp/utility.sql_in
@@ -785,26 +785,11 @@ BEGIN
     str_val = btrim(split_part(full_name, '.', 2), ' ');
 
     IF( str_val is null or str_val = '' ) THEN
-        -- If user does not explicitly specify schema name,
-        -- tentatively set the schema name to public
         ret_val = 'public';
-
-        -- If there is no table belonging to public,
-        -- set the schema name to temporary schema.
-        IF (
-             NOT MADLIB_SCHEMA.__table_exists
-                (
-                    ret_val,
-                    MADLIB_SCHEMA.__strip_schema_name(full_name)
-                )
-           )  THEN
-           SELECT nspname FROM pg_catalog.pg_namespace 
-                WHERE oid=pg_my_temp_schema() INTO ret_val;
-        END IF;
     ELSE
         ret_val = btrim(split_part(full_name, '.', 1), ' ');
     END IF;
-    RETURN lower(ret_val);
+    RETURN ret_val;
 end
 $$ LANGUAGE PLPGSQL;
 

--- a/methods/decision_tree/src/pg_gp/utility.sql_in
+++ b/methods/decision_tree/src/pg_gp/utility.sql_in
@@ -297,111 +297,101 @@ $$ LANGUAGE PLPGSQL;
 
 /*
  * @brief Test if the specified table exists or not
- * @param schema_name   schema name of the table
- * @param table_name    the short table name without schema name
+ *
+ * @param full_table_name    The full table name
  *
  */
-DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__table_exists
-    (
-    schema_name  TEXT,
-    table_name   TEXT
-    );
-    
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__table_exists
     (
-    schema_name  TEXT,
-    table_name   TEXT
+    full_table_name    TEXT
     ) 
 RETURNS BOOLEAN AS $$
 DECLARE
-    curstmt         TEXT := '';
-    result          INT := 0;
-    schema_name_c   TEXT := '';
-    table_name_c    TEXT := '';
+    --toid              OID;
+    table_name          TEXT;
+    temp                TEXT[];
+    len                 INT;
+    schema_names        TEXT[];
+    temp_schema         TEXT;
 BEGIN
-    PERFORM MADLIB_SCHEMA.__assert
-        (schema_name IS NOT NULL, 'Schema name must not be null!');
-        
-    PERFORM MADLIB_SCHEMA.__assert
-        (table_name IS NOT NULL, 'Table name must not be null!');
-    
-    IF (length(btrim(lower(schema_name), ' ')) = 0) THEN
-        schema_name_c = 'public';
-    ELSE
-        schema_name_c = schema_name;
+    IF (full_table_name IS NULL) THEN
+        RETURN 'f';
     END IF;
+
+    temp = string_to_array(full_table_name, '.');
+    len = array_upper(temp, 1);
     
-    table_name_c = btrim(lower(table_name), ' ');
+    IF (1 = len) THEN
+        -- get all schema names from search_path except the implicit schema 
+        schema_names = current_schemas('f');
+
+        -- add this session's temp schema to search path too
+        EXECUTE 'SELECT nspname FROM pg_catalog.pg_namespace 
+                 WHERE oid = pg_my_temp_schema() LIMIT 1'
+            INTO temp_schema;
+        schema_names[array_upper(schema_names, 1) + 1] = temp_schema;
+        
+        table_name = temp[1];
+    ELSE
+        PERFORM MADLIB_SCHEMA.__assert
+            (
+                len = 2, 
+                'wrong full table name<' || full_table_name || '>'
+            );
+        schema_names[1] = lower(btrim(temp[1]));
+        table_name = lower(btrim(temp[2], ' '));
+    END IF; 
+        
+    SELECT count(c.oid)
+    FROM   pg_catalog.pg_class c
+           LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = table_name
+      AND  n.nspname = any(schema_names)
+    INTO   len;
     
-    SELECT MADLIB_SCHEMA.__format('SELECT count(c.oid)
-        FROM pg_catalog.pg_class c
-        LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE btrim(c.relname, '' '') = ''%''
-        AND btrim(n.nspname, '' '') = ''%'';',
-        table_name_c,
-        schema_name_c
-        )
-        INTO curstmt;
-    
-    EXECUTE curstmt INTO result;
-    
-    RETURN result >= 1;
+    RETURN len >= 1;
 END
 $$ LANGUAGE PLPGSQL;
 
 
 /*
  * @brief Test if the specified column exists or not
- * @param schema_name   schema name of the table
- * @param table_name    the short table name without schema name
- * @param column_name   name of the column
+ *
+ * @param full_table_name    The full table name
  *
  */
-DROP FUNCTION IF EXISTS MADLIB_SCHEMA.__column_exists
-    (
-    schema_name  TEXT,
-    table_name   TEXT,
-    column_name  TEXT
-    );
-    
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__column_exists
     (
-    schema_name  TEXT,
-    table_name   TEXT,
-    column_name  TEXT
+    full_table_name   TEXT,
+    column_name       TEXT
     ) 
 RETURNS BOOLEAN AS $$
 DECLARE
     curstmt         TEXT := '';
-    result          INT := 0;
-    schema_name_c   TEXT := '';
-    table_name_c    TEXT := '';
+    result          INT  := 0;
 BEGIN
     PERFORM MADLIB_SCHEMA.__assert
-        (schema_name IS NOT NULL, 'schema name must not be null!');
-
-    PERFORM MADLIB_SCHEMA.__assert
-        (table_name IS NOT NULL, 'table name must not be null!');
+        (
+            (full_table_name IS NOT NULL) AND (column_name IS NOT NULL), 
+            'the table name and column name must not be null'
+        );
                 
-    PERFORM MADLIB_SCHEMA.__assert
-        (column_name IS NOT NULL, 'column name must not be null!');
-        
-    IF (length(btrim(lower(schema_name), ' ')) = 0) THEN
-        schema_name_c = 'public';
-    ELSE
-        schema_name_c = schema_name;
-    END IF;
-    
-    table_name_c = btrim(lower(table_name), ' ');
-    
-    IF (MADLIB_SCHEMA.__table_exists(schema_name_c, table_name_c)) THEN
-        EXECUTE 'SELECT COUNT(*) 
+    IF (MADLIB_SCHEMA.__table_exists(full_table_name)) THEN
+        SELECT MADLIB_SCHEMA.__format
+            (
+                'SELECT COUNT(*) 
                  FROM pg_catalog.pg_attribute 
                  WHERE attnum > 0 AND 
                        (NOT attisdropped) AND
-                       attname = ''' || column_name || ''' AND
-                       attrelid = ''' ||  schema_name_c || '.' || table_name_c || '''::regclass'
-        INTO result;
+                       attname = ''%'' AND
+                       attrelid = ''%''::regclass',
+                ARRAY[
+                    column_name,
+                    full_table_name
+                ]
+            ) INTO curstmt;
+            
+        EXECUTE curstmt INTO result;
         
         RETURN result >= 1;         
     END IF;
@@ -442,7 +432,7 @@ BEGIN
     
     PERFORM MADLIB_SCHEMA.__assert
         (
-        MADLIB_SCHEMA.__table_exists(schema_name, table_name) = existence, 
+        MADLIB_SCHEMA.__table_exists(schema_name||'.'||table_name) = existence, 
         err_msg
         );
 END
@@ -1656,9 +1646,7 @@ BEGIN
     
     PERFORM MADLIB_SCHEMA.__validate_input_table
         (
-            MADLIB_SCHEMA.__get_schema_name(input_table_name)   ||
-            '.'                                                 ||
-            MADLIB_SCHEMA.__strip_schema_name(input_table_name),
+            input_table_name,
             feature_names,
             id_column_name,
             class_column_name
@@ -1824,9 +1812,7 @@ BEGIN
 
     PERFORM MADLIB_SCHEMA.__validate_input_table
         (
-            MADLIB_SCHEMA.__get_schema_name(input_table_name)   ||
-            '.'                                                 ||
-            MADLIB_SCHEMA.__strip_schema_name(input_table_name)
+            input_table_name
         );
                 
     SELECT MADLIB_SCHEMA.__format
@@ -2176,8 +2162,7 @@ BEGIN
     IF (
         NOT MADLIB_SCHEMA.__column_exists
                     (
-                    MADLIB_SCHEMA.__get_schema_name(input_table_name),
-                    MADLIB_SCHEMA.__strip_schema_name(input_table_name),
+                    input_table_name,
                     column_name
                     ) 
        ) THEN

--- a/methods/decision_tree/src/pg_gp/utility.sql_in
+++ b/methods/decision_tree/src/pg_gp/utility.sql_in
@@ -785,11 +785,26 @@ BEGIN
     str_val = btrim(split_part(full_name, '.', 2), ' ');
 
     IF( str_val is null or str_val = '' ) THEN
+        -- If user does not explicitly specify schema name,
+        -- tentatively set the schema name to public
         ret_val = 'public';
+
+        -- If there is no table belonging to public,
+        -- set the schema name to temporary schema.
+        IF (
+             NOT MADLIB_SCHEMA.__table_exists
+                (
+                    ret_val,
+                    MADLIB_SCHEMA.__strip_schema_name(full_name)
+                )
+           )  THEN
+           SELECT nspname FROM pg_catalog.pg_namespace 
+                WHERE oid=pg_my_temp_schema() INTO ret_val;
+        END IF;
     ELSE
         ret_val = btrim(split_part(full_name, '.', 1), ' ');
     END IF;
-    RETURN ret_val;
+    RETURN lower(ret_val);
 end
 $$ LANGUAGE PLPGSQL;
 

--- a/methods/decision_tree/src/pg_gp/utility.sql_in
+++ b/methods/decision_tree/src/pg_gp/utility.sql_in
@@ -305,54 +305,9 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__table_exists
     (
     full_table_name    TEXT
     ) 
-RETURNS BOOLEAN AS $$
-DECLARE
-    --toid              OID;
-    table_name          TEXT;
-    temp                TEXT[];
-    len                 INT;
-    schema_names        TEXT[];
-    temp_schema         TEXT;
-BEGIN
-    IF (full_table_name IS NULL) THEN
-        RETURN 'f';
-    END IF;
-
-    temp = string_to_array(full_table_name, '.');
-    len = array_upper(temp, 1);
-    
-    IF (1 = len) THEN
-        -- get all schema names from search_path except the implicit schema 
-        schema_names = current_schemas('f');
-
-        -- add this session's temp schema to search path too
-        EXECUTE 'SELECT nspname FROM pg_catalog.pg_namespace 
-                 WHERE oid = pg_my_temp_schema() LIMIT 1'
-            INTO temp_schema;
-        schema_names[array_upper(schema_names, 1) + 1] = temp_schema;
-        
-        table_name = temp[1];
-    ELSE
-        PERFORM MADLIB_SCHEMA.__assert
-            (
-                len = 2, 
-                'wrong full table name<' || full_table_name || '>'
-            );
-        schema_names[1] = lower(btrim(temp[1]));
-        table_name = lower(btrim(temp[2], ' '));
-    END IF; 
-        
-    SELECT count(c.oid)
-    FROM   pg_catalog.pg_class c
-           LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-    WHERE  c.relname = table_name
-      AND  n.nspname = any(schema_names)
-    INTO   len;
-    
-    RETURN len >= 1;
-END
-$$ LANGUAGE PLPGSQL;
-
+RETURNS BOOLEAN AS 
+'MODULE_PATHNAME', 'table_exists' 
+LANGUAGE C IMMUTABLE;
 
 /*
  * @brief Test if the specified column exists or not


### PR DESCRIPTION
The decision tree algorithm currently do not accept temporary tables as training sets.

This pull request corrected this behavior.
