### PR TITLE
fix madlib-434

### DIFF
--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -3871,6 +3871,9 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.c45_classify
 RETURNS MADLIB_SCHEMA.c45_classify_result AS $$
 DECLARE
     encoded_table_name  TEXT := '';
+    temp_result_table   TEXT := '';
+    metatable_name      TEXT;
+    result_rec          RECORD;
     begin_time          TIMESTAMP;
     ret                 MADLIB_SCHEMA.c45_classify_result;
 BEGIN
@@ -3880,20 +3883,32 @@ BEGIN
     END IF;
     
     begin_time = clock_timestamp();
-    
+    temp_result_table = madlib.__strip_schema_name(result_table_name)||'_temp_result';
     SELECT MADLIB_SCHEMA.__c45_classify_internal
         (
         classification_table_name, 
         tree_table_name, 
-        result_table_name, 
-        'f',
+        temp_result_table, 
+        't',
         verbosity
         )  INTO encoded_table_name;
-    
-    EXECUTE 'ALTER TABLE '||result_table_name||' DROP COLUMN jump;';
-    EXECUTE 'ALTER TABLE '||result_table_name||' DROP COLUMN parent_id;';
-    EXECUTE 'ALTER TABLE '||result_table_name||' DROP COLUMN leaf_id;';
+
+    metatable_name = MADLIB_SCHEMA.__get_metatable_name( tree_table_name );
+    -- we do not store schema name to the table, add it here.
+    metatable_name = 'MADLIB_SCHEMA.'||metatable_name;
+    -- Get the metatable storing the encoding information of class.
+    EXECUTE 'SELECT column_name,table_name FROM '||metatable_name||
+            ' WHERE column_type=''c'' LIMIT 1;'
+            INTO result_rec;
+    result_rec.table_name = 'MADLIB_SCHEMA.'||result_rec.table_name;
+
+   -- translate the encoded class information back
+    EXECUTE 'CREATE TABLE '||result_table_name||' AS SELECT n.id, m.'||result_rec.column_name
+        ||' as class,n.prob from '||temp_result_table||' n,'||result_rec.table_name
+        ||' m where n.class=m.key m4_ifdef(`__GREENPLUM__', `DISTRIBUTED BY (id)');';
+        
     EXECUTE 'DROP TABLE IF EXISTS ' || encoded_table_name || ';';
+    EXECUTE 'DROP TABLE IF EXISTS ' || temp_result_table || ';';
     EXECUTE 'SELECT COUNT(*) FROM ' ||classification_table_name||';' INTO ret.input_set_size;
     
     ret.cost_time = clock_timestamp() - begin_time;

--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -3850,7 +3850,7 @@ $$ LANGUAGE PLPGSQL;
  *
  * @return The columns of classified table:
  * - <tt>id INT</tt> - Record id.
- * - <tt>class INT</tt> - Predicted class.
+ * - <tt>class (The same type as the class column in training set)</tt> - Predicted class.
  * - <tt>prob FLOAT</tt> - Probability of the predicted class.
  */
 DROP FUNCTION IF EXISTS MADLIB_SCHEMA.c45_classify
@@ -3926,7 +3926,7 @@ $$ LANGUAGE PLPGSQL;
  *
  * @return The columns of classified table:
  * - <tt>id INT</tt> - Record id.
- * - <tt>class INT</tt> - Predicted class.
+ * - <tt>class (The same type as the class column in training set)</tt> - Predicted class.
  * - <tt>prob FLOAT</tt> - Probability of the predicted class.
  */
 DROP FUNCTION IF EXISTS MADLIB_SCHEMA.c45_classify

--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -3892,15 +3892,14 @@ BEGIN
         't',
         verbosity
         )  INTO encoded_table_name;
-
+    -- After adding target_schema, we store schema name to the table.
+    -- No need to change it anymore.
     metatable_name = MADLIB_SCHEMA.__get_metatable_name( tree_table_name );
-    -- we do not store schema name to the table, add it here.
-    metatable_name = 'MADLIB_SCHEMA.'||metatable_name;
+
     -- Get the metatable storing the encoding information of class.
     EXECUTE 'SELECT column_name,table_name FROM '||metatable_name||
             ' WHERE column_type=''c'' LIMIT 1;'
             INTO result_rec;
-    result_rec.table_name = 'MADLIB_SCHEMA.'||result_rec.table_name;
 
    -- translate the encoded class information back
     EXECUTE 'CREATE TABLE '||result_table_name||' AS SELECT n.id, m.'||result_rec.column_name

--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -3892,14 +3892,15 @@ BEGIN
         't',
         verbosity
         )  INTO encoded_table_name;
-    -- After adding target_schema, we store schema name to the table.
-    -- No need to change it anymore.
-    metatable_name = MADLIB_SCHEMA.__get_metatable_name( tree_table_name );
 
+    metatable_name = MADLIB_SCHEMA.__get_metatable_name( tree_table_name );
+    -- we do not store schema name to the table, add it here.
+    metatable_name = 'MADLIB_SCHEMA.'||metatable_name;
     -- Get the metatable storing the encoding information of class.
     EXECUTE 'SELECT column_name,table_name FROM '||metatable_name||
             ' WHERE column_type=''c'' LIMIT 1;'
             INTO result_rec;
+    result_rec.table_name = 'MADLIB_SCHEMA.'||result_rec.table_name;
 
    -- translate the encoded class information back
     EXECUTE 'CREATE TABLE '||result_table_name||' AS SELECT n.id, m.'||result_rec.column_name


### PR DESCRIPTION
Currently, the decision tree algorithm returns the result table of {Id, Class, Possibility}. For the column of 'Class', it contains the encoded information.

From the point of end users, the 'Class' column should contain information before encoding.

This pull request fix this issue.
