### PR TITLE
MADLIB-351

### DIFF
--- a/src/madpack/madpack.py
+++ b/src/madpack/madpack.py
@@ -268,14 +268,15 @@ def __get_madlib_dbver(schema):
 ## # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 def __get_dbver():
     try:
-        versionString = __run_sql_query("""SELECT version()""",
+        versionStr = __run_sql_query("""SELECT version()""",
             True)[0]['version']
         if portid == 'postgres':
-            return re.search("PostgreSQL[a-zA-Z\s]*(\d+\.\d+)",
-                versionString).group(1)
+            match = re.search("PostgreSQL[a-zA-Z\s]*(\d+\.\d+)",
+                versionStr)
         elif portid == 'greenplum':
-            return re.search("Greenplum[a-zA-Z\s]*(\d+\.\d+)",
-                versionString).group(1)
+            match = re.search("Greenplum[a-zA-Z\s]*(\d+\.\d+)",
+                versionStr)
+        return None if match is None else match.group(1)
     except:
         __error("Failed reading database version", True)
 
@@ -802,16 +803,26 @@ def main(argv):
         
         # Get DB version
         dbver = __get_dbver()
-        __info("Detected %s version %s." % (ports[portid]['name'], dbver), True)
         portdir = os.path.join(maddir, "ports", portid)
-        if not os.path.isdir(os.path.join(portdir, dbver)):
-            __error("This version is not among the %s versions for which "
-                "MADlib support files have been installed (%s)." % 
-                (ports[portid]['name'],
-                ", ".join([name for name in os.listdir(portdir)
-                                if os.path.isdir(os.path.join(portdir, name))
-                                and re.match("^\d+\.\d+", name)])
+        supportedVersions = [dirItem for dirItem in os.listdir(portdir)
+                                if os.path.isdir(os.path.join(portdir, dirItem))
+                                and re.match("^\d+\.\d+", dirItem)]
+        if dbver is None:
+            dbver = ".".join(map(str, max([map(int, versionStr.split('.'))
+                    for versionStr in supportedVersions])))
+            __info("Could not parse version string reported by {DBMS}. Will "
+                "default to newest supported version of {DBMS} "
+                "({version}).".format(
+                    DBMS = ports[portid]['name'],
+                    version = dbver
                 ), True)
+        else:
+            __info("Detected %s version %s." % (ports[portid]['name'], dbver),
+                True)
+            if not os.path.isdir(os.path.join(portdir, dbver)):
+                __error("This version is not among the %s versions for which "
+                    "MADlib support files have been installed (%s)." % 
+                    (ports[portid]['name'], ", ".join(supportedVersions)), True)
         
         # Validate that db platform is correct 
         if __check_db_port(portid) == False:

--- a/src/ports/greenplum/5.0/CMakeLists.txt
+++ b/src/ports/greenplum/5.0/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_current_greenplum_version()

--- a/src/ports/greenplum/cmake/FindGreenplum.cmake
+++ b/src/ports/greenplum/cmake/FindGreenplum.cmake
@@ -5,6 +5,7 @@ endif(NOT DEFINED _FIND_PACKAGE_FILE)
 
 # Set parameters for calling FindPostgreSQL.cmake
 set(_NEEDED_PG_CONFIG_PACKAGE_NAME "Greenplum Database")
+set(_PG_CONFIG_VERSION_NUM_MACRO "GP_VERSION_NUM")
 set(_PG_CONFIG_VERSION_MACRO "GP_VERSION")
 set(_SEARCH_PATH_HINTS
     "/usr/local/greenplum-db/bin"

--- a/src/ports/greenplum/cmake/FindGreenplum_5_0.cmake
+++ b/src/ports/greenplum/cmake/FindGreenplum_5_0.cmake
@@ -1,0 +1,2 @@
+set(_FIND_PACKAGE_FILE "${CMAKE_CURRENT_LIST_FILE}")
+include("${CMAKE_CURRENT_LIST_DIR}/FindGreenplum.cmake")


### PR DESCRIPTION
Build system:
- Now uses {PG|GP}_VERSION_NUM instead of {PG|GP}_VERSION if available. (Main benefit: Now builds fine against development builds of Greenplum. Unfortunately, GP_VERSION does not contain the major build version but only "main build dev" by default.)

Madpack:
- When DBMS version cannot be determined because of a parsing error, default to the newest supported version of this DBMS. (Main benefit: Now installs fine on development build of Greenplum. Unfortunately "SELECT version()" does not return a major version number of development builds by default.)
