### PR TITLE
Support EXTENSION in PG 9.1+.

### DIFF
--- a/src/ports/postgres/CMakeLists.txt
+++ b/src/ports/postgres/CMakeLists.txt
@@ -195,6 +195,10 @@ function(add_${PORT_LC}_library IN_PORT_VERSION)
         "${CMAKE_CURRENT_BINARY_DIR}/madpack/SQLCommon.m4"
         @ONLY
     )
+    configure_file("${PORT_SOURCE_DIR}/madpack/madlib.control_in"
+        "${CMAKE_CURRENT_BINARY_DIR}/madpack/madlib.control"
+        @ONLY
+    )
     
     add_custom_target(pythonFiles_${DBMS} ALL
         DEPENDS ${PYTHON_TARGET_FILES})
@@ -213,6 +217,10 @@ function(add_${PORT_LC}_library IN_PORT_VERSION)
         REGEX "^(.*/)?\\.DS_Store\$" EXCLUDE
     )
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/madpack/SQLCommon.m4"
+        DESTINATION ports/${PORT_DIR_NAME}/${IN_PORT_VERSION}/madpack
+        COMPONENT ${DBMS}
+    )
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/madpack/madlib.control"
         DESTINATION ports/${PORT_DIR_NAME}/${IN_PORT_VERSION}/madpack
         COMPONENT ${DBMS}
     )

--- a/src/ports/postgres/madpack/madlib.control_in
+++ b/src/ports/postgres/madpack/madlib.control_in
@@ -1,0 +1,3 @@
+default_version = '@MADLIB_VERSION_STRING@'
+comment = 'A scalable in-database analytics library'
+relocatable = false


### PR DESCRIPTION
In madpack, if the target platform supports extension, it switches
to create extension files instead of installing with the old way.
EXTENSION in postgres requires two files in its install directory
under $SHAREDIR/extension, and madpack has been avoiding interaction
with platform's directory.  It is still arguable to switch the
install process automatically, maybe leaving this choice another
command is the better answer.

madlib.control_in is put in madpack directory, per some design
discussion with Florian.  Also this includes a small change in
madpack to show python stack trace on database object creation
error when -v option is specified, which is handy for the diagnosis
of the script problem.

MADLIB-316
