### PR TITLE
Add schema qualifiers to commutator/negator in svec.

### DIFF
--- a/methods/svec/src/pg_gp/svec.sql_in
+++ b/methods/svec/src/pg_gp/svec.sql_in
@@ -777,8 +777,8 @@ CREATE OPERATOR MADLIB_SCHEMA.= (
 	leftarg = float8[], 
 	rightarg = float8[], 
 	procedure = MADLIB_SCHEMA.float8arr_eq,
-	commutator = = ,
---	negator = <> ,
+	commutator = operator(MADLIB_SCHEMA.=) ,
+--	negator = operator(MADLIB_SCHEMA.<>) ,
 	restrict = eqsel, join = eqjoinsel
 );
 */
@@ -904,8 +904,8 @@ CREATE CAST (float8[] AS MADLIB_SCHEMA.svec) WITH FUNCTION MADLIB_SCHEMA.svec_ca
 
 CREATE OPERATOR MADLIB_SCHEMA.= (
 	leftarg = MADLIB_SCHEMA.svec, rightarg = MADLIB_SCHEMA.svec, procedure = MADLIB_SCHEMA.svec_eq,
-	commutator = = ,
---	negator = <> ,
+	commutator = operator(MADLIB_SCHEMA.=) ,
+--	negator = operator(MADLIB_SCHEMA.<>) ,
 	restrict = eqsel, join = eqjoinsel
 );
 
@@ -1023,34 +1023,34 @@ DROP OPERATOR IF EXISTS *|| (int4, MADLIB_SCHEMA.svec) ;
 
 CREATE OPERATOR MADLIB_SCHEMA.< (
 	leftarg = MADLIB_SCHEMA.svec, rightarg = MADLIB_SCHEMA.svec, procedure = MADLIB_SCHEMA.svec_l2_lt,
-	commutator = > , negator = >= ,
+	commutator = operator(MADLIB_SCHEMA.>) , negator = operator(MADLIB_SCHEMA.>=) ,
 	restrict = scalarltsel, join = scalarltjoinsel
 );
 CREATE OPERATOR MADLIB_SCHEMA.<= (
 	leftarg = MADLIB_SCHEMA.svec, rightarg = MADLIB_SCHEMA.svec, procedure = MADLIB_SCHEMA.svec_l2_le,
-	commutator = >= , negator = > ,
+	commutator = operator(MADLIB_SCHEMA.>=) , negator = operator(MADLIB_SCHEMA.>) ,
 	restrict = scalarltsel, join = scalarltjoinsel
 );
 CREATE OPERATOR MADLIB_SCHEMA.<> (
 	leftarg = MADLIB_SCHEMA.svec, rightarg = MADLIB_SCHEMA.svec, procedure = MADLIB_SCHEMA.svec_l2_eq,
-	commutator = <> ,
-	negator = =,
+	commutator = operator(MADLIB_SCHEMA.<>) ,
+	negator = operator(MADLIB_SCHEMA.=),
 	restrict = eqsel, join = eqjoinsel
 );
 CREATE OPERATOR MADLIB_SCHEMA.== (
 	leftarg = MADLIB_SCHEMA.svec, rightarg = MADLIB_SCHEMA.svec, procedure = MADLIB_SCHEMA.svec_l2_eq,
-	commutator = = ,
-	negator = <> ,
+	commutator = operator(MADLIB_SCHEMA.=) ,
+	negator = operator(MADLIB_SCHEMA.<>) ,
 	restrict = eqsel, join = eqjoinsel
 );
 CREATE OPERATOR MADLIB_SCHEMA.>= (
 	leftarg = MADLIB_SCHEMA.svec, rightarg = MADLIB_SCHEMA.svec, procedure = MADLIB_SCHEMA.svec_l2_ge,
-	commutator = <= , negator = < ,
+	commutator = operator(MADLIB_SCHEMA.<=) , negator = operator(MADLIB_SCHEMA.<) ,
 	restrict = scalargtsel, join = scalargtjoinsel
 );
 CREATE OPERATOR MADLIB_SCHEMA.> (
 	leftarg = MADLIB_SCHEMA.svec, rightarg = MADLIB_SCHEMA.svec, procedure = MADLIB_SCHEMA.svec_l2_gt,
-	commutator = < , negator = <= ,
+	commutator = operator(MADLIB_SCHEMA.<) , negator = operator(MADLIB_SCHEMA.<=) ,
 	restrict = scalargtsel, join = scalargtjoinsel
 );
 


### PR DESCRIPTION
Without specifying them, PG creates empty operator in public schema, which is not what we expect.

MADLIB-470
