### PR TITLE
Fixes for madlib-382

### DIFF
--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -3437,7 +3437,7 @@ BEGIN
                 (
                     'SELECT id
                      FROM %
-                     WHERE parent_id = % AND tid=%
+                     WHERE parent_id = % 
                      ORDER BY id',
                     ARRAY[
                         tree_table,

--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -3447,7 +3447,7 @@ BEGIN
 
     FOR child_nid IN EXECUTE curstmt LOOP
         ret = ret || MADLIB_SCHEMA.__display_tree_no_ordered_aggr
-			(
+						(
                         	tree_table,
                         	child_nid,
                         	feature,

--- a/methods/decision_tree/src/pg_gp/decision_tree.sql_in
+++ b/methods/decision_tree/src/pg_gp/decision_tree.sql_in
@@ -3441,22 +3441,22 @@ BEGIN
                      ORDER BY id',
                     ARRAY[
                         tree_table,
-                        MADLIB_SCHEMA.__to_char(id),
-                        MADLIB_SCHEMA.__to_char(tree_id)
+                        MADLIB_SCHEMA.__to_char(id)
                         ]
                 );
 
     FOR child_nid IN EXECUTE curstmt LOOP
-        ret = ret || MADLIB_SCHEMA.__display_tree_no_ordered_aggr(
-                        tree_table,
-                        child_nid,
-                        feature,
-                        depth + 1,
-                        is_feature_cont,
-                        temp_split_value,
-                        metatable_name,
-                        max_depth,
-                        tree_id);
+        ret = ret || MADLIB_SCHEMA.__display_tree_no_ordered_aggr
+			(
+                        	tree_table,
+                        	child_nid,
+                        	feature,
+                        	depth + 1,
+                        	is_feature_cont,
+                        	temp_split_value,
+                        	metatable_name,
+                        	max_depth
+                        );
     END LOOP;
 
     RETURN ret;


### PR DESCRIPTION
In current version, there is no tree ID in the result tree table. Therefore, remove the related code. Now, it can run successfully in Postgres8.4 and series version. Thanks.
