### PR TITLE
Feature Extraction: - Improvement per review and test.

### DIFF
--- a/methods/textfex_viterbi/src/pg_gp/test/textfex_viterbi.sql_in
+++ b/methods/textfex_viterbi/src/pg_gp/test/textfex_viterbi.sql_in
@@ -123,50 +123,57 @@ BEGIN
 	(28,2,'.',28),        (0,3,'his',4),       (1,3,'actions',4),   (2,3,'prevent',4),    (3,3,'disaster',4), 
         (4,3,'.',4);
 	analyze textfex_segmenttbl;
-           
-        -- m&r factor table
-        CREATE TABLE viterbi_mtbl (score integer[][]);
-        CREATE TABLE viterbi_rtbl (seg_text text, label integer, score integer);
 
-        CREATE TABLE prev_textfex_label(id int);
-        -- Insert unique tokens into the segment_hashtbl
-        CREATE TABLE textfex_segment_hashtbl(seg_text text);
-        -- create a temp partial dictionary table which stores the words whose occurance
-        -- is below certain threshold, refer to the CRF Package
-        CREATE TABLE textfex_unknown_segment_hashtbl(seg_text text);
-          
-        -- Generate a sparse matrix to store the r factors
-        CREATE TABLE textfex_rtbl (seg_text text NOT NULL, label integer, value double precision);
-          
-        -- Generate M factor table
-        CREATE TABLE textfex_mtbl(prev_label integer, label integer, value double precision);
-
-        -- extract features for tokens stored in segmenttbl 
+	-- extract features for tokens stored in segmenttbl 
 	PERFORM MADLIB_SCHEMA.text_feature_extraction('textfex_segmenttbl','textfex_dictionary','textfex_label','textfex_regex','textfex_feature','viterbi_mtbl','viterbi_rtbl');
 
         -- Expected viterbi labeling result
         CREATE TABLE expected_extraction(doc_id integer, start_pos integer, seg_text text, label character varying);
         INSERT INTO expected_extraction VALUES
-	(1,0,'chancellor','NNP'),(1,1,'of','IN'),         (1,2,'the','DT'),        (1,3,'exchequer','NNP'), (1,4,'nigel','NNP'),     
-	(1,5,'lawson','NNP'),    (1,6,'''s','POS'),       (1,7,'restated','VBN'),  (1,8,'commitment','NN'), (1,9,'to','TO'),         
-	(1,10,'a','DT'),         (1,11,'firm','NN'),      (1,12,'monetary','JJ'),  (1,13,'policy','NN'),    (1,14,'has','VBZ'),      
-	(1,15,'helped','VBN'),   (1,16,'to','TO'),        (1,17,'prevent','VB'),   (1,18,'a','DT'),         (1,19,'freefall','NN'),  
-	(1,20,'in','IN'),        (1,21,'sterling','NN'),  (1,22,'over','IN'),      (1,23,'the','DT'),       (1,24,'past','JJ'),      
-	(1,25,'week','NN'),      (1,26,'.','.'),          (2,0,'but','CC'),        (2,1,'analysts','NNS'),  (2,2,'reckon','VBP'),    
-	(2,3,'underlying','VBG'),(2,4,'support','NN'),    (2,5,'for','IN'),        (2,6,'sterling','NN'),   (2,7,'has','VBZ'),       
+	(1,0,'chancellor','NNP'),(1,1,'of','IN'),         (1,2,'the','DT'),        (1,3,'exchequer','NNP'), (1,4,'nigel','NNP'),
+	(1,5,'lawson','NNP'),    (1,6,'''s','POS'),       (1,7,'restated','VBN'),  (1,8,'commitment','NN'), (1,9,'to','TO'),
+	(1,10,'a','DT'),         (1,11,'firm','NN'),      (1,12,'monetary','JJ'),  (1,13,'policy','NN'),    (1,14,'has','VBZ'),
+	(1,15,'helped','VBN'),   (1,16,'to','TO'),        (1,17,'prevent','VB'),   (1,18,'a','DT'),         (1,19,'freefall','NN'),
+	(1,20,'in','IN'),        (1,21,'sterling','NN'),  (1,22,'over','IN'),      (1,23,'the','DT'),       (1,24,'past','JJ'),
+	(1,25,'week','NN'),      (1,26,'.','.'),          (2,0,'but','CC'),        (2,1,'analysts','NNS'),  (2,2,'reckon','VBP'),
+	(2,3,'underlying','VBG'),(2,4,'support','NN'),    (2,5,'for','IN'),        (2,6,'sterling','NN'),   (2,7,'has','VBZ'),
 	(2,8,'been','VBN'),      (2,9,'eroded','VBN'),    (2,10,'by','IN'),        (2,11,'the','DT'),       (2,12,'chancellor','NN'),
-	(2,13,'''s','POS'),      (2,14,'failure','NN'),   (2,15,'to','TO'),        (2,16,'announce','VB'),  (2,17,'any','DT'),       
-	(2,18,'new','JJ'),       (2,19,'policy','NN'),    (2,20,'measures','NNS'), (2,21,'in','IN'),        (2,22,'his','PRP$'),     
-	(2,23,'mansion','NNP'),  (2,24,'house','NNP'),    (2,25,'speech','NN'),    (2,26,'last','JJ'),      (2,27,'thursday','NNP'), 
+	(2,13,'''s','POS'),      (2,14,'failure','NN'),   (2,15,'to','TO'),        (2,16,'announce','VB'),  (2,17,'any','DT'),
+	(2,18,'new','JJ'),       (2,19,'policy','NN'),    (2,20,'measures','NNS'), (2,21,'in','IN'),        (2,22,'his','PRP$'),
+	(2,23,'mansion','NNP'),  (2,24,'house','NNP'),    (2,25,'speech','NN'),    (2,26,'last','JJ'),      (2,27,'thursday','NNP'),
 	(2,28,'.','.'),          (3,0,'his','NNP'),       (3,1,'actions','NNP'),   (3,2,'prevent','NNP'),   (3,3,'disaster','NNP'),
-        (3,4,'.','.');   
- 
-        PERFORM MADLIB_SCHEMA.vcrf_label('textfex_segmenttbl', 'viterbi_mtbl', 'viterbi_rtbl', 'textfex_label', 'extraction', 'madlib_installcheck_textfex_viterbi');
+	(3,4,'.','.');
 
-        -- do a comparison between the expected result and the viterbi extraction result. It succeed only if the two tables are the same.
-	SELECT COUNT(*) INTO result_count FROM ((SELECT doc_id, start_pos, seg_text, label FROM expected_extraction) EXCEPT (SELECT doc_id, start_pos, seg_text, label FROM extraction)) AS U;
-        SELECT INTO result CASE WHEN (result_count = 0) THEN 'PASS' ELSE 'FAIL' END;
-          
+	PERFORM MADLIB_SCHEMA.vcrf_label(
+		'textfex_segmenttbl',
+		'viterbi_mtbl',
+		'viterbi_rtbl',
+		'textfex_label',
+		'extraction');
+
+	-- Compare the expected result and the viterbi extraction result.  It succeeds
+	-- only if the two tables are the same.
+	SELECT s1.count + s2.count INTO result_count
+	FROM (
+		SELECT count(*) FROM(
+			SELECT doc_id, start_pos, seg_text, label
+			FROM expected_extraction
+			EXCEPT ALL
+			SELECT doc_id, start_pos, seg_text, label
+			FROM extraction
+		) AS U
+	)s1,
+	(
+		SELECT count(*) FROM(
+			SELECT doc_id, start_pos, seg_text, label
+			FROM extraction
+			EXCEPT ALL
+			SELECT doc_id, start_pos, seg_text, label
+			FROM expected_extraction
+		) AS U
+	)s2;
+	SELECT INTO result CASE WHEN (result_count = 0) THEN 'PASS' ELSE 'FAIL' END;
+
 	IF result = 'FAIL' THEN
 	   RAISE EXCEPTION 'Failed install check %', result_count;
 	END IF;

--- a/methods/textfex_viterbi/src/pg_gp/textfex.sql_in
+++ b/methods/textfex_viterbi/src/pg_gp/textfex.sql_in
@@ -14,27 +14,37 @@ m4_include(`SQLCommon.m4')
 /**
 @addtogroup grp_textfex_viterbi
 
-@about 
-This module provides the functionality of feature extraction for basic text analysis tasks such as
-part-of-speech(POS) tagging, named entity resolution. In addition to feature extraction, it also 
-have a Viterbi implementation to get the best label sequence and the conditional probability 
+@about
+This module provides a functionality of the feature extraction for basic text
+analysis tasks such as part-of-speech(POS) tagging, named entity resolution.
+In addition to the feature extraction, it also has a Viterbi implementation
+to get the best label sequence and the conditional probability
 \f$ p(top1_label_sequence|sentence) \f$.
-At present, six feature types are implemented
-    - Edge Feature: transition feature that encodes the transition feature weight from current label to next label.
+
+At present, six feature types are implemented.
+    - Edge Feature: transition feature that encodes the transition feature
+      weight from current label to next label.
     - Start Feature: fired when the current token is the first token in a sentence.
     - End Feature: fired when the current token is the last token in a sentence.
-    - Word Feature: fired when the current token is observed in the trained dictionary. 
-    - Unknown Feature: fired when the current token is not observed in the trained dictionary for at least certain times.
-    - Regex Feature: fired when the current token can be matched by the regular expression.
-you can add your own feature type according to the training model
+    - Word Feature: fired when the current token is observed in the trained
+      dictionary.
+    - Unknown Feature: fired when the current token is not observed in the trained
+      dictionary for at least certain times.
+    - Regex Feature: fired when the current token can be matched by the regular
+      expression.
 
-Instead of scanning every tokens in a sentence and extract features for each token on fly, 
- we extract features for each distinct token and materialize it in the table.
- When we call viterbi function to get the best label sequence, we only need to a single lookup to get the feature weight.
+You can add your own feature type according to the training model.
 
-@usage 
-  - Use CRF PACKAGE [1] to generate the trained models. Basically CRF PACKAGE generates two model files 'feature' and 'crf'.
-    Write some simple scripts to convert the data in the model files to the data format required by in this module.
+Instead of scanning every token in a sentence and extracting features for
+each token on the fly, we extract features for each distinct token and
+materialize it in the table.  When we call viterbi function to get the best
+label sequence, we only need a single lookup to get the feature weight.
+
+@usage
+  - Use CRF PACKAGE [1] to generate the trained models. Basically CRF PACKAGE
+    generates two model files 'feature' and 'crf'.  Write some simple scripts
+    to convert the data in the model files to the data format required by in
+    this module.
 
   - Load model from local drive to database 
     <pre>SELECT madlib.load_crf_model(
@@ -50,19 +60,19 @@ Instead of scanning every tokens in a sentence and extract features for each tok
          '<em>viterbi_mtbl</em>',
          '<em>viterbi_rtbl</em>');</pre>
 
-  - Run Viterbi function to get the best label sequence and the conditional probability \f$ p(top1_label_sequence|sentence) \f$.
+  - Run the Viterbi function to get the best label sequence and the conditional
+    probability \f$ p(top1_label_sequence|sentence) \f$.
     <pre>SELECT madlib.vcrf_label(
          '<em>segmenttbl</em>',
          '<em>viterbi_mtbl</em>',
          '<em>viterbi_rtbl</em>',
          '<em>labeltbl</em>',
-         '<em>resulttbl</em>',
-         '<em>schemaname</em>');</pre>
+         '<em>resulttbl</em>');</pre>
 
 @literature
 
 [1] http://crf.sourceforge.net/
- 
+
 [2] http://www.cs.berkeley.edu/~daisyw/ViterbiCRF.html
 
 [3] http://en.wikipedia.org/wiki/Viterbi_algorithm
@@ -71,18 +81,27 @@ Instead of scanning every tokens in a sentence and extract features for each tok
 */
 
 /**
- * @brief This function extracts text feature.
- * This feature extraction function will produce two factor tables, m table and r table. 
- * The viterbi_m table and viterbi_r table are used to calculate the best label sequence for each sentence.
- * - viterbi_mtbl table
- * encodes the edge features which are solely dependent on upon current label and previous y value.
- * m table has three columns which are prev_label, label, value respectively.
- * if the number of labels in \f$ n \f$, then the m factors table will \f$ n^2 \f$ rows. Each row encodes the transition feature weight 
- * value from previous label to current label.
- * startFeature is can be considered as a special edge feature which is from the very first to the first token
- * endFeature can be considered as a special edge feature which is from the last token to the very end.
- * so m table encodes the edgeFeature, startFeature, endFeature.
- * if the total number of labels in the label space are 45 from 0 to 44. then the m factors array is as follows:
+ * @brief This function extracts text features.
+ *
+ * This feature extraction function will produce two factor tables, "m table"
+ * (\a viterbi_mtbl) and "r table" (\a viterbi_rtbl).  The \a viterbi_mtbl
+ * table and \a viterbi_rtbl table are used to calculate the best label
+ * sequence for each sentence.
+ *
+ * - <em>viterbi_mtbl</em> table
+ * encodes the edge features which are solely dependent on upon current label and
+ * previous y value. The m table has three columns which are prev_label, label,
+ * and value respectively.
+ * If the number of labels in \f$ n \f$, then the m factor table will \f$ n^2 \f$
+ * rows.  Each row encodes the transition feature weight value from the previous label
+ * to the current label.
+ *
+ * \a startFeature is considered as a special edge feature which is from the
+ * beginning to the first token.  Likewise, \a endFeature can be considered
+ * as a special edge feature which is from the last token to the very end.
+ * So m table encodes the edgeFeature, startFeature, and endFeature.
+ * If the total number of labels in the label space is 45 from 0 to 44,
+ * then the m factor array is as follows:
  * <pre>
  *                  0  1  2  3  4  5...44
  * startFeature -1  a  a  a  a  a  a...a
@@ -93,8 +112,9 @@ Instead of scanning every tokens in a sentence and extract features for each tok
  * endFeature   45  a  a  a  a  a  a...a</pre>
  * 
  * - viterbi_r table
- * is related to specific tokens. It encodes the single state features, e.g., wordFeature, RegexFeature
- * for all tokens. The r table is represented in the following way.
+ * is related to specific tokens.  It encodes the single state features,
+ * e.g., wordFeature, RegexFeature for all tokens.  The r table is represented
+ * in the following way.
  * <pre>
  *        0  1  2  3  4...44
  * token1 a  a  a  a  a...a
@@ -109,12 +129,39 @@ Instead of scanning every tokens in a sentence and extract features for each tok
  *
  */
 
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.text_feature_extraction(segmenttbl text, dictionary  text, labeltbl text, regextbl text, featuretbl text,
-                                                                   viterbi_mtbl text, viterbi_rtbl text) RETURNS void AS 
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.text_feature_extraction(
+        segmenttbl text,
+        dictionary  text,
+        labeltbl text,
+        regextbl text,
+        featuretbl text,
+        viterbi_mtbl text,
+        viterbi_rtbl text) RETURNS void AS
 $$
+        # Clear m&r tables
+        plpy.execute("""
+            DROP TABLE IF EXISTS {viterbi_mtbl}, {viterbi_rtbl};
+            """.format(
+                viterbi_mtbl = viterbi_mtbl,
+                viterbi_rtbl = viterbi_rtbl
+            ))
+        # Create m&r factor table
+        plpy.execute("""
+            CREATE TABLE {viterbi_mtbl} (score integer[][]);
+            """.format(viterbi_mtbl = viterbi_mtbl));
+        plpy.execute("""
+            CREATE TABLE {viterbi_rtbl}
+            (seg_text text, label integer, score integer);
+            """.format(viterbi_rtbl = viterbi_rtbl))
+        # Create index for performance
+        plpy.execute("""
+            CREATE INDEX {viterbi_rtbl}_idx ON {viterbi_rtbl} (seg_text)
+            """.format(viterbi_rtbl = viterbi_rtbl))
+
         plpy.execute("TRUNCATE TABLE " + viterbi_mtbl + ", " + viterbi_rtbl + ";")
 
         plpy.execute("DROP TABLE IF EXISTS prev_labeltbl, segment_hashtbl, unknown_segment_hashtbl, rtbl, mtbl;")
+        plpy.execute("DROP TABLE IF EXISTS prev_labeltbl, segment_hashtbl, unknown_segment_hashtbl, rtbl, mtbl CASCADE;")
 
         plpy.execute("CREATE TEMP TABLE prev_labeltbl(id int);")
 
@@ -172,14 +219,16 @@ $$
                         WHERE  features.name = 'End.';""")
 
 m4_ifdef(`__HAS_ORDERED_AGGREGATES_', `
-        plpy.execute("""INSERT INTO viterbi_mtbl
+        plpy.execute("""INSERT INTO {viterbi_mtbl}
                         SELECT array_agg(weight ORDER BY prev_label,label) 
                         FROM   (SELECT prev_label, label, (SUM(value)*1000)::integer AS weight 
                                 FROM   mtbl
                                 GROUP BY prev_label,label
-                                ORDER BY prev_label,label) as TEMP_MTBL;""")
+                                ORDER BY prev_label,label) as TEMP_MTBL;""".format(
+                                    viterbi_mtbl = viterbi_mtbl
+                                ))
 ', `
-        plpy.execute("""INSERT INTO viterbi_mtbl
+        plpy.execute("""INSERT INTO {viterbi_mtbl}
                         SELECT ARRAY(
                             SELECT
                                 (SUM(value) * 1000)::integer
@@ -189,7 +238,9 @@ m4_ifdef(`__HAS_ORDERED_AGGREGATES_', `
                                 prev_label, label
                             ORDER BY
                                 prev_label, label
-                        );""")
+                        );""".format(
+                            viterbi_mtbl = viterbi_mtbl
+                        ))
 ')
 
         plpy.execute("""INSERT INTO rtbl(seg_text, label, value) 

--- a/methods/textfex_viterbi/src/pg_gp/viterbi.sql_in
+++ b/methods/textfex_viterbi/src/pg_gp/viterbi.sql_in
@@ -49,24 +49,17 @@ returns int[] as 'MODULE_PATHNAME' language c strict;
  * @param factor_rtbl Name of table containing all the r factors.
  * @param labeltbl Name of table containing all the labels in the label space.
  * @param resulttbl Name of table to store the output
- * @param schemaname The schema name of the output tables
  * @returns the top1 label sequence, the last two elements in the array is used to calculate the top1 probability 
  */
 
 CREATE OR REPLACE FUNCTION
-MADLIB_SCHEMA.vcrf_label(segtbl text, factor_mtbl text, factor_rtbl text, labeltbl text, resulttbl text, schemaname text)   RETURNS text AS
+MADLIB_SCHEMA.vcrf_label(segtbl text, factor_mtbl text, factor_rtbl text, labeltbl text, resulttbl text)   RETURNS text AS
   $$
-  m_factors = schemaname + "._m_factors"
-  r_factors = schemaname + "._r_factors"
+  m_factors = "_m_factors"
+  r_factors = "_r_factors"
   resulttbl_raw = resulttbl + "_raw"
 
-  plpy.execute("DROP TABLE IF EXISTS " + m_factors +","+ r_factors + "," + resulttbl_raw +";")
-  plpy.execute("CREATE INDEX rfactor_idx ON " + factor_rtbl + "(seg_text);")
-
-  retval = {}
-  retval["m_factors"] = m_factors
-  retval["r_factors"] = r_factors
-  retval["result_table"] = resulttbl
+  plpy.execute("DROP TABLE IF EXISTS " + m_factors +","+ r_factors + "," + resulttbl_raw +" CASCADE;")
 
   query = """
   -- for each sentence, store array representation of r_factors
@@ -114,5 +107,5 @@ m4_ifdef(`__HAS_ORDERED_AGGREGATES_', `
 
   query = "SELECT * FROM MADLIB_SCHEMA.vcrf_top1_view(\'" + segtbl + "\', \'" + labeltbl + "\', \'" + resulttbl_raw + "\', \'" + resulttbl + "\');"
   plpy.execute(query);
-   
+
 $$ LANGUAGE plpythonu STRICT;


### PR DESCRIPTION
This rearranges assorted code that was making it inconvenient from user
perspective.  viterbi_mtbl and viterbi_rtbl are now created inside
text_feature_extraction() and index is created at the same time.
viterbi_mtbl was hard-coded in text_feature_extraction(), and now
it accepts argument.  vcrf_label() took an argument for a schema name
but it didn't use it in a good way, so now the argument is deprecated.
Also some tables in the install_test() that seemed to not be used are
removed entirely from the source.
