### PR TITLE
Conditionally apply the patch for GP4.1.

### DIFF
--- a/src/ports/greenplum/4.1/patch/Versions_4_1_0_to_4_1_1.sh.in
+++ b/src/ports/greenplum/4.1/patch/Versions_4_1_0_to_4_1_1.sh.in
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-mkdir -p server/utils
+"@CMAKE_COMMAND@" -E make_directory server/utils
+
 sed 's/^struct SyncBitvectorContainer_s$/typedef struct SyncBitvectorContainer_s/g' \
     "@GREENPLUM_4_1_SERVER_INCLUDE_DIR@/utils/syncbitvector.h" > \
     server/utils/syncbitvector.h

--- a/src/ports/greenplum/4.1/patch/Versions_4_1_0_to_4_1_1.sh.in
+++ b/src/ports/greenplum/4.1/patch/Versions_4_1_0_to_4_1_1.sh.in
@@ -1,25 +1,6 @@
 #!/bin/sh
 
-"@CMAKE_COMMAND@" -E copy "@GREENPLUM_4_1_SERVER_INCLUDE_DIR@/utils/syncbitvector.h" \
+mkdir -p server/utils
+sed 's/^struct SyncBitvectorContainer_s$/typedef struct SyncBitvectorContainer_s/g' \
+    "@GREENPLUM_4_1_SERVER_INCLUDE_DIR@/utils/syncbitvector.h" > \
     server/utils/syncbitvector.h
-
-# The later version has fixed this issue.
-FIXED=`perl -ne 'print "FIXED"
-	if /^typedef struct SyncBitvectorContainer_s$/' < server/utils/syncbitvector.h`
-
-if [ "$FIXED" != "FIXED" ]
-then
-	patch -p0 <<'EOF'
---- server/utils/syncbitvector.old.h	2010-11-18 15:07:30.000000000 -0800
-+++ server/utils/syncbitvector.h	2011-04-20 23:29:41.000000000 -0700
-@@ -16,7 +16,7 @@
- #define SYNC_BITVECTOR_MAX_COUNT 	(100)								/* max total size = 100 MB */
- 
- /* bit vector container */
--struct SyncBitvectorContainer_s
-+typedef struct SyncBitvectorContainer_s
- {
- 	int64 vectorCount;		// number of vectors stored
- 
-EOF
-fi

--- a/src/ports/greenplum/4.1/patch/Versions_4_1_0_to_4_1_1.sh.in
+++ b/src/ports/greenplum/4.1/patch/Versions_4_1_0_to_4_1_1.sh.in
@@ -3,7 +3,13 @@
 "@CMAKE_COMMAND@" -E copy "@GREENPLUM_4_1_SERVER_INCLUDE_DIR@/utils/syncbitvector.h" \
     server/utils/syncbitvector.h
 
-patch -p0 <<'EOF'
+# The later version has fixed this issue.
+FIXED=`perl -ne 'print "FIXED"
+	if /^typedef struct SyncBitvectorContainer_s$/' < server/utils/syncbitvector.h`
+
+if [ "$FIXED" != "FIXED" ]
+then
+	patch -p0 <<'EOF'
 --- server/utils/syncbitvector.old.h	2010-11-18 15:07:30.000000000 -0800
 +++ server/utils/syncbitvector.h	2011-04-20 23:29:41.000000000 -0700
 @@ -16,7 +16,7 @@
@@ -16,3 +22,4 @@ patch -p0 <<'EOF'
  	int64 vectorCount;		// number of vectors stored
  
 EOF
+fi


### PR DESCRIPTION
It seems the current build system is able to apply the patch by
checking patch version, but in GPDB development environment,
it is not always true; the patch version is still 0 while the
header file has been fixed.

MADLIB-485
