### PR TITLE
Support CREATE EXTENSION, take two.

### DIFF
--- a/src/madpack/sort-module.py
+++ b/src/madpack/sort-module.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+
+"""
+sort-module.py
+
+Given number of strings, sort them based on the module name which the
+string contains resolving the dependencies.  Example:
+
+  $ sort-module.py a/regress/b a/svec/b a/array_ops/b
+  > a/svec/b a/regress/b a/array_opts/b
+
+Note this script assumes to be run at the exact current directory,
+so you need change directory first to run it.
+"""
+
+import configyml
+
+
+portspecs = configyml.get_modules("../config")
+
+def find_order(path):
+  for i, moduleinfo in enumerate(portspecs['modules']):
+    modname = moduleinfo['name']
+    if modname in path:
+      return i
+  # return as the last if not found.
+  return len(portspecs['modules'])
+
+def main(args):
+  print " ".join(sorted(args, key = find_order))
+
+if __name__ == '__main__':
+  import sys
+  main(sys.argv[1:])

--- a/src/ports/postgres/9.1/CMakeLists.txt
+++ b/src/ports/postgres/9.1/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_current_postgresql_version()
+add_extension_support()

--- a/src/ports/postgres/CMakeLists.txt
+++ b/src/ports/postgres/CMakeLists.txt
@@ -236,6 +236,99 @@ macro(add_current_${PORT_LC}_version)
     endif(${PORT_UC}_${_VERSION_UNDERSCORES}_FOUND)
 endmacro(add_current_${PORT_LC}_version)
 
+# -- Extension support
+# If the DBMS can support CREATE EXTENSION, call this function
+# after add_current_PORT_version()
+function(add_extension_support)
+    get_filename_component(_VERSION "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
+    string(REPLACE "." "_" PORT_VERSION_UNDERSCORE "${_VERSION}")
+    set(DBMS "${PORT_LC}_${PORT_VERSION_UNDERSCORE}")
+    set(DBMS_UC "${PORT_UC}_${PORT_VERSION_UNDERSCORE}")
+
+    foreach(CURRENT_FILE ${SQL_TARGET_FILES})
+        if(NOT ${CURRENT_FILE} MATCHES "/test/")
+            set(OUTFILE ${CURRENT_FILE})
+            string(REGEX REPLACE ".sql_in\$" ".sql" OUTFILE ${OUTFILE})
+            get_dir_name(OUTDIR ${OUTFILE})
+            get_filename_component(MODULE_NAME ${OUTDIR} NAME)
+
+            # This should match with madpack
+            # We use @extschema@ for its schema and let users
+            # decide the schema name when CREATE EXTENSION.
+            # Also, we install libmadlib.so into $libdir
+            # so madlib.control specifies MODULE_PATHNAME and we don't
+            # do it here.
+            set(M4_ARGS
+                "-P"
+                "-DMADLIB_SCHEMA=@extschema@"
+                "-DPLPYTHON_LIBDIR=${${DBMS_UC}_SHARE_DIR}/madlib/modules"
+                "-DMODULE_NAME=${MODULE_NAME}"
+                "-D${PORT_UC}"
+                "-I${CMAKE_CURRENT_BINARY_DIR}/madpack"
+            )
+            add_custom_command(OUTPUT "${OUTFILE}"
+                COMMAND ${CMAKE_COMMAND} -E make_directory "${OUTDIR}"
+                COMMAND ${M4_BINARY} ${M4_ARGS} "${CURRENT_FILE}" > "${OUTFILE}"
+                DEPENDS sqlFiles_${PORT_LC}
+                COMMENT "Preprocessing ${CURRENT_FILE} with m4."
+            )
+            list(APPEND MODULE_SQL_POST_FILES ${OUTFILE})
+        endif(NOT ${CURRENT_FILE} MATCHES "/test/")
+    endforeach(CURRENT_FILE)
+
+    configure_file("${PORT_SOURCE_DIR}/extension/madlib.control_in"
+        "${CMAKE_CURRENT_BINARY_DIR}/extension/madlib.control"
+        @ONLY
+    )
+    # base file contains miscellaneous operations such like creating history table
+    set(EXTENSION_SQL_BASE "${CMAKE_CURRENT_BINARY_DIR}/extension/madlib.sql.base")
+    set(extschema "@extschema@")
+    configure_file("${PORT_SOURCE_DIR}/extension/madlib.sql.base_in"
+        "${EXTENSION_SQL_BASE}"
+        @ONLY
+    )
+    unset(extschema)
+
+    # We use X.Y.Z style for version string for it is recommended in PGXN.
+    set(EXTENSION_SQL "${CMAKE_CURRENT_BINARY_DIR}/extension/madlib--${MADLIB_VERSION_MAJOR}.${MADLIB_VERSION_MINOR}.${MADLIB_VERSION_PATCH}.sql")
+
+    # The workhorse for extension target
+    # It is hard to interpret Modules.yml in this cmake file, thus we use
+    # sort-module.py to sort modules based on the dependencies.
+    add_custom_command(OUTPUT ${EXTENSION_SQL}
+        COMMAND cat ${EXTENSION_SQL_BASE}
+            `cd ${CMAKE_BINARY_DIR}/src/madpack &&
+            python sort-module.py ${MODULE_SQL_POST_FILES}` >${EXTENSION_SQL}
+        DEPENDS ${MODULE_SQL_POST_FILES} madpackFiles configFiles pythonFiles_${DBMS} madlib_${DBMS}
+        COMMENT "Concatenating into ${EXTENSION_SQL}"
+    )
+    # default target for extension
+    add_custom_target(extension
+        DEPENDS ${EXTENSION_SQL}
+    )
+
+    # clean target for extension
+    add_custom_target(extension-clean
+        COMMAND ${CMAKE_COMMAND} -E remove ${EXTENSION_SQL}
+    )
+
+    # install target for extension
+    # Unfortunately, cmake install command cannot be used here, as
+    # DIRECTORY install doesn't have custom target option.
+    add_custom_target(extension-install
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${${DBMS_UC}_SHARE_DIR}/madlib
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_BINARY_DIR}/modules ${${DBMS_UC}_SHARE_DIR}/madlib/modules
+        COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_CURRENT_BINARY_DIR}/lib/libmadlib.so ${${DBMS_UC}_LIB_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy
+            ${EXTENSION_SQL} ${${DBMS_UC}_SHARE_DIR}/extension/
+        COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_CURRENT_BINARY_DIR}/extension/madlib.control
+            ${${DBMS_UC}_SHARE_DIR}/extension/
+        DEPENDS ${EXTENSION_SQL}
+    )
+endfunction(add_extension_support)
 
 # -- 6. Build shared library and copy version-specific file for all
 #       ${PORT_UC}_X_Y_PG_CONFIG macros defined by the user. If none has been
@@ -245,3 +338,4 @@ determine_target_versions(VERSIONS)
 foreach(VERSION ${VERSIONS})
 	add_subdirectory(${VERSION})
 endforeach(VERSION)
+

--- a/src/ports/postgres/cmake/FindPostgreSQL.cmake
+++ b/src/ports/postgres/cmake/FindPostgreSQL.cmake
@@ -21,6 +21,7 @@
 #      (see below)
 #  ${PKG_NAME}_FOUND - set to true if headers and binary were found
 #  ${PKG_NAME}_LIB_DIR - PostgreSQL library directory
+#  ${PKG_NAME}_SHARE_DIR - PostgreSQL share directory
 #  ${PKG_NAME}_CLIENT_INCLUDE_DIR - client include directory
 #  ${PKG_NAME}_SERVER_INCLUDE_DIR - server include directory
 #  ${PKG_NAME}_EXECUTABLE - path to postgres binary
@@ -155,7 +156,12 @@ if(${PKG_NAME}_PG_CONFIG AND ${PKG_NAME}_CLIENT_INCLUDE_DIR)
                 OUTPUT_VARIABLE ${PKG_NAME}_LIB_DIR
                 OUTPUT_STRIP_TRAILING_WHITESPACE
             )
-            
+
+            execute_process(COMMAND ${${PKG_NAME}_PG_CONFIG} --sharedir
+                OUTPUT_VARIABLE ${PKG_NAME}_SHARE_DIR
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+
             architecture("${${PKG_NAME}_EXECUTABLE}" ${PKG_NAME}_ARCHITECTURE)
         else()
             message(STATUS "Found pg_config at \"${${PKG_NAME}_PG_CONFIG}\", "

--- a/src/ports/postgres/extension/madlib.control_in
+++ b/src/ports/postgres/extension/madlib.control_in
@@ -1,0 +1,5 @@
+default_version = '@MADLIB_VERSION_MAJOR@.@MADLIB_VERSION_MINOR@.@MADLIB_VERSION_PATCH@'
+comment = 'A scalable in-database analytics library'
+relocatable = false
+module_pathname = '$libdir/libmadlib.so'
+requires = 'plpythonu'

--- a/src/ports/postgres/extension/madlib.sql.base_in
+++ b/src/ports/postgres/extension/madlib.sql.base_in
@@ -1,0 +1,5 @@
+CREATE TABLE @extschema@.migrationhistory(
+    id serial, version varchar(255), applied timestamp default current_timestamp
+);
+INSERT INTO @extschema@.migrationhistory(version)
+    VALUES('@MADLIB_VERSION_STRING@'::text);


### PR DESCRIPTION
Instead of the previous attempt to support this in madpack time, this time
we try to make the build system to create EXTENSION files so that upcoming
PGXN support can handle it gracefully.  For users who want to install it
as an extension, the process is to download source, configure, and
"make extension-install."  Still the extension is not relocatable, users
can specify schema name on CREATE EXTENSION with SCHEMA option.

MADLIB-316
