### PR TITLE
Hypothesis tests: Fixes for MADLIB-526, MADLIB-527, MADLIB-528

### DIFF
--- a/src/modules/stats/mann_whitney_test.cpp
+++ b/src/modules/stats/mann_whitney_test.cpp
@@ -35,11 +35,11 @@ public:
         numTies(&mStorage[2], 2),
         rankSum(&mStorage[4], 2),
         last(&mStorage[6]) { }
-    
+
     inline operator AnyType() const {
         return mStorage;
     }
-    
+
 private:
     Handle mStorage;
 
@@ -58,7 +58,7 @@ mw_test_transition::run(AnyType &args) {
     MWTestTransitionState<MutableArrayHandle<double> > state = args[0];
     int sample = args[1].getAs<bool>() ? 0 : 1;
     double value = args[2].getAs<double>();
-    
+
     // For almostEqual, we choose a precision of 2 * 1 units in the last place.
     // This is because we assume that value is original data, so the only
     // precision loss is due to representation as floating-point number.
@@ -67,17 +67,21 @@ mw_test_transition::run(AnyType &args) {
             state.rankSum(i) += state.numTies(i) * 0.5;
     } else if (state.last < value) {
         state.numTies.setZero();
+    } else if (std::isnan(value)) {
+        // If the input contains NaN, we'll have it propagate
+        state.rankSum(0) = state.rankSum(1)
+            = std::numeric_limits<double>::quiet_NaN();
     } else if (state.num.sum() > 0) {
         // also satisfied here: state.last > value
         throw std::invalid_argument("Must be used as an ordered aggregate, "
             "in ascending order of the second argument.");
     }
-    
+
     state.num(sample)++;
     state.rankSum(sample) += (2. * state.num.sum() - state.numTies.sum()) / 2.;
     state.numTies(sample)++;
     state.last = value;
-    
+
     return state;
 }
 
@@ -89,14 +93,14 @@ mw_test_final::run(AnyType &args) {
 
     Eigen::Vector2d U;
     double numProd = state.num.prod();
-    
+
     U(0) = state.rankSum(1) - state.num(1) * (state.num(1) + 1.) / 2.;
     U(1) = numProd - U(0);
-    
+
     double u_statistic = U.minCoeff();
     double z_statistic = (u_statistic - (numProd / 2.))
                        / (std::sqrt( numProd * (state.num.sum() + 1) / 12. ));
-    
+
     AnyType tuple;
     tuple
         << z_statistic

--- a/src/ports/postgres/modules/stats/hypothesis_tests.sql_in
+++ b/src/ports/postgres/modules/stats/hypothesis_tests.sql_in
@@ -1,4 +1,4 @@
-/* ----------------------------------------------------------------------- *//** 
+/* ----------------------------------------------------------------------- *//**
  *
  * @file hypothesis_tests.sql_in
  *
@@ -116,7 +116,7 @@ LANGUAGE C IMMUTABLE STRICT;
  */
 CREATE AGGREGATE MADLIB_SCHEMA.t_test_one(
     /*+ value */ DOUBLE PRECISION) (
-    
+
     SFUNC=MADLIB_SCHEMA.t_test_one_transition,
     STYPE=DOUBLE PRECISION[],
     FINALFUNC=MADLIB_SCHEMA.t_test_one_final,
@@ -164,7 +164,7 @@ LANGUAGE C IMMUTABLE STRICT;
  *    \f]
  *    where
  *    \f[
- *        s_p^2 = \frac{\sum_{i=1}^n (x_i - \bar x)^2 
+ *        s_p^2 = \frac{\sum_{i=1}^n (x_i - \bar x)^2
  *                         + \sum_{i=1}^m (y_i - \bar y)^2}
  *                     {n + m - 2}
  *    \f]
@@ -172,7 +172,7 @@ LANGUAGE C IMMUTABLE STRICT;
  *    The corresponding random
  *    variable is Student-t distributed with
  *    \f$ (n + m - 2) \f$ degrees of freedom.
- *  - <tt>df BIGINT</tt> - Degrees of freedom \f$ (n + m - 2) \f$
+ *  - <tt>df FLOAT8</tt> - Degrees of freedom \f$ (n + m - 2) \f$
  *  - <tt>p_value_one_sided FLOAT8</tt> - Lower bound on one-sided p-value.
  *    In detail, the result is \f$ \Pr[\bar X - \bar Y \geq \bar x - \bar y \mid \mu_X = \mu_Y] \f$,
  *    which is a lower bound on
@@ -193,7 +193,7 @@ LANGUAGE C IMMUTABLE STRICT;
 CREATE AGGREGATE MADLIB_SCHEMA.t_test_two_pooled(
     /*+ "fromFirstSample" */ BOOLEAN,
     /*+ "value" */ DOUBLE PRECISION) (
-    
+
     SFUNC=MADLIB_SCHEMA.t_test_two_transition,
     STYPE=DOUBLE PRECISION[],
     FINALFUNC=MADLIB_SCHEMA.t_test_two_pooled_final,
@@ -257,7 +257,7 @@ LANGUAGE C IMMUTABLE STRICT;
 CREATE AGGREGATE MADLIB_SCHEMA.t_test_two_unpooled(
     /*+ first */ BOOLEAN,
     /*+ value */ DOUBLE PRECISION) (
-    
+
     SFUNC=MADLIB_SCHEMA.t_test_two_transition,
     STYPE=DOUBLE PRECISION[],
     FINALFUNC=MADLIB_SCHEMA.t_test_two_unpooled_final,
@@ -312,7 +312,7 @@ CREATE AGGREGATE MADLIB_SCHEMA.t_test_two_unpooled(
 CREATE AGGREGATE MADLIB_SCHEMA.f_test(
     /*+ "fromFirstSample" */ BOOLEAN,
     /*+ "value" */ DOUBLE PRECISION) (
-    
+
     SFUNC=MADLIB_SCHEMA.t_test_two_transition,
     STYPE=DOUBLE PRECISION[],
     FINALFUNC=MADLIB_SCHEMA.f_test_final,
@@ -439,7 +439,7 @@ CREATE AGGREGATE MADLIB_SCHEMA.chi2_gof_test(
     /*+ observed */ BIGINT,
     /*+ expected */ DOUBLE PRECISION /*+ DEFAULT NULL */,
     /*+ df */ BIGINT /*+ DEFAULT NULL */
-) (    
+) (
     SFUNC=MADLIB_SCHEMA.chi2_gof_test_transition,
     STYPE=DOUBLE PRECISION[],
     FINALFUNC=MADLIB_SCHEMA.chi2_gof_test_final,
@@ -450,7 +450,7 @@ CREATE AGGREGATE MADLIB_SCHEMA.chi2_gof_test(
 CREATE AGGREGATE MADLIB_SCHEMA.chi2_gof_test(
     /*+ observed */ BIGINT,
     /*+ expected */ DOUBLE PRECISION
-) (    
+) (
     SFUNC=MADLIB_SCHEMA.chi2_gof_test_transition,
     STYPE=DOUBLE PRECISION[],
     FINALFUNC=MADLIB_SCHEMA.chi2_gof_test_final,
@@ -460,7 +460,7 @@ CREATE AGGREGATE MADLIB_SCHEMA.chi2_gof_test(
 
 CREATE AGGREGATE MADLIB_SCHEMA.chi2_gof_test(
     /*+ observed */ BIGINT
-) (    
+) (
     SFUNC=MADLIB_SCHEMA.chi2_gof_test_transition,
     STYPE=DOUBLE PRECISION[],
     FINALFUNC=MADLIB_SCHEMA.chi2_gof_test_final,
@@ -606,7 +606,7 @@ LANGUAGE C IMMUTABLE STRICT;
  *    where
  *    \f[
  *        r_{x,i}
- *        =   \{ j \mid x_j < x_i \} + \{ j \mid y_j < x_i \} + 
+ *        =   \{ j \mid x_j < x_i \} + \{ j \mid y_j < x_i \} +
  *            \frac{\{ j \mid x_j = x_i \} + \{ j \mid y_j = x_i \} + 1}{2}
  *    \f]
  *    is defined as the rank of \f$ x_i \f$ in the combined list of all
@@ -633,7 +633,7 @@ m4_ifdef(`__GREENPLUM__',`ORDERED')
 AGGREGATE MADLIB_SCHEMA.mw_test(
     /*+ "fromFirstSample" */ BOOLEAN,
     /*+ "value" */ DOUBLE PRECISION
-) (    
+) (
     SFUNC=MADLIB_SCHEMA.mw_test_transition,
     STYPE=DOUBLE PRECISION[],
     FINALFUNC=MADLIB_SCHEMA.mw_test_final,
@@ -705,7 +705,7 @@ LANGUAGE C IMMUTABLE STRICT;
  *    \f$
  *        w^+ = \sum_{i \mid x_i > 0} r_i
  *    \f$
- *    and 
+ *    and
  *    \f$
  *        w^- = \sum_{i \mid x_i < 0} r_i
  *    \f$
@@ -728,7 +728,7 @@ LANGUAGE C IMMUTABLE STRICT;
  *    where \f$ t_i \f$ is the number of
  *    values with absolute value equal to \f$ |x_i| \f$. The corresponding
  *    random variable is approximately standard normally distributed.
- *  - <tt>p_value_one_sided FLOAT8</tt> - One-sided p-value i.e., 
+ *  - <tt>p_value_one_sided FLOAT8</tt> - One-sided p-value i.e.,
  *    \f$ \Pr[Z \geq z \mid \mu \leq 0] \f$. Computed as
  *    <tt>(1.0 - \ref normal_cdf "normal_cdf"(z_statistic))</tt>.
  *  - <tt>p_value_two_sided FLOAT8</tt> - Two-sided p-value, i.e.,
@@ -743,7 +743,7 @@ LANGUAGE C IMMUTABLE STRICT;
  *    between the first and second value in a pair is at most (or equal to,
  *    respectively) \f$ \mu_0 \f$:
  *    <pre>SELECT (wsr_test(<em>first</em> - <em>second</em> - <em>mu_0</em> ORDER BY abs(<em>first</em> - <em>second</em>))).* FROM <em>source</em></pre>
- *    If correctly determining ties is important (e.g., you may want to do so 
+ *    If correctly determining ties is important (e.g., you may want to do so
  *    when comparing to software products that take \c first, \c second,
  *    and \c mu_0 as individual parameters), supply the precision parameter.
  *    This can be done as follows:
@@ -766,7 +766,7 @@ m4_ifdef(`__GREENPLUM__',`ORDERED')
 AGGREGATE MADLIB_SCHEMA.wsr_test(
     /*+ value */ DOUBLE PRECISION,
     /*+ "precision" */ DOUBLE PRECISION /*+ DEFAULT NULL */
-) (    
+) (
     SFUNC=MADLIB_SCHEMA.wsr_test_transition,
     STYPE=DOUBLE PRECISION[],
     FINALFUNC=MADLIB_SCHEMA.wsr_test_final,
@@ -777,7 +777,7 @@ CREATE
 m4_ifdef(`__GREENPLUM__',`ORDERED')
 AGGREGATE MADLIB_SCHEMA.wsr_test(
     /*+ value */ DOUBLE PRECISION
-) (    
+) (
     SFUNC=MADLIB_SCHEMA.wsr_test_transition,
     STYPE=DOUBLE PRECISION[],
     FINALFUNC=MADLIB_SCHEMA.wsr_test_final,
@@ -877,7 +877,7 @@ LANGUAGE C IMMUTABLE STRICT;
 CREATE AGGREGATE MADLIB_SCHEMA.one_way_anova(
     /*+ group */ INTEGER,
     /*+ value */ DOUBLE PRECISION) (
-    
+
     SFUNC=MADLIB_SCHEMA.one_way_anova_transition,
     STYPE=DOUBLE PRECISION[],
     FINALFUNC=MADLIB_SCHEMA.one_way_anova_final,

--- a/src/ports/postgres/modules/stats/hypothesis_tests.sql_in
+++ b/src/ports/postgres/modules/stats/hypothesis_tests.sql_in
@@ -321,7 +321,6 @@ CREATE AGGREGATE MADLIB_SCHEMA.f_test(
 );
 
 
-
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.chi2_gof_test_transition(
     state DOUBLE PRECISION[],
     observed BIGINT,
@@ -329,8 +328,9 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.chi2_gof_test_transition(
     df BIGINT
 ) RETURNS DOUBLE PRECISION[]
 AS 'MODULE_PATHNAME'
-LANGUAGE C IMMUTABLE
-CALLED ON NULL INPUT;
+LANGUAGE C
+IMMUTABLE
+STRICT;
 
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.chi2_gof_test_transition(
     state DOUBLE PRECISION[],
@@ -338,17 +338,18 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.chi2_gof_test_transition(
     expected DOUBLE PRECISION
 ) RETURNS DOUBLE PRECISION[]
 AS 'MODULE_PATHNAME'
-LANGUAGE C IMMUTABLE
-CALLED ON NULL INPUT;
+LANGUAGE C
+IMMUTABLE
+STRICT;
 
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.chi2_gof_test_transition(
     state DOUBLE PRECISION[],
     observed BIGINT
 ) RETURNS DOUBLE PRECISION[]
 AS 'MODULE_PATHNAME'
-LANGUAGE C IMMUTABLE
-CALLED ON NULL INPUT;
-
+LANGUAGE C
+IMMUTABLE
+STRICT;
 
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.chi2_gof_test_merge_states(
     state1 DOUBLE PRECISION[],
@@ -356,7 +357,8 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.chi2_gof_test_merge_states(
 RETURNS DOUBLE PRECISION[]
 AS 'MODULE_PATHNAME'
 LANGUAGE C
-IMMUTABLE STRICT;
+IMMUTABLE
+STRICT;
 
 CREATE TYPE MADLIB_SCHEMA.chi2_test_result AS (
     statistic DOUBLE PRECISION,
@@ -370,7 +372,9 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.chi2_gof_test_final(
     state DOUBLE PRECISION[]
 ) RETURNS MADLIB_SCHEMA.chi2_test_result
 AS 'MODULE_PATHNAME'
-LANGUAGE C IMMUTABLE STRICT;
+LANGUAGE C
+IMMUTABLE
+STRICT;
 
 /**
  * @brief Perform Pearson's chi-squared goodness-of-fit test
@@ -383,13 +387,13 @@ LANGUAGE C IMMUTABLE STRICT;
  * @param observed Number \f$ n_i \f$ of observations of the current event/row
  * @param expected Expected number of observations of current event/row. This
  *     number is not required to be normalized. That is, \f$ p^0_i \f$ will be
- *     taken as \c expected divided by <tt>sum(expected)</tt>. If this parameter
- *     is \c NULL, chi2_test() will use
+ *     taken as \c expected divided by <tt>sum(expected)</tt>. Hence, if this
+ *     parameter is not specified, chi2_test() will by default use
  *     \f$ p^0 = (\frac 1k, \dots, \frac 1k) \f$, i.e., test that \f$ p \f$ is a
  *     discrete uniform distribution.
  * @param df Degrees of freedom. This is the number of events reduced by the
  *     degree of freedom lost by using the observed numbers for defining the
- *     expected number of observations. If this parameter is \c NULL, the degree
+ *     expected number of observations. If this parameter is 0, the degree
  *     of freedom is taken as \f$ (k - 1) \f$.
  *
  * @return A composite value as follows. Let \f$ n = \sum_{i=1}^n n_i \f$.
@@ -437,14 +441,14 @@ LANGUAGE C IMMUTABLE STRICT;
  */
 CREATE AGGREGATE MADLIB_SCHEMA.chi2_gof_test(
     /*+ observed */ BIGINT,
-    /*+ expected */ DOUBLE PRECISION /*+ DEFAULT NULL */,
-    /*+ df */ BIGINT /*+ DEFAULT NULL */
+    /*+ expected */ DOUBLE PRECISION /*+ DEFAULT 1 */,
+    /*+ df */ BIGINT /*+ DEFAULT 0 */
 ) (
     SFUNC=MADLIB_SCHEMA.chi2_gof_test_transition,
     STYPE=DOUBLE PRECISION[],
     FINALFUNC=MADLIB_SCHEMA.chi2_gof_test_final,
     m4_ifdef(`__GREENPLUM__',`prefunc=MADLIB_SCHEMA.chi2_gof_test_merge_states,')
-    INITCOND='{0,0,0,0,0,0,0}'
+    INITCOND='{0,0,0,0,0,0}'
 );
 
 CREATE AGGREGATE MADLIB_SCHEMA.chi2_gof_test(

--- a/src/ports/postgres/modules/stats/test/chi2_test.sql_in
+++ b/src/ports/postgres/modules/stats/test/chi2_test.sql_in
@@ -1,6 +1,6 @@
 /* -----------------------------------------------------------------------------
  * Test Chi-squared goodness-of-fit test.
- * 
+ *
  * Example taken from:
  * http://www.statsdirect.com/help/chi_square_tests/chi_good.htm
  * -------------------------------------------------------------------------- */
@@ -19,7 +19,7 @@ INSERT INTO chi2_test_blood_group(blood_group, observed, expected) VALUES
     ('AB', 8, 5.61);
 
 CREATE TABLE chi2_gof_test_1 AS
-SELECT (chi2_gof_test(observed, expected, NULL)).* FROM chi2_test_blood_group;
+SELECT (chi2_gof_test(observed, expected)).* FROM chi2_test_blood_group;
 
 SELECT * FROM chi2_gof_test_1;
 SELECT assert(


### PR DESCRIPTION
- Welch–Satterthwaite formula gives non-integrate degress of freedom, but documentation used to say that an integral value is returned.
- Since the MW test is a rank-based test, there is no reason to disallow infinities. NaNs on the other hand now propagate. No error is raised.
- §4.15.4 ("Aggregate functions") of ISO/IEC 9075-2:2003, "SQL/Foundation" demands that aggregate functions ignore rows with NULL values. It is therefore confusing to use NULL arguments. The chi-squared GOF now has numeric default values for the expected number of observations (1) and degree of freedom (0), and the documentation explains how these values are interpreted.
