### PR TITLE
SVEC: Another fix for text order in gp_sfv.

### DIFF
--- a/methods/svec/src/pg_gp/sql/gp_sfv_sort_order.sql_in
+++ b/methods/svec/src/pg_gp/sql/gp_sfv_sort_order.sql_in
@@ -47,7 +47,7 @@ CREATE TEMP TABLE dictionary_array( dict text[] )
     m4_ifdef(`GREENPLUM',`distributed randomly');
 
 insert into dictionary_array
-    select array_agg( term order by term asc ) from dictionary
+    select array(select term from dictionary order by term asc)
 ;
 
 select

--- a/methods/svec/src/pg_gp/sql/gp_sfv_sort_order.sql_in
+++ b/methods/svec/src/pg_gp/sql/gp_sfv_sort_order.sql_in
@@ -47,7 +47,7 @@ CREATE TEMP TABLE dictionary_array( dict text[] )
     m4_ifdef(`GREENPLUM',`distributed randomly');
 
 insert into dictionary_array
-    select array(select term from dictionary order by term asc)
+    select array(select term from dictionary order by term asc limit all)
 ;
 
 select


### PR DESCRIPTION
Jira: MADLIB-457
The previous fix was not correct in that replacing strcmp with strcol was
still not enough to match behaviors with the text sort operation in the
database backend.  There is a little hack to deal with undefined orders in
non-C collation, in which case the backend uses strcmp as the last resort.

I rewrote the existing implementation to be efficient with use of bttextcmp.
This contains a little more of cosmetic changes than addressing issue, as
well as the fix for test failure in use of the ordered aggregate in PG8.4
and GPDB4.0.
