### PR TITLE
Probability functions: Improved handling of invalid arguments

### DIFF
--- a/license/third_party/CERN-Root.txt
+++ b/license/third_party/CERN-Root.txt
@@ -1,5 +1,5 @@
 From the CERN ROOT Licensing page
-(http://eigen.tuxfamily.org/index.php?title=Licensing_FAQ):
+(http://root.cern.ch/drupal/content/license):
 
 > The ROOT system is being made available under the LGPL, which allows ROOT to
 > be used in a wide range of open and closed environments.

--- a/src/modules/prob/kolmogorov.cpp
+++ b/src/modules/prob/kolmogorov.cpp
@@ -58,6 +58,7 @@ namespace TMath {
  */
 
 // BEGIN Copied from CERN ROOT, math/mathcore/src/TMath.cxx
+// http://root.cern.ch/viewvc/trunk/math/mathcore/src/TMath.cxx?view=markup&pathrev=41830
 // (SVN Rev. 41830, ll. 122-137)
 Int_t TMath::Nint(Double_t x)
 {
@@ -78,6 +79,7 @@ Int_t TMath::Nint(Double_t x)
 // END Copied from CERN ROOT, math/mathcore/src/TMath.cxx
 
 // BEGIN Copied from CERN ROOT, math/mathcore/src/TMath.cxx
+// http://root.cern.ch/viewvc/trunk/math/mathcore/src/TMath.cxx?view=markup&pathrev=41830
 // (SVN Rev. 41830, ll. 657-715)
 Double_t TMath::KolmogorovProb(Double_t z)
 {

--- a/src/modules/stats/chi_squared_test.cpp
+++ b/src/modules/stats/chi_squared_test.cpp
@@ -165,8 +165,10 @@ chi2_gof_test_final::run(AnyType &args) {
     AnyType tuple;
     tuple
         << statistic
-        << prob::cdf(complement(prob::chi_squared(
-            static_cast<double>(degreeOfFreedom)), statistic))
+        << (degreeOfFreedom > 0
+            ? prob::cdf(complement(prob::chi_squared(
+                static_cast<double>(degreeOfFreedom)), statistic))
+            : Null())
         << degreeOfFreedom
         << phi
         << C;

--- a/src/ports/postgres/modules/prob/prob.sql_in
+++ b/src/ports/postgres/modules/prob/prob.sql_in
@@ -1394,7 +1394,7 @@ IMMUTABLE STRICT;
 /**
  * @brief Poisson probability mass function
  *
- * @param x Random variate \f$ x >= 0 \f$
+ * @param x Random variate \f$ x \f$
  * @param mean Average occurrence rate \f$ \lambda > 0 \f$
  * @return \f$ f(x) \f$ where \f$ f \f$ is the probability mass function of a
  *     Poisson distributed random variable with mean \f$ \lambda \f$

--- a/src/ports/postgres/modules/prob/test/prob.sql_in
+++ b/src/ports/postgres/modules/prob/test/prob.sql_in
@@ -831,7 +831,8 @@ SELECT assert(
 SELECT assert(
     isnan(fisher_f_quantile('NaN', 1, 1) ) AND
     isnan(fisher_f_quantile(1, 'NaN', 1) ) AND
-    isnan(fisher_f_quantile(1, 1, 'NaN') ),
+    isnan(fisher_f_quantile(1, 1, 'NaN') ) AND
+    isnan(fisher_f_quantile(.5, 1, 'NaN') ),
     'Fisher F Quantile: Wrong handling of NaNs.'
 );
 
@@ -2387,8 +2388,10 @@ SELECT assert(
 
 SELECT assert(
     pareto_cdf(-1, 1, 1) = 0 AND
+    pareto_cdf(0, 1, 1) = 0 AND
     pareto_cdf(1, 1, 1) = 0 AND
     pareto_cdf(2, 1, 1) = 0.5 AND
+    pareto_cdf(2, 2, 3) = 0 AND
     pareto_cdf('Inf', 1, 1) = 1,
 
     'Pareto CDF: Wrong handling regular values'
@@ -2425,8 +2428,10 @@ SELECT assert(
 
 SELECT assert(
     pareto_pdf(-1, 1, 1) = 0 AND
+    pareto_pdf(0, 1, 1) = 0 AND
     pareto_pdf(1, 1, 1) = 1 AND
     pareto_pdf(2, 1, 1) = 0.25 AND
+    pareto_pdf(2, 2, 3) = 3. * 2^3 / 2^(3 + 1) /* = 1.5 (exactly representable) */ AND
     pareto_pdf('Inf', 1, 1) = 0,
 
     'Pareto PDF: Wrong handling regular values'
@@ -2612,16 +2617,19 @@ SELECT assert(
     relative_error(rayleigh_cdf(2,3), 0.1992626) < 1e-5 AND
     rayleigh_cdf(0,3) = 0 AND
     rayleigh_cdf(-1,3) = 0 AND
-    rayleigh_cdf(2,'Inf') = 0,
+    rayleigh_cdf('-Inf',2) = 0 AND
+    rayleigh_cdf('Inf',2) = 1,
 
     'Rayleigh CDF: Wrong handling regular values'
 );
 
 SELECT assert(
     check_if_raises_error($$SELECT rayleigh_cdf(0.5, 0)$$) AND
-    check_if_raises_error($$SELECT rayleigh_cdf(0.5, -1)$$),
+    check_if_raises_error($$SELECT rayleigh_cdf(0.5, -1)$$) AND
+    check_if_raises_error($$SELECT rayleigh_cdf(0.5, '-Inf')$$) AND
+    check_if_raises_error($$SELECT rayleigh_cdf(0.5, 'Inf')$$),
 
-    'Rayleigh CDF: shape less than or equal to 0 does not raise error.'
+    'Rayleigh CDF: shape outside (0, infinity) does not raise error.'
 );
 
 -- rayleigh_pdf
@@ -2641,16 +2649,19 @@ SELECT assert(
     relative_error(rayleigh_pdf(2,3), 0.1779416) < 1e-5 AND
     rayleigh_pdf(0,3) = 0 AND
     rayleigh_pdf(-1,3) = 0 AND
-    rayleigh_pdf(2,'Inf') = 0,
+    rayleigh_pdf('-Inf',2) = 0 AND
+    rayleigh_pdf('Inf',2) = 0,
 
     'Rayleigh PDF: Wrong handling regular values'
 );
 
 SELECT assert(
     check_if_raises_error($$SELECT rayleigh_pdf(0.5, 0)$$) AND
-    check_if_raises_error($$SELECT rayleigh_pdf(0.5, -1)$$),
+    check_if_raises_error($$SELECT rayleigh_pdf(0.5, -1)$$) AND
+    check_if_raises_error($$SELECT rayleigh_pdf(0.5, '-Inf')$$) AND
+    check_if_raises_error($$SELECT rayleigh_pdf(0.5, 'Inf')$$),
 
-    'Rayleigh PDF: shape less than or equal to 0 does not raise error.'
+    'Rayleigh PDF: shape outside (0, infinity) does not raise error.'
 );
 
 -- rayleigh_quantile
@@ -2676,9 +2687,11 @@ SELECT assert(
 
 SELECT assert(
     check_if_raises_error($$SELECT rayleigh_quantile(0.5, 0)$$) AND
-    check_if_raises_error($$SELECT rayleigh_quantile(0.5, -1)$$),
+    check_if_raises_error($$SELECT rayleigh_quantile(0.5, -1)$$) AND
+    check_if_raises_error($$SELECT rayleigh_quantile(0.5, '-Inf')$$) AND
+    check_if_raises_error($$SELECT rayleigh_quantile(0.5, 'Inf')$$),
 
-    'Rayleigh Quantile: shape less than or equal to 0 does not raise error.'
+    'Rayleigh Quantile: shape outside (0, infinity) does not raise error.'
 );
 
 SELECT assert(
@@ -2839,8 +2852,9 @@ SELECT assert(
     triangular_cdf(0, 0, 1, 2) = 0 AND
     triangular_cdf(-1, 0, 1, 2) = 0 AND
     triangular_cdf(2, 0, 1, 2) = 1 AND
-    triangular_cdf(3, 0, 1, 2) = 1 ,
-
+    triangular_cdf(3, 0, 1, 2) = 1 AND
+    triangular_cdf('-Inf', 0, 1, 2) = 0 AND
+    triangular_cdf('Inf', 0, 1, 2) = 1,
 
     'Triangular CDF: Wrong handling regular values'
 );
@@ -2881,7 +2895,9 @@ SELECT assert(
     triangular_pdf(0, 0, 1, 2) = 0 AND
     triangular_pdf(-1, 0, 1, 2) = 0 AND
     triangular_pdf(2, 0, 1, 2) = 0 AND
-    triangular_pdf(3, 0, 1, 2) = 0 ,
+    triangular_pdf(3, 0, 1, 2) = 0 AND
+    triangular_pdf('-Inf', 0, 1, 2) = 0 AND
+    triangular_pdf('Inf', 0, 1, 2) = 0,
 
 
     'Triangular PDF: Wrong handling regular values'
@@ -2968,7 +2984,9 @@ SELECT assert(
     uniform_cdf(-1, 0, 1) = 0 AND
     uniform_cdf(1, 0, 1) = 1 AND
     uniform_cdf(2, 0, 1) = 1 AND
-    uniform_cdf(0.5, 0, 1) = 0.5,
+    uniform_cdf(0.5, 0, 1) = 0.5 AND
+    uniform_cdf('-Inf', 0, 1) = 0 AND
+    uniform_cdf('Inf', 0, 1) = 1,
 
     'Uniform CDF: Wrong handling regular values'
 );
@@ -2999,7 +3017,9 @@ SELECT assert(
     uniform_pdf(-1, 0, 1) = 0 AND
     uniform_pdf(1, 0, 1) = 1 AND
     uniform_pdf(2, 0, 1) = 0 AND
-    uniform_pdf(0.5, 0, 1) = 1,
+    uniform_pdf(0.5, 0, 1) = 1 AND
+    uniform_pdf('-Inf', 0, 1) = 0 AND
+    uniform_pdf('Inf', 0, 1) = 0,
 
     'Uniform PDF: Wrong handling regular values'
 );


### PR DESCRIPTION
Jira: MADLIB-538, MADLIB-541, MADLIB-542, MADLIB-543, MADLIB-548

Fixes:
- Chi-Squared GOF test: return NULL for p-values if d.f. <= 0 instead of raising an error (MADLIB-538)
- "parameter x is not accepting 0 in pareto cdf and pdf" (MADLIB-541)
- "parameter x is not accepting positive and negative infinities in triangular/uniform cdf/pdf" (MADLIB-542)
- "parameter x is not accepting 0 in pareto cdf and pdf" (MADLIB-541)
- "fisher f quantile with NaN as df2 should return NaN, but it raises internal error" (MADLIB-543)
- "rayleigh cdf/pdf are accepting positive infinity as their parameter scale while they should not" (MADLIB-548)
