### PR TITLE
Fixes in probability module

### DIFF
--- a/src/modules/stats/one_way_anova.cpp
+++ b/src/modules/stats/one_way_anova.cpp
@@ -291,8 +291,10 @@ one_way_anova_final::run(AnyType &args) {
         << mean_square_between
         << mean_square_within
         << statistic
-        << prob::cdf(
-            complement(prob::fisher_f(df_between, df_within), statistic));
+        << ((df_between >= 1 && df_within >= 1)
+            ? prob::cdf(
+                complement(prob::fisher_f(df_between, df_within), statistic))
+            : Null());
     return tuple;
 }
 

--- a/src/ports/postgres/modules/prob/prob.sql_in
+++ b/src/ports/postgres/modules/prob/prob.sql_in
@@ -1028,7 +1028,7 @@ IMMUTABLE STRICT;
  *
  * @param x Random variate \f$ x \f$
  * @param df Degrees of freedom \f$ \nu > 0 \f$
- * @param ncp The noncentrality parameter \f$ \lambda > 0 \f$
+ * @param ncp The noncentrality parameter \f$ \lambda \geq 0 \f$
  * @return \f$ \Pr[X \leq x] \f$ where \f$ X \f$ is a noncentral-chi-squared
  *     distributed random variable with \f$ \nu \f$ degrees of freedom and
  *     noncentrality parameter \f$ \lambda \f$
@@ -1047,7 +1047,7 @@ IMMUTABLE STRICT;
  *
  * @param x Random variate \f$ x \f$
  * @param df Degrees of freedom \f$ \nu > 0 \f$
- * @param ncp The noncentrality parameter \f$ \lambda > 0 \f$
+ * @param ncp The noncentrality parameter \f$ \lambda \geq 0 \f$
  * @return \f$ f(x) \f$ where \f$ f \f$ is the probability density function of
  *     a noncentral-chi-squared distributed random variable with \f$ \nu \f$
  *     degrees of freedom and noncentrality parameter \f$ \lambda \f$
@@ -1066,7 +1066,7 @@ IMMUTABLE STRICT;
  *
  * @param p Probability \f$ p \in [0,1] \f$
  * @param df Degrees of freedom \f$ \nu > 0 \f$
- * @param ncp The noncentrality parameter \f$ \lambda > 0 \f$
+ * @param ncp The noncentrality parameter \f$ \lambda \geq 0 \f$
  * @return \f$ x \f$ such that \f$ p = \Pr[X \leq x] \f$ where \f$ X \f$ is a
  *     noncentral-chi-squared distributed random variable with \f$ \nu \f$
  *     degrees of freedom and noncentrality parameter \f$ \lambda \f$

--- a/src/ports/postgres/modules/prob/test/prob.sql_in
+++ b/src/ports/postgres/modules/prob/test/prob.sql_in
@@ -569,9 +569,10 @@ SELECT assert(
 
 SELECT assert(
     check_if_raises_error($$SELECT exponential_cdf(1, 0)$$) AND
-    check_if_raises_error($$SELECT exponential_cdf(1, -1)$$) ,
+    check_if_raises_error($$SELECT exponential_cdf(1, -1)$$) AND
+    check_if_raises_error($$SELECT exponential_cdf(0.5, 'Inf')$$),
 
-    'Exponential CDF: Non-positive degree of freedom (nu) does not raise error.'
+    'Exponential CDF: lambda ouside of (0, infinity) does not raise error.'
 );
 
 -- exponential_pdf
@@ -598,9 +599,10 @@ SELECT assert(
 
 SELECT assert(
     check_if_raises_error($$SELECT exponential_pdf(1, 0)$$) AND
-    check_if_raises_error($$SELECT exponential_pdf(1, -1)$$) ,
+    check_if_raises_error($$SELECT exponential_pdf(1, -1)$$) AND
+    check_if_raises_error($$SELECT exponential_pdf(0.5, 'Inf')$$),
 
-    'Exponential PDF: Non-positive degree of freedom (nu) does not raise error.'
+    'Exponential PDF: lambda ouside of (0, infinity) does not raise error.'
 );
 
 -- exponential_quantile
@@ -626,9 +628,10 @@ SELECT assert(
 
 SELECT assert(
     check_if_raises_error($$SELECT exponential_quantile(1, 0)$$) AND
-    check_if_raises_error($$SELECT exponential_quantile(1, -1)$$) ,
+    check_if_raises_error($$SELECT exponential_quantile(1, -1)$$) AND
+    check_if_raises_error($$SELECT exponential_quantile(0.5, 'Inf')$$),
 
-    'Exponential quantile: Non-positive degree of freedom (nu) does not raise error.'
+    'Exponential quantile: lambda outside of (0, infinity) does not raise error.'
 );
 
 SELECT assert(
@@ -667,9 +670,12 @@ SELECT assert(
 
 SELECT assert(
     check_if_raises_error($$SELECT extreme_value_cdf(0.5, 1, 0)$$) AND
-    check_if_raises_error($$SELECT extreme_value_cdf(0.5, 1, -1)$$),
+    check_if_raises_error($$SELECT extreme_value_cdf(0.5, 1, -1)$$) AND
+    check_if_raises_error($$SELECT extreme_value_cdf(0.5, 'Inf', 1)$$) AND
+    check_if_raises_error($$SELECT extreme_value_cdf(0.5, '-Inf', 1)$$) AND
+    check_if_raises_error($$SELECT extreme_value_cdf(0.5, 0, 'Inf')$$),
 
-    'Extreme Value CDF: scale less than or equal to 0 does not raise error.'
+    'Extreme Value CDF: scale outside of (0, infinity) does not raise error.'
 );
 
 -- extreme_value_pdf
@@ -700,9 +706,12 @@ SELECT assert(
 
 SELECT assert(
     check_if_raises_error($$SELECT extreme_value_pdf(0.5, 1, 0)$$) AND
-    check_if_raises_error($$SELECT extreme_value_pdf(0.5, 1, -1)$$),
+    check_if_raises_error($$SELECT extreme_value_pdf(0.5, 1, -1)$$) AND
+    check_if_raises_error($$SELECT extreme_value_pdf(0.5, 'Inf', 1)$$) AND
+    check_if_raises_error($$SELECT extreme_value_pdf(0.5, '-Inf', 1)$$) AND
+    check_if_raises_error($$SELECT extreme_value_pdf(0.5, 0, 'Inf')$$),
 
-    'Extreme Value PDF: scale less than or equal to 0 does not raise error.'
+    'Extreme Value PDF: scale outside of (0, infinity) does not raise error.'
 );
 
 -- extreme_value_quantile
@@ -733,9 +742,12 @@ SELECT assert(
 
 SELECT assert(
     check_if_raises_error($$SELECT extreme_value_quantile(0.5, 1, 0)$$) AND
-    check_if_raises_error($$SELECT extreme_value_quantile(0.5, 1, -1)$$),
+    check_if_raises_error($$SELECT extreme_value_quantile(0.5, 1, -1)$$) AND
+    check_if_raises_error($$SELECT extreme_value_quantile(0.5, 'Inf', 1)$$) AND
+    check_if_raises_error($$SELECT extreme_value_quantile(0.5, '-Inf', 1)$$) AND
+    check_if_raises_error($$SELECT extreme_value_quantile(0.5, 0, 'Inf')$$),
 
-    'Extreme Value Quantile: scale less than or equal to 0 does not raise error.'
+    'Extreme Value Quantile: scale outside of (0, infinity) does not raise error.'
 );
 
 

--- a/src/ports/postgres/modules/stats/hypothesis_tests.sql_in
+++ b/src/ports/postgres/modules/stats/hypothesis_tests.sql_in
@@ -690,19 +690,13 @@ LANGUAGE C IMMUTABLE STRICT;
  *
  * @param value Value of random variate \f$ x_i \f$ or \f$ y_i \f$. Values of 0
  *     are ignored (i.e., they do not count towards \f$ n \f$).
- * @param precision The precision with which value is known. The precision
- *     determines the handling of ties. The current value is regarded a tie
- *     with the previous value if <tt>value - precision</tt> is at most
- *     <tt>value + precision</tt>, for any of the immediately preceeding rows
- *     that form a tie.
- *
- * @warning
- *      There are conflicting sources for the variance reduction in case of ties:
- *      - http://mlsc.lboro.ac.uk/resources/statistics/wsrt.pdf
- *      - http://de.wikipedia.org/wiki/Wilcoxon-Vorzeichen-Rang-Test
- *      .
- *      We currently use the former. This needs to be verified with some
- *      trusworthy sources.
+ * @param precision The precision \f$ \epsilon_i \f$ with which value is known.
+ *     The precision determines the handling of ties. The current value
+ *     \f$ v_i \f$ is regarded a tie with the previous value \f$ v_{i-1} \f$ if
+ *     \f$ v_i - \epsilon_i \leq \max_{j=1, \dots, i-1} v_j + \epsilon_j \f$.
+ *     If \c precision is negative, then it will be treated as
+ *     <tt>value * 2^(-52)</tt>. (Note that \f$ 2^{-52} \f$ is the machine
+ *     epsilon for type <tt>DOUBLE PRECISION</tt>.)
  *
  * @return A composite value:
  *  - <tt>statistic FLOAT8</tt> - statistic computed as follows. Let
@@ -769,7 +763,7 @@ CREATE
 m4_ifdef(`__GREENPLUM__',`ORDERED')
 AGGREGATE MADLIB_SCHEMA.wsr_test(
     /*+ value */ DOUBLE PRECISION,
-    /*+ "precision" */ DOUBLE PRECISION /*+ DEFAULT NULL */
+    /*+ "precision" */ DOUBLE PRECISION /*+ DEFAULT -1 */
 ) (
     SFUNC=MADLIB_SCHEMA.wsr_test_transition,
     STYPE=DOUBLE PRECISION[],

--- a/src/utils/Reference.hpp
+++ b/src/utils/Reference.hpp
@@ -74,6 +74,10 @@ public:
      * operator= would be used even though there is a conversion path
      * through dest.operator=(orig.operator U())
      */
+    MutableReference &operator=(const MutableReference& inReference) {
+        return this->operator=(static_cast<const Base&>(inReference));
+    }
+
     MutableReference &operator=(const Base &inReference) {
         *mPtr = *inReference.ptr();
         return *this;


### PR DESCRIPTION
**Contains the following changes:**

Wilcoxon-Signed-Rank test: Changes semantics for precision argument, Documentation update

Jira: MADLIB-405, MADLIB-534, MADLIB-553

Probability functions:
- Hollander/Wolfe ("Nonparametric statistical methods", 2nd ed., p. 38, 1999) confirm the formula that we have been using. The warning about conflicting source has been deleted. (MADLIB-405)
- No longer treat NULL as special value for precision argument (MADLIB-534)
- Negative precision will now result in using the default precision, non-finite precision will be rejected (MADLIB-553)

SQL2C++ converter:
- Support for unary expressions (needed for negative default arguments)

Probability functions (Extreme-value/Exponential): Fixed handling of non-finite parameters

Jira: MADLIB-555, MADLIB-556

These are boost "bugs". Implemented fixes for the cases where boost does not catch non-finite parameters.

Probability functions: Documentation update

Jira: MADLIB-546

Fixes:
- Noncentrality parameter for Chi-squared may also be 0

Kolmogorov-Smirnov test: Fixed wrong calculation of test statistic

Jira: MADLIB-554

Fixed the following issue:
Whenever, we saw a new row, we computed the distance of the empirical distribution functions at the current position as

```
double diff = std::fabs(state.num(0) / state.expectedNum(0)
                - state.num(1) / state.expectedNum(1));
```

This could give wrong results in case of ties. After all, we increased state.num(0) and state.num(1) one after the other, so diff could temporarily be larger than it would be at the end of a group of ties.

One-way ANOVA: return NULL for p-values if d.f. <= 0 instead of raising error

Jira: MADLIB-552
