### PR TITLE
Probability functions: Improved corner-case handling for [negative_]binomial functions

### DIFF
--- a/src/ports/postgres/modules/prob/prob.sql_in
+++ b/src/ports/postgres/modules/prob/prob.sql_in
@@ -689,7 +689,7 @@ IMMUTABLE STRICT;
 /**
  * @brief Inverse Gamma quantile function
  *
- * @param p Probability \f$ p \in (0,1] \f$
+ * @param p Probability \f$ p \in [0,1] \f$
  * @param shape Shape \f$ \alpha > 0 \f$
  * @param scale Scale \f$ \beta > 0 \f$
  * @return \f$ x \f$ such that \f$ p = \Pr[X \leq x] \f$ where \f$ X \f$ is
@@ -901,7 +901,7 @@ IMMUTABLE STRICT;
  * @param x Random variate \f$ x \f$
  * @param r Total number \f$ r > 0 \f$ of successes in \f$ x + r \f$ trials
  *     (assuming success in the last trial)
- * @param sp Success probability \f$ \mathit{sp} \in [0,1] \f$ in each trial
+ * @param sp Success probability \f$ \mathit{sp} \in (0,1] \f$ in each trial
  * @return \f$ \Pr[X \leq x] \f$ where \f$ X \f$ is a negative-binomially
  *     distributed random variable with parameters \f$ r, \mathit{sp} \f$
  */
@@ -920,7 +920,7 @@ IMMUTABLE STRICT;
  * @param x Random variate \f$ x \f$
  * @param r Total number \f$ r > 0 \f$ of successes in \f$ x + r \f$ trials
  *     (assuming success in the last trial)
- * @param sp Success probability \f$ \mathit{sp} \in [0,1] \f$ in each trial
+ * @param sp Success probability \f$ \mathit{sp} \in (0,1] \f$ in each trial
  * @return \f$ f(x) \f$ where \f$ f \f$ is the probability mass function of
  *     a negative-binomially distributed random variable with parameters
  *     \f$ r, \mathit{sp} \f$
@@ -940,7 +940,7 @@ IMMUTABLE STRICT;
  * @param p Probability \f$ p \in [0,1] \f$
  * @param r Total number \f$ r > 0 \f$ of successes in \f$ x + r \f$ trials
  *     (assuming success in the last trial)
- * @param sp Success probability \f$ \mathit{sp} \in [0,1] \f$ in each trial
+ * @param sp Success probability \f$ \mathit{sp} \in (0,1] \f$ in each trial
  * @return If \f$ p \leq 0.5 \f$ the maximum \f$ x \f$ such that
  *     \f$ p \geq \Pr[X \leq x] \f$. If \f$ p > 0.5 \f$ the minimum \f$ x \f$
  *     such that \f$ p \leq \Pr[X \leq x] \f$. Here, \f$ X \f$ is

--- a/src/ports/postgres/modules/prob/test/prob.sql_in
+++ b/src/ports/postgres/modules/prob/test/prob.sql_in
@@ -329,7 +329,9 @@ SELECT assert(
 SELECT assert(
     relative_error(binomial_quantile(0.2962843, 11, 0.4), 3) < 1e-5 AND
     binomial_quantile(0, 11, 0.4) = 0 AND
-    binomial_quantile(1, 11, 0.4) = 11 ,
+    binomial_quantile(1, 11, 0.4) = 11 AND
+    binomial_quantile(0.5, 20, 1) = 20 AND
+    binomial_quantile(0.5, 20, 0) = 0,
 
     'Binomial quantile: Wrong handling regular values'
 );
@@ -1691,11 +1693,11 @@ SELECT assert(
 );
 
 SELECT assert(
-    NOT check_if_raises_error($$SELECT negative_binomial_cdf(0, 1, 0)$$) AND
+    check_if_raises_error($$SELECT negative_binomial_cdf(0, 1, 0)$$) AND
     check_if_raises_error($$SELECT negative_binomial_cdf(0, 1, 2)$$) AND
     check_if_raises_error($$SELECT negative_binomial_cdf(0, 1, -1)$$),
 
-    'Negative binomial CDF: succ_prob out of range [0,1] does not raise error.'
+    'Negative binomial CDF: succ_prob out of range (0,1] does not raise error.'
 );
 
 -- negative_binomial_pmf
@@ -1728,11 +1730,11 @@ SELECT assert(
 );
 
 SELECT assert(
-    NOT check_if_raises_error($$SELECT negative_binomial_pmf(0, 1, 0)$$) AND
+    check_if_raises_error($$SELECT negative_binomial_pmf(0, 1, 0)$$) AND
     check_if_raises_error($$SELECT negative_binomial_pmf(0, 1, 2)$$) AND
     check_if_raises_error($$SELECT negative_binomial_pmf(0, 1, -1)$$),
 
-    'Negative binomial PMF: succ_prob out of range [0,1] does not raise error.'
+    'Negative binomial PMF: succ_prob out of range (0,1] does not raise error.'
 );
 
 -- negative_binomial_quantile
@@ -1753,7 +1755,8 @@ SELECT assert(
     relative_error(negative_binomial_quantile(0.003906407, 11, 0.4), 3) < 1e-5 AND
     relative_error(negative_binomial_quantile(0.22805, 11, 0.4), 11) < 1e-5 AND
     relative_error(negative_binomial_quantile(0.287089336441514, 11, 0.4), 12) < 1e-5 AND
-    negative_binomial_quantile(1, 11, 0.4) = 'Inf',
+    negative_binomial_quantile(1, 11, 0.4) = 'Inf' AND
+    negative_binomial_quantile(0.5, 20, 1) = 0,
 
     'Negative binomial Quantile: Wrong handling regular values'
 );
@@ -1766,11 +1769,11 @@ SELECT assert(
 );
 
 SELECT assert(
-    NOT check_if_raises_error($$SELECT negative_binomial_quantile(0, 1, 0)$$) AND
+    check_if_raises_error($$SELECT negative_binomial_quantile(0, 1, 0)$$) AND
     check_if_raises_error($$SELECT negative_binomial_quantile(0, 1, 2)$$) AND
     check_if_raises_error($$SELECT negative_binomial_quantile(0, 1, -1)$$),
 
-    'Negative binomial Quantile: succ_prob out of range [0,1] does not raise error.'
+    'Negative binomial Quantile: succ_prob out of range (0,1] does not raise error.'
 );
 
 SELECT assert(


### PR DESCRIPTION
Jira: MADLIB-537, MADLIB-544

Fixes:
- binomial and negative_binomial: Corner cases with success probability 0 or 1 are overridden, instead of being wrongly handled by boost
- Disallow success probability 0 for negative binomial
- Documentation: inverse_gamma_quantile() now accepts probability 0 (MADLIB-544)
- New unit tests for the above
