### PR TITLE
Automatic downloads of 3rd-party source through madlib.net

### DIFF
--- a/configure
+++ b/configure
@@ -23,7 +23,9 @@ cd ..
 
 cat <<MAKEFILE >Makefile
 
-all %:
+all:
+
+%:
 	\$(MAKE) -C build \$@
 clean:
 	rm -f Makefile

--- a/deploy/PGXN/package.sh
+++ b/deploy/PGXN/package.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
 GIT_URL=$1
+BRANCH=$2
 
 if [ -z $GIT_URL ]; then
-    echo "$0 GIT_URL"
+    echo "$0 GIT_URL BRANCH"
     exit;
 fi
 
@@ -11,7 +12,7 @@ ORIG=`pwd`
 TEMPDIR=`mktemp -d -t madlib`
 cd $TEMPDIR
 
-git clone $GIT_URL madlib
+git clone $GIT_URL madlib && (cd madlib; git checkout $BRANCH)
 
 # This is the version string for the distribution.
 VERSION=`cat madlib/deploy/PGXN/dist.ver`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,12 +5,18 @@
 # -- Paths and MD5 hashes of third-party downloadable source code (third-party
 #    components needed only by specific ports are downloaded there) ------------
 
+set(MADLIB_REDIRECT_PREFIX "http://madlib.net/redirects/third_party.php?url=")
+
 # For in-house testing, we might want to change the base URLs of code-hosting
 # sites to something local
 # "-DSOURCEFORGE_BASE_URL=http://test.local/projects"
-set(SOURCEFORGE_BASE_URL "http://sourceforge.net/projects" CACHE STRING
+set(SOURCEFORGE_BASE_URL
+    "${MADLIB_REDIRECT_PREFIX}http://sourceforge.net/projects"
+    CACHE STRING
     "Base URL for Sourceforge projects. May be overridden for testing purposes.")
-set(BITBUCKET_BASE_URL "https://bitbucket.org" CACHE STRING
+set(BITBUCKET_BASE_URL
+    "${MADLIB_REDIRECT_PREFIX}https://bitbucket.org"
+    CACHE STRING
     "Base URL for Bitbucket projects. May be overridden for testing purposes.")
 
 # Boost might not be present on the system (or simply too old). In this case, we
@@ -46,7 +52,6 @@ set(EIGEN_TAR_MD5 695f24be85c4fe957ce6a4dd11161f48)
 
 set(EIGEN_TAR "eigen-${EIGEN_VERSION}.tar.gz")
 set(EIGEN_URL "${BITBUCKET_BASE_URL}/eigen/eigen/get/${EIGEN_VERSION}.tar.gz")
-set(EIGEN_SVN "${BITBUCKET_BASE_URL}/eigen/eigen/tags/${EIGEN_VERSION}")
 
 if(NOT EIGEN_TAR_SOURCE)
     find_file(EIGEN_TAR_SOURCE ${EIGEN_TAR}
@@ -130,28 +135,13 @@ endif(Boost_FOUND)
 
 # -- Third-party dependencies: Download the C++ linear-algebra library Eigen ---
 
-string(REGEX MATCH "^[a-zA-Z]+" _EIGEN_PROTOCOL ${EIGEN_TAR_SOURCE})
-if(_EIGEN_PROTOCOL STREQUAL "https")
-    # FIXME: This is somewhat ugly
-    # Unfortunately, CMake does not come with SSL support for file downloads.
-    # See: http://www.cmake.org/pipermail/cmake/2009-November/thread.html#33589
-    # Bitbucket on the other hand only provides SSL downloads
-    # We therefore assume that a "https" protocol refers to a SVN repository
-    set(_EIGEN_SOURCE
-        SVN_REPOSITORY ${EIGEN_SVN} UPDATE_COMMAND /usr/bin/env echo Ignored: svn update
-    )
-else(_EIGEN_PROTOCOL STREQUAL "https")
-    set(_EIGEN_SOURCE
-        URL ${EIGEN_TAR_SOURCE} URL_MD5 ${EIGEN_TAR_MD5}
-    )
-endif(_EIGEN_PROTOCOL STREQUAL "https")
-
 # FIXME: Eigen is a third-party source that is patched in-place. Other
 # third-party headers are patched in the patch directory.
 ExternalProject_Add(EP_eigen
     PREFIX ${MAD_THIRD_PARTY}
     DOWNLOAD_DIR ${MAD_THIRD_PARTY}/downloads
-    ${_EIGEN_SOURCE}
+    URL ${EIGEN_TAR_SOURCE}
+    URL_MD5 ${EIGEN_TAR_MD5}
     PATCH_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/patch/Eigen.sh"
     CMAKE_COMMAND /usr/bin/env echo Ignored: cmake
     BUILD_COMMAND /usr/bin/env echo Ignored: make

--- a/src/ports/postgres/CMakeLists.txt
+++ b/src/ports/postgres/CMakeLists.txt
@@ -326,7 +326,7 @@ function(add_extension_support)
         COMMAND ${CMAKE_COMMAND} -E copy_directory
             ${CMAKE_CURRENT_BINARY_DIR}/modules ${${DBMS_UC}_SHARE_DIR}/madlib/modules
         COMMAND ${CMAKE_COMMAND} -E copy
-            ${CMAKE_CURRENT_BINARY_DIR}/lib/libmadlib.so ${${DBMS_UC}_LIB_DIR}
+            ${CMAKE_CURRENT_BINARY_DIR}/lib/libmadlib.so ${${DBMS_UC}_PKGLIB_DIR}
         COMMAND ${CMAKE_COMMAND} -E copy
             ${EXTENSION_SQL} ${${DBMS_UC}_SHARE_DIR}/extension/
         COMMAND ${CMAKE_COMMAND} -E copy

--- a/src/ports/postgres/cmake/FindPostgreSQL.cmake
+++ b/src/ports/postgres/cmake/FindPostgreSQL.cmake
@@ -22,6 +22,7 @@
 #  ${PKG_NAME}_FOUND - set to true if headers and binary were found
 #  ${PKG_NAME}_LIB_DIR - PostgreSQL library directory
 #  ${PKG_NAME}_SHARE_DIR - PostgreSQL share directory
+#  ${PKG_NAME}_PKGLIB_DIR - PostgreSQL package library directory
 #  ${PKG_NAME}_CLIENT_INCLUDE_DIR - client include directory
 #  ${PKG_NAME}_SERVER_INCLUDE_DIR - server include directory
 #  ${PKG_NAME}_EXECUTABLE - path to postgres binary
@@ -159,6 +160,11 @@ if(${PKG_NAME}_PG_CONFIG AND ${PKG_NAME}_CLIENT_INCLUDE_DIR)
 
             execute_process(COMMAND ${${PKG_NAME}_PG_CONFIG} --sharedir
                 OUTPUT_VARIABLE ${PKG_NAME}_SHARE_DIR
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+
+            execute_process(COMMAND ${${PKG_NAME}_PG_CONFIG} --pkglibdir
+                OUTPUT_VARIABLE ${PKG_NAME}_PKGLIB_DIR
                 OUTPUT_STRIP_TRAILING_WHITESPACE
             )
 


### PR DESCRIPTION
Jira: MADLIB-604

By default, all URLs of third-party software is now prefixed with
"http://madlib.net/redirects/third_party.php?url=". This gives us a chance
of intercepting and redirecting in case the third-party software is no
longer available.
