### PR TITLE
C++ AL: Treat MemoryContext as a hint only during memory allocations

### DIFF
--- a/src/dbal/dbal.hpp
+++ b/src/dbal/dbal.hpp
@@ -35,6 +35,14 @@ enum Mutability {
     Mutable
 };
 
+/**
+ * @brief Memory context to use for allocation (hint only)
+ *
+ * This is only meant to be a hint to the platform-specific parts of the AL.
+ * An implementation may choose to perform an allocation in a specific aggregate
+ * context if the memory needs to live longer than the current function call.
+ * It should be used, e.g., when allocating transition states.
+ */
 enum MemoryContext {
     FunctionContext,
     AggregateContext

--- a/src/ports/greenplum/dbconnector/Compatibility.hpp
+++ b/src/ports/greenplum/dbconnector/Compatibility.hpp
@@ -42,6 +42,10 @@ namespace {
  *
  * This function is essentially a copy of AggCheckCallContext from
  * backend/executor/nodeAgg.c, which is part of PostgreSQL >= 9.0.
+ *
+ * @warning The AggState struct is known to have changed between GPDB 4.2.1 and
+ *     GPDB 4.2.2. Essentially, this imnplies that it is not safe to ever rely
+ *     on what \c aggcontext will be set to!
  */
 inline
 int

--- a/src/ports/postgres/dbconnector/Allocator_impl.hpp
+++ b/src/ports/postgres/dbconnector/Allocator_impl.hpp
@@ -341,8 +341,6 @@ Allocator::internalAllocate(void *inPtr, const size_t inSize) const {
 
     void *ptr;
     bool errorOccurred = false;
-    MemoryContext oldContext = NULL;
-    MemoryContext aggContext = NULL;
 
     if (F == dbal::ReturnNULL) {
         /*
@@ -355,19 +353,20 @@ Allocator::internalAllocate(void *inPtr, const size_t inSize) const {
     }
 
     PG_TRY(); {
-        if (MC == dbal::AggregateContext) {
-            if (!AggCheckCallContext(fcinfo, &aggContext))
-                errorOccurred = true;
-            else {
-                oldContext = MemoryContextSwitchTo(aggContext);
-                ptr = (R == Reallocation) ? internalRePalloc<ZM>(inPtr, inSize)
-                                          : internalPalloc<ZM>(inSize);
-                MemoryContextSwitchTo(oldContext);
-            }
-        } else {
-            ptr = R ? internalRePalloc<ZM>(inPtr, inSize)
-                    : internalPalloc<ZM>(inSize);
-        }
+        /*
+         * We used to respect the request for MC == dbal::AggregateContext here,
+         * but current PostgreSQL/Greenplum versions do not take any advantage
+         * of transition states allocated in the aggregate context anyways.
+         * They still copy the transition state, whenever the address of the
+         * returned state is different from the address of the input state.
+         *
+         * Any other use of the aggregate context (say, auxiliary data/caches
+         * for transition states) is not currently supported by the C++ AL.
+         *
+         * See also: MADLIB-606 (issue that triggered this code change).
+         */
+        ptr = R ? internalRePalloc<ZM>(inPtr, inSize)
+                : internalPalloc<ZM>(inSize);
     } PG_CATCH(); {
         if (F == dbal::ReturnNULL) {
             /*
@@ -393,22 +392,6 @@ Allocator::internalAllocate(void *inPtr, const size_t inSize) const {
             errorOccurred = true;
         }
     } PG_END_TRY();
-
-    if (errorOccurred) {
-        PG_TRY(); {
-            // Clean up after ourselves
-            if (oldContext != NULL)
-                MemoryContextSwitchTo(oldContext);
-        } PG_CATCH(); {
-            if (F == dbal::ReturnNULL) {
-                // We tried to clean up after ourselves. If this fails, we can
-                // only ignore the issue.
-                FlushErrorState();
-            }
-            // Else do nothing. We will add a bad-allocation exception on top of
-            // the existing PostgreSQL exception stack.
-        } PG_END_TRY();
-    }
 
     if (F == dbal::ReturnNULL) {
         RESUME_INTERRUPTS();


### PR DESCRIPTION
Jira: MADLIB-606

We used to respect the request for dbal::AggregateContext when doing memory
allocations, but current PostgreSQL/Greenplum versions do not take any advantage
of transition states allocated in the aggregate context anyway. They still copy
the transition state, whenever the address of the returned state is different
from the address of the input state.

Other uses of the aggregate context (say, auxiliary data/caches for transition
states) are not currently supported by the C++ AL.

MADLIB-606 was eventually the trigger for this change.
