### PR TITLE
Fixed documentation for hypothesis tests

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -1,3 +1,53 @@
+# Define GNU M4 preprocessor macros
+#
+# Generate M4 code and M4 command-line arguments to define a set of macros that
+# will be available to non-compiled source code (SQL, Python).
+#
+# It is expected that the caller has defined the following variables:
+# PORT_UC
+# DBMS
+# DBMS_UC
+# ${DBMS_UC}_VERSION_MAJOR
+# ${DBMS_UC}_VERSION_MINOR
+# ${DBMS_UC}_VERSION_PATCH
+# ${DBMS_UC}_ARCHITECTURE
+function(define_m4_macros OUT_M4_CMD_LINE OUT_M4_CODE)
+    set(IN_FEATURES ${ARGN})
+
+    set(MACROS
+        "${PORT_UC}"
+        "__${PORT_UC}__"
+        "__PORT__=${PORT_UC}"
+        "__DBMS__=${DBMS}"
+        "__DBMS_VERSION__=${${DBMS_UC}_VERSION_STRING}"
+        "__DBMS_VERSION_MAJOR__=${${DBMS_UC}_VERSION_MAJOR}"
+        "__DBMS_VERSION_MINOR__=${${DBMS_UC}_VERSION_MINOR}"
+        "__DBMS_VERSION_PATCH__=${${DBMS_UC}_VERSION_PATCH}"
+        "__DBMS_ARCHITECTURE__=${${DBMS_UC}_ARCHITECTURE}"
+        "__MADLIB_VERSION__=${MADLIB_VERSION_STRING}"
+        "__MADLIB_VERSION_MAJOR__=${MADLIB_VERSION_MAJOR}"
+        "__MADLIB_VERSION_MINOR__=${MADLIB_VERSION_MINOR}"
+        "__MADLIB_VERSION_PATCH__=${MADLIB_VERSION_PATCH}"
+        "__MADLIB_GIT_REVISION__=${MADLIB_GIT_REVISION}"
+        "__MADLIB_BUILD_TIME__=${MADLIB_BUILD_TIME}"
+        "__MADLIB_BUILD_TYPE__=${CMAKE_BUILD_TYPE}"
+        "__MADLIB_BUILD_SYSTEM__=${CMAKE_SYSTEM}"
+        "__MADLIB_C_COMPILER__=${MADLIB_C_COMPILER}"
+        "__MADLIB_CXX_COMPILER__=${MADLIB_CXX_COMPILER}"
+        ${IN_FEATURES}
+    )
+    list_replace("^(.+)$" "-D\\\\1" ${OUT_M4_CMD_LINE} ${MACROS})
+    list_replace("^([^=]+)$" "m4_define(`\\\\1')" ${OUT_M4_CODE} ${MACROS})
+    list_replace("^([^=]+)=(.+)$" "m4_define(`\\\\1', ``\\\\2'')" ${OUT_M4_CODE}
+        ${${OUT_M4_CODE}})
+    string(REGEX REPLACE ";" "\\n" ${OUT_M4_CODE} "${${OUT_M4_CODE}}")
+
+    # Pass values to caller
+    set(${OUT_M4_CMD_LINE} "${${OUT_M4_CMD_LINE}}" PARENT_SCOPE)
+    set(${OUT_M4_CODE} "${${OUT_M4_CODE}}" PARENT_SCOPE)
+endfunction(define_m4_macros)
+
+
 macro(join_strings OUT_STRING SEPARATOR LIST)
     foreach(ITEM ${LIST})
         if("${${OUT_STRING}}" STREQUAL "")
@@ -29,14 +79,14 @@ macro(architecture FILENAME OUT_ARCHITECTURE)
             COMMAND file "${FILENAME}"
             OUTPUT_VARIABLE _FILE_OUTPUT
             OUTPUT_STRIP_TRAILING_WHITESPACE)
-        
+
         # Filter out known architectures
         string(REGEX MATCHALL "x86[-_]64|i386|ppc|ppc64" _ARCHITECTURE "${_FILE_OUTPUT}")
-        
+
         # Normalize (e.g., some vendors use x86-64 instead of x86_64)
         string(REGEX REPLACE "x86[-_]64" "x86_64" _ARCHITECTURE "${_ARCHITECTURE}")
     endif(APPLE)
-    
+
     list(REMOVE_DUPLICATES _ARCHITECTURE)
     list(LENGTH _ARCHITECTURE _ARCHITECTURE_LENGTH)
     if(_ARCHITECTURE_LENGTH GREATER 1)
@@ -57,7 +107,7 @@ endmacro(word_length)
 
 # Given the length of the parameter list, we require named arguments.
 # IN_COMMAND can contain "\${CURRENT_PATH}" and "\${OUTFILE}"
-# IN_COMMENT can contain "\${CURRENT_FILE}" which will be substituted by the 
+# IN_COMMENT can contain "\${CURRENT_FILE}" which will be substituted by the
 # current file
 macro(batch_add_command
     ARG_NAME_1 IN_TARGET_PREFIX
@@ -68,7 +118,7 @@ macro(batch_add_command
     ARG_NAME_6 IN_COMMENT
     ARG_NAME_7 OUT_TARGET_FILES
     ARG_NAME_8)
-    
+
     if( (NOT ("${ARG_NAME_1}" STREQUAL TARGET_PREFIX)) OR
         (NOT ("${ARG_NAME_2}" STREQUAL SOURCE_PREFIX)) OR
         (NOT ("${ARG_NAME_3}" STREQUAL TARGET_SUFFIX)) OR
@@ -77,21 +127,21 @@ macro(batch_add_command
         (NOT ("${ARG_NAME_6}" STREQUAL COMMENT)) OR
         (NOT ("${ARG_NAME_7}" STREQUAL TARGET_FILE_LIST_REF)) OR
         (NOT ("${ARG_NAME_8}" STREQUAL SOURCE_FILE_LIST)) )
-        
+
         message(FATAL_ERROR "Missing (or misspelled) arguments given to batch_add_command().")
     endif()
-    set(IN_SOURCE_FILE_LIST ${ARGN})    
-    
+    set(IN_SOURCE_FILE_LIST ${ARGN})
+
     foreach(CURRENT_FILE ${IN_SOURCE_FILE_LIST})
         get_filename_component(CURRENT_PATH "${IN_SOURCE_PREFIX}${CURRENT_FILE}" ABSOLUTE)
-        
+
         set(OUTFILE "${IN_TARGET_PREFIX}${CURRENT_FILE}")
         if(NOT ("${IN_SOURCE_SUFFIX}" STREQUAL ""))
             string(REGEX REPLACE "${IN_SOURCE_SUFFIX}\$" "${IN_TARGET_SUFFIX}"
                 OUTFILE "${OUTFILE}")
         endif(NOT ("${IN_SOURCE_SUFFIX}" STREQUAL ""))
         get_dir_name(OUTDIR ${OUTFILE})
-        
+
         string(REPLACE "\${CURRENT_PATH}" "${CURRENT_FILE}" IN_COMMAND "${IN_COMMAND}")
         string(REPLACE "\${OUTFILE}" "${OUTFILE}" IN_COMMAND "${IN_COMMAND}")
         string(REPLACE "\${OUTDIR}" "${OUTDIR}" IN_COMMAND "${IN_COMMAND}")
@@ -101,7 +151,7 @@ macro(batch_add_command
             ${IN_COMMAND}
             DEPENDS "${CURRENT_PATH}"
             COMMENT "${IN_COMMENT}")
-        
+
         list(APPEND ${OUT_TARGET_FILES}
             ${OUTFILE})
     endforeach(CURRENT_FILE)
@@ -160,7 +210,7 @@ endmacro(get_max_version)
 
 macro(get_filtered_list OUT_LIST IN_REGEX)
     set(IN_LIST ${ARGN})
-    
+
     set(${OUT_LIST} "")
     foreach(ITEM ${IN_LIST})
         if("${ITEM}" MATCHES "${IN_REGEX}")
@@ -171,7 +221,7 @@ endmacro(get_filtered_list)
 
 macro(list_replace IN_REGEX IN_REPLACE_STRING OUT_LIST)
     set(IN_LIST ${ARGN})
-    
+
     set(${OUT_LIST})
     foreach(ITEM ${IN_LIST})
         string(REGEX REPLACE "${IN_REGEX}" "${IN_REPLACE_STRING}" ITEM_REPLACED "${ITEM}")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -51,6 +51,19 @@ set(DOXYGEN_HTML_OUTPUT html CACHE STRING
     "Path (relative to \${DOXYGEN_OUTPUT_<config>} where HTML docs will be put."
 )
 
+# -- Set macros for SQL/Python files -------------------------------------------
+
+set(PORT_UC "DOXYGEN")
+set(DBMS "doxygen")
+set(DBMS_UC "${PORT_UC}")
+set(${DBMS_UC}_VERSION_STRING "0.0.0")
+set(${DBMS_UC}_VERSION_MAJOR "0")
+set(${DBMS_UC}_VERSION_MINOR "0")
+set(${DBMS_UC}_VERSION_PATCH "0")
+set(${DBMS_UC}_ARCHITECTURE "all")
+set(DBMS_FEATURES "__HAS_ORDERED_AGGREGATES__")
+define_m4_macros(M4_DEFINES_CMD_LINE M4_DEFINES_CODE ${DBMS_FEATURES})
+
 
 # -- Build doxysql (the SQL parser) using flex and bison -----------------------
 

--- a/doc/bin/CMakeLists.txt
+++ b/doc/bin/CMakeLists.txt
@@ -10,19 +10,11 @@ add_custom_target(doxyBinFiles ALL DEPENDS ${BIN_TARGET_FILES})
 
 list(APPEND M4_ARGUMENTS
     "\"-DMADLIB_SCHEMA=MADlib\""
-    "\"-I${CMAKE_CURRENT_BINARY_DIR}/tmp\""
+    "\"-I${CMAKE_BINARY_DIR}/doc/etc\""
 )
-
 join_strings(_M4_ARGUMENTS " " "${M4_ARGUMENTS}")
+set(_M4_ARGUMENTS "${_M4_ARGUMENTS}")
+
 configure_file(py_filter.sh.in py_filter.sh @ONLY)
-
-execute_process(
-    COMMAND
-        "${CMAKE_COMMAND}" -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/tmp"
-    COMMAND
-        "${CMAKE_COMMAND}" -E touch
-            "${CMAKE_CURRENT_BINARY_DIR}/tmp/SQLCommon.m4"
-)
 configure_file(sql_filter.sh.in sql_filter.sh @ONLY)
-
 configure_file(update_mathjax.sh.in update_mathjax.sh @ONLY)

--- a/doc/etc/CMakeLists.txt
+++ b/doc/etc/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 configure_file(user.doxyfile.in user.doxyfile)
 configure_file(developer.doxyfile.in developer.doxyfile)
+configure_file(SQLCommon.m4_in SQLCommon.m4)
 
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/doxygen.css

--- a/doc/etc/SQLCommon.m4_in
+++ b/doc/etc/SQLCommon.m4_in
@@ -1,0 +1,4 @@
+/*
+ * During build time, macro definitions will be inserted here.
+ */
+@M4_DEFINES_CODE@

--- a/src/ports/postgres/cmake/PostgreSQLUtils.cmake
+++ b/src/ports/postgres/cmake/PostgreSQLUtils.cmake
@@ -9,48 +9,6 @@ function(define_postgresql_features IN_VERSION OUT_FEATURES)
     set(${OUT_FEATURES} "${${OUT_FEATURES}}" PARENT_SCOPE)
 endfunction(define_postgresql_features)
 
-# Define GNU M4 preprocessor macros
-#
-# Generate M4 code and M4 command-line arguments to define a set of macros that
-# will be available to non-compiled source code (SQL, Python).
-#
-function(define_m4_macros OUT_M4_CMD_LINE OUT_M4_CODE)
-    set(IN_FEATURES ${ARGN})
-
-    set(MACROS
-        "${PORT_UC}"
-        "__${PORT_UC}__"
-        "__PORT__=${PORT_UC}"
-        "__DBMS__=${DBMS}"
-        "__DBMS_VERSION__=${${DBMS_UC}_VERSION_STRING}"
-        "__DBMS_VERSION_MAJOR__=${${DBMS_UC}_VERSION_MAJOR}"
-        "__DBMS_VERSION_MINOR__=${${DBMS_UC}_VERSION_MINOR}"
-        "__DBMS_VERSION_PATCH__=${${DBMS_UC}_VERSION_PATCH}"
-        "__DBMS_ARCHITECTURE__=${${DBMS_UC}_ARCHITECTURE}"
-        "__MADLIB_VERSION__=${MADLIB_VERSION_STRING}"
-        "__MADLIB_VERSION_MAJOR__=${MADLIB_VERSION_MAJOR}"
-        "__MADLIB_VERSION_MINOR__=${MADLIB_VERSION_MINOR}"
-        "__MADLIB_VERSION_PATCH__=${MADLIB_VERSION_PATCH}"
-        "__MADLIB_GIT_REVISION__=${MADLIB_GIT_REVISION}"
-        "__MADLIB_BUILD_TIME__=${MADLIB_BUILD_TIME}"
-        "__MADLIB_BUILD_TYPE__=${CMAKE_BUILD_TYPE}"
-        "__MADLIB_BUILD_SYSTEM__=${CMAKE_SYSTEM}"
-        "__MADLIB_C_COMPILER__=${MADLIB_C_COMPILER}"
-        "__MADLIB_CXX_COMPILER__=${MADLIB_CXX_COMPILER}"
-        ${IN_FEATURES}
-    )
-    list_replace("^(.+)$" "-D\\\\1" ${OUT_M4_CMD_LINE} ${MACROS})
-    list_replace("^([^=]+)$" "m4_define(`\\\\1')" ${OUT_M4_CODE} ${MACROS})
-    list_replace("^([^=]+)=(.+)$" "m4_define(`\\\\1', ``\\\\2'')" ${OUT_M4_CODE}
-        ${${OUT_M4_CODE}})
-    string(REGEX REPLACE ";" "\\n" ${OUT_M4_CODE} "${${OUT_M4_CODE}}")
-    
-    # Pass values to caller
-    set(${OUT_M4_CMD_LINE} "${${OUT_M4_CMD_LINE}}" PARENT_SCOPE)
-    set(${OUT_M4_CODE} "${${OUT_M4_CODE}}" PARENT_SCOPE)
-endfunction(define_m4_macros)
-
-
 # Add the installer group for this port and a component for all files that are
 # not version-specific
 #


### PR DESCRIPTION
Jira: MADLIB-624

Commit 884ff80 introduced a regression in that the three ordered-aggregate tests
{ks|mw|wsr}_test did no longer show up in the documentation. This has been
fixed. Also, all SQL macros that are otherwise defined in "SQLCommon.m4" are now
also define when running doxygen. This should increase the compatibility in the
future.

Biggest change: I moved the CMake macro 'define_m4_macros' from
PostgreSQLUtils.cmake to Utils.cmake.
