### PR TITLE
Change the return type of rf_train from RECORD to rf_train_result.

### DIFF
--- a/methods/cart/src/pg_gp/rf.sql_in
+++ b/methods/cart/src/pg_gp/rf.sql_in
@@ -541,7 +541,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.rf_train
     node_split_threshold        FLOAT, 
     verbosity                   INT
     ) 
-RETURNS RECORD AS $$
+RETURNS MADLIB_SCHEMA.rf_train_result AS $$
 DECLARE
     begin_func_exec                 TIMESTAMP;
     rf_table_name                   TEXT;


### PR DESCRIPTION
JIRA: MADLIB-631
I tracked the history of the file in our local repository. It seems we made a mistake for replacement. The RECORD type will affect the cases which check the field in the result type.
