### PR TITLE
The wrong encoding result cases the scoring API failure.

### DIFF
--- a/methods/cart/src/pg_gp/dt_preproc.sql_in
+++ b/methods/cart/src/pg_gp/dt_preproc.sql_in
@@ -1079,7 +1079,11 @@ m4_changequote(>>>`<<<, >>>'<<<)
     IF (h2hmv_routine_id = 1) THEN
         where_txt = ' WHERE NULLIF(NULLIF(btrim(fval, '' ''), ''?''), '''') IS NOT NULL';
     ELSE
-        fval_txt  = ' NULLIF(NULLIF(btrim(fval, '' ''), ''?''), '''')';
+        fval_txt  = ' CASE WHEN NULLIF(NULLIF(btrim(fval, '' ''), ''?''), '''') IS NULL THEN
+                                NULL
+                            ELSE
+                                fval
+                      END '
     END IF;
     
     IF (cls_col_name IS NULL) THEN
@@ -1814,7 +1818,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
             cls_col_name,
             attr_col_names,
             is_conts,
-            2,
+            h2hmv_routine_id,
             verbosity
         );  
     

--- a/methods/cart/src/pg_gp/dt_preproc.sql_in
+++ b/methods/cart/src/pg_gp/dt_preproc.sql_in
@@ -1083,7 +1083,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
                                 NULL
                             ELSE
                                 fval
-                      END '
+                      END ';
     END IF;
     
     IF (cls_col_name IS NULL) THEN


### PR DESCRIPTION
JIRA: MADLIB-632
During encoding, we should not btrim the attribute value, since we will use it as join key between encoded table and raw training table. The second problem is we always use 'explict' option during encoding in classification/score. We should use the passed parameter.
