### PR TITLE
Fix a wrong check caused by new linregr

### DIFF
--- a/src/modules/regress/LinearRegression_impl.hpp
+++ b/src/modules/regress/LinearRegression_impl.hpp
@@ -80,6 +80,12 @@ LinearRegressionAccumulator<Container>::operator<<(const tuple_type& inTuple) {
         this->resize();
     }
 
+    // dimension check
+    if (widthOfX != static_cast<uint16_t>(x.size())) {
+        throw std::runtime_error("Inconsistent numbers of independent "
+            "variables.");
+    }
+
     numRows++;
     y_sum += y;
     y_square_sum += y * y;
@@ -100,16 +106,6 @@ inline
 LinearRegressionAccumulator<Container>&
 LinearRegressionAccumulator<Container>::operator<<(
     const LinearRegressionAccumulator<OtherContainer>& inOther) {
-
-    // Initialize if necessary
-    if (numRows == 0) {
-        *this = inOther;
-        return *this;
-    }
-
-    if (widthOfX != inOther.widthOfX)
-        throw std::runtime_error("Inconsistent numbers of independent "
-            "variables.");
 
     numRows += inOther.numRows;
     y_sum += inOther.y_sum;

--- a/src/modules/regress/linear.cpp
+++ b/src/modules/regress/linear.cpp
@@ -36,6 +36,14 @@ linregr_merge_states::run(AnyType& args) {
     MutableLinRegrState stateLeft = args[0].getAs<MutableByteString>();
     LinRegrState stateRight = args[1].getAs<ByteString>();
 
+    // We first handle the trivial case where this function is called with one
+    // of the states being the initial state
+    if (stateLeft.numRows == 0) {
+        return stateRight.storage();
+    } else if (stateRight.numRows == 0) {
+        return stateLeft.storage();
+    }
+
     stateLeft << stateRight;
     return stateLeft.storage();
 }


### PR DESCRIPTION
JIRA: MADLIB-637
A bug in merge function:
Wrong check was triggered if one of the segment is merged as a "stateRight" does not have tuples.
