### PR TITLE
insert the information of the columns in which all the values are null to the meta table

### DIFF
--- a/methods/cart/src/pg_gp/dt.sql_in
+++ b/methods/cart/src/pg_gp/dt.sql_in
@@ -4012,6 +4012,7 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__check_training_table
     ) 
 RETURNS VOID AS $$
 DECLARE
+    num_attrs                 INT;
 BEGIN
     PERFORM MADLIB_SCHEMA.__assert
         (
@@ -4043,10 +4044,12 @@ BEGIN
 
     IF (feature_col_names IS NULL) THEN
         -- 2 means the id and class column
+        num_attrs = MADLIB_SCHEMA.__num_of_columns(training_table_name) - 2;
+        
         PERFORM MADLIB_SCHEMA.__assert
             (
-                features_per_node IS NULL OR
-                MADLIB_SCHEMA.__num_of_columns(training_table_name) - 2 >= features_per_node,
+                (features_per_node IS NULL AND num_attrs > 0)  OR
+                (features_per_node IS NOT NULL AND num_attrs >= features_per_node),
                 'the value of features_per_node must be less than or equal to the total number ' ||
                 'of features of the training table'
            );        
@@ -4056,10 +4059,11 @@ BEGIN
                 'each feature in continuous_feature_names must be a column of the training table'
             );
     ELSE
+        num_attrs = array_upper(feature_col_names, 1);
         PERFORM MADLIB_SCHEMA.__assert
             (
-                features_per_node IS NULL OR
-                array_upper(feature_col_names, 1) >= features_per_node,
+                (features_per_node IS NULL AND num_attrs > 0) OR
+                (features_per_node IS NOT NULL AND num_attrs >= features_per_node),
                 'the value of features_per_node must be less than or equal to the total number ' ||
                 'of features of the training table'
            );    

--- a/methods/cart/src/pg_gp/dt_preproc.sql_in
+++ b/methods/cart/src/pg_gp/dt_preproc.sql_in
@@ -1633,6 +1633,29 @@ m4_changequote(>>>`<<<, >>>'<<<)
 
     EXECUTE curstmt;
 
+    IF (h2hmv_routine_id = 1) THEN
+        -- retrieve the information of the columns (all the values in those 
+        -- columns are missing), and insert them to the meta table. 
+        curstmt = MADLIB_SCHEMA.__format
+            (
+                'INSERT INTO %
+                 SELECT id, (ARRAY[''%''])[id] as column_name,
+                        ''f'' as column_type, ''t'', NULL, 0
+                 FROM (
+                     SELECT generate_series(1, %) id
+                     EXCEPT
+                     SELECT id FROM % WHERE column_type = ''f'' 
+                 ) t',
+                ARRAY[
+                    meta_tbl_name,
+                    array_to_string(attr_col_names, ''','''),
+                    array_upper(attr_col_names, 1)::TEXT,
+                    meta_tbl_name
+                ]
+            );
+        EXECUTE curstmt;
+    END IF;
+    
     -- no need this table
     EXECUTE 'DROP TABLE IF EXISTS tmp_dist_table';
 

--- a/methods/cart/src/pg_gp/dt_preproc.sql_in
+++ b/methods/cart/src/pg_gp/dt_preproc.sql_in
@@ -1085,7 +1085,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
                                 fval
                       END ';
     END IF;
-    
+
     IF (cls_col_name IS NULL) THEN
         -- if the kv_cls_name is null, then the class column will be null        
         curstmt = MADLIB_SCHEMA.__format
@@ -1459,9 +1459,9 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__encode_table
     ) 
 RETURNS VOID AS $$
 DECLARE
-    column_name         TEXT :='';
     curstmt             TEXT := '';
     attr_col_names      TEXT[]; 
+    lit_attr_col_names  TEXT[];
     kv_attr_name        TEXT := enc_table_name || '_col';
     kv_cls_name         TEXT := enc_table_name || '_class';
     is_conts            BOOL[];
@@ -1489,7 +1489,7 @@ m4_changequote(`>>>', `<<<')
 m4_ifdef(`__HAS_ORDERED_AGGREGATES__', >>>
         curstmt = MADLIB_SCHEMA.__format
             (
-                'SELECT array_agg(attname ORDER BY attname) as attnames 
+                'SELECT array_agg(quote_ident(attname) ORDER BY attname) as attnames 
                  FROM   pg_attribute 
                  WHERE  attrelid = ''%''::regclass and attnum > 0 AND 
                         attname <> ''%'' AND
@@ -1508,7 +1508,7 @@ m4_ifdef(`__HAS_ORDERED_AGGREGATES__', >>>
             (
                 'SELECT ARRAY
                  (
-                 SELECT attname 
+                 SELECT quote_ident(attname) 
                  FROM   pg_attribute 
                  WHERE  attrelid = ''%''::regclass and attnum > 0 AND 
                         attname <> ''%'' AND
@@ -1536,7 +1536,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
 
     ret.pre_proc_time = clock_timestamp() - exec_begin;
     exec_begin = clock_timestamp();
-    
+
     -- create the KV table for the class column.
     EXECUTE 'DROP TABLE IF EXISTS ' || kv_cls_name;
     curstmt = MADLIB_SCHEMA.__format
@@ -1566,7 +1566,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
     
     ret.gen_kv_time = clock_timestamp() - exec_begin;
     exec_begin = clock_timestamp();
-
+    
     -- breakup each record of the training table and keep the result
     -- into a new table.
     PERFORM MADLIB_SCHEMA.__breakup_table
@@ -1612,11 +1612,13 @@ m4_changequote(>>>`<<<, >>>'<<<)
     ret.gen_enc_time = clock_timestamp() - exec_begin;
     exec_begin = clock_timestamp();
     
+    SELECT ARRAY(SELECT quote_literal(unnest(attr_col_names))) INTO lit_attr_col_names;
+    
     -- put the features' meta information to the metatable
     curstmt = MADLIB_SCHEMA.__format
         (
             'INSERT INTO %
-             SELECT fid as id, (ARRAY[''%''])[fid] as column_name,
+             SELECT fid as id, (ARRAY[%])[fid] as column_name,
                     ''f'' as column_type,
                     is_cont,
                     ''%''::regclass::OID,
@@ -1625,7 +1627,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
              GROUP BY fid, is_cont',
             ARRAY[
                 meta_tbl_name,
-                array_to_string(attr_col_names, ''','''),
+                array_to_string(lit_attr_col_names, ','),
                 kv_attr_name,                
                 'tmp_dist_table'
             ]
@@ -1639,7 +1641,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
         curstmt = MADLIB_SCHEMA.__format
             (
                 'INSERT INTO %
-                 SELECT id, (ARRAY[''%''])[id] as column_name,
+                 SELECT id, (ARRAY[%])[id] as column_name,
                         ''f'' as column_type, ''t'', NULL, 0
                  FROM (
                      SELECT generate_series(1, %) id
@@ -1648,7 +1650,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
                  ) t',
                 ARRAY[
                     meta_tbl_name,
-                    array_to_string(attr_col_names, ''','''),
+                    array_to_string(lit_attr_col_names, ','),
                     array_upper(attr_col_names, 1)::TEXT,
                     meta_tbl_name
                 ]

--- a/methods/cart/src/pg_gp/dt_utility.sql_in
+++ b/methods/cart/src/pg_gp/dt_utility.sql_in
@@ -417,7 +417,7 @@ RETURNS BOOLEAN AS $$
     (
         SELECT unnest($1)
         EXCEPT
-        SELECT attname
+        SELECT quote_ident(attname) 
         FROM pg_attribute
         WHERE attrelid = $2::regclass   AND
               attnum > 0                AND
@@ -481,7 +481,7 @@ BEGIN
 
     -- null or empty array will be filtered 
     FOR index IN 1..array_upper(ret, 1) LOOP
-        ret[index] = btrim(ret[index], ' ');
+        ret[index] = quote_ident(btrim(ret[index], ' '));
     END LOOP;
 
     RETURN ret;

--- a/src/config/Modules.yml
+++ b/src/config/Modules.yml
@@ -15,7 +15,6 @@ modules:
     - name: data_profile
       depends: ['sketch']
     - name: cart
-      depends: ['array_ops']
     - name: kmeans
       depends: ['array_ops','svec']
     - name: kernel_machines

--- a/src/config/Modules.yml
+++ b/src/config/Modules.yml
@@ -15,6 +15,7 @@ modules:
     - name: data_profile
       depends: ['sketch']
     - name: cart
+      depends: ['array_ops']
     - name: kmeans
       depends: ['array_ops','svec']
     - name: kernel_machines


### PR DESCRIPTION
JIRA: [MADLIB-635](http://jira.madlib.net/browse/MADLIB-635)
During encoding process, if all the values of a column is null, then we will remove the column from breakup table in 'ignore' mode. Therefore, besides insert the columns' information in the breakup table to the metatable, we need to insert those columns in which all the values are null to the meta table. This PR is used to track the issue.

When i fix this bug, I found that we didn't change the file Module.yml. As now we invoke some functions from array_ops, we need to depend on that module. As it's a minor problem, i combine to this PR. Thanks.
