### PR TITLE
Training function will be failed when the result tree table is under default schema.

### DIFF
--- a/methods/cart/src/pg_gp/dt_utility.sql_in
+++ b/methods/cart/src/pg_gp/dt_utility.sql_in
@@ -320,6 +320,9 @@ $$ LANGUAGE PLPGSQL IMMUTABLE;
  *
  * @return The schema name of the table.
  *
+ * @note This function should be VOLATILE, since we may get schema name 
+ *       from a new created table in the same transaction.
+ *
  */       
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__get_schema_name
     (
@@ -370,7 +373,7 @@ BEGIN
     
     RETURN schema_name;
 end
-$$ LANGUAGE PLPGSQL STABLE;
+$$ LANGUAGE PLPGSQL;
 
 
 /*


### PR DESCRIPTION
JIRA: MADLIB-640.
The scenario is, that we create the table 'car_tree' and then call get_schema_name function to retrieve the schema of that table from pg_namespace. As this function (get_schema_name) is stable, it just return null. The solution is change it to VOLATILE.
