### PR TITLE
score function return 'divide by zero' on madelon, since the class column is malformat.

### DIFF
--- a/methods/cart/src/pg_gp/c45.sql_in
+++ b/methods/cart/src/pg_gp/c45.sql_in
@@ -421,7 +421,7 @@ BEGIN
             verbosity,
             'tree'
         );
-    RAISE INFO '%', tree_table_name;
+        
     train_rs = MADLIB_SCHEMA.__encode_and_train
         (
             'C4.5',

--- a/methods/cart/src/pg_gp/dt_preproc.sql_in
+++ b/methods/cart/src/pg_gp/dt_preproc.sql_in
@@ -1068,7 +1068,6 @@ m4_ifdef(>>>__GREENPLUM_GE_4_2_1__<<<, >>>
         );
 <<<)
 m4_changequote(>>>`<<<, >>>'<<<)
-    RAISE INFO '%', curstmt;
 
     EXECUTE curstmt;
 
@@ -1114,6 +1113,11 @@ m4_changequote(>>>`<<<, >>>'<<<)
             );
 
     ELSE
+        -- for scoring, as the class column may have some values which are not 
+        -- appear in the training table, we need use left join here to ensure all
+        -- the rows of the input table were breakup. Here, we simple encode those 
+        -- values to 0. Therefore, during scoring, the samples with 0 (encoded
+        -- value) as class label will be recognized as mis-classified.
         curstmt = MADLIB_SCHEMA.__format
             (
                 'INSERT INTO %(id, fid, fval, is_cont, class)
@@ -1123,10 +1127,10 @@ m4_changequote(>>>`<<<, >>>'<<<)
                      SELECT %, generate_series(1, %) as fid, 
                         unnest(array[MADLIB_SCHEMA.__to_char(%)]) as fval, 
                         unnest(array[''%''::BOOL]::BOOL[]) as is_cont,
-                        code as class
+                        coalesce(code, 0::INT) as class
                      FROM
-                        % t1, % t2
-                     WHERE MADLIB_SCHEMA.__to_char(t1.%) = t2.fval                    
+                        % t1 LEFT JOIN % t2
+                     ON MADLIB_SCHEMA.__to_char(t1.%) = t2.fval                    
                     ) t
                  %',
                 ARRAY[


### PR DESCRIPTION
JIRA: MADLIB-632.
The root cause is, that the dataset 'madelon_test' is wrong. The class labels of that dataset were missing. However, from dev perspective, we need to handle this exception. With the fix and the dataset, then the score should be zero, since the expected class labels are not the same with the classified labels at all.

```
testdb=# select distinct class from dt_madelon;
 class 
-------
 -1
 1
(2 rows)

testdb=# select distinct class from dt_madelon_test;
 class 
-------

(1 row)
```

We use left join to ensure all the rows of classification/scoring table were breakup, even the class labels in that table were not in training table. The class labels which don't appear in the training dataset will be treat as 0 (encoded value). Therefore, during scoring, those samples with 0 class label will be regarded misclassified.
