### PR TITLE
Association Rules: Avoid hash aggregate on svec

### DIFF
--- a/src/ports/postgres/modules/assoc_rules/assoc_rules.sql_in
+++ b/src/ports/postgres/modules/assoc_rules/assoc_rules.sql_in
@@ -507,7 +507,9 @@ LOOP
     EXECUTE 'DROP TABLE IF EXISTS list_b'; 
     EXECUTE 'CREATE TEMPORARY TABLE list_b AS
     SELECT  MADLIB_SCHEMA.svec_to_string(set_list) text_svec, 
-            set_list, ' || n + 1 || ' as iteration
+            MADLIB_SCHEMA.svec_from_string(
+                MADLIB_SCHEMA.svec_to_string(set_list)) set_list,
+            ' || n + 1 || ' as iteration
     FROM (
         SELECT
             MADLIB_SCHEMA.svec_minus(
@@ -524,7 +526,7 @@ LOOP
           AND b.iteration = ' || n || '
     ) t
     WHERE MADLIB_SCHEMA.svec_l1norm(set_list) = ' || n + 1 || '
-    GROUP BY 1, 2, 3
+    GROUP BY MADLIB_SCHEMA.svec_to_string(set_list)
     m4_ifdef(`GREENPLUM',`DISTRIBUTED BY (text_svec)') 
     '; 
 

--- a/src/ports/postgres/modules/assoc_rules/assoc_rules.sql_in
+++ b/src/ports/postgres/modules/assoc_rules/assoc_rules.sql_in
@@ -506,16 +506,17 @@ LOOP
 
     EXECUTE 'DROP TABLE IF EXISTS list_b'; 
     EXECUTE 'CREATE TEMPORARY TABLE list_b AS
-    SELECT  MADLIB_SCHEMA.svec_to_string(set_list) text_svec, 
-            MADLIB_SCHEMA.svec_from_string(
-                MADLIB_SCHEMA.svec_to_string(set_list)) set_list,
+    SELECT  text_svec,
+            MADLIB_SCHEMA.svec_from_string(text_svec) as set_list,
             ' || n + 1 || ' as iteration
     FROM (
         SELECT
-            MADLIB_SCHEMA.svec_minus(
-                MADLIB_SCHEMA.svec_plus(a.set_list, b.set_list), 
-                MADLIB_SCHEMA.svec_mult(a.set_list, b.set_list)
-            ) as set_list
+            MADLIB_SCHEMA.svec_to_string(
+                MADLIB_SCHEMA.svec_minus(
+                    MADLIB_SCHEMA.svec_plus(a.set_list, b.set_list), 
+                    MADLIB_SCHEMA.svec_mult(a.set_list, b.set_list)
+                )
+            ) as text_svec
         FROM
             assoc_rule_sets a 
        CROSS JOIN
@@ -525,8 +526,8 @@ LOOP
           AND a.iteration = ' || n || ' 
           AND b.iteration = ' || n || '
     ) t
-    WHERE MADLIB_SCHEMA.svec_l1norm(set_list) = ' || n + 1 || '
-    GROUP BY MADLIB_SCHEMA.svec_to_string(set_list)
+    WHERE MADLIB_SCHEMA.svec_l1norm(MADLIB_SCHEMA.svec_from_string(text_svec)) = ' || n + 1 || '
+    GROUP BY text_svec
     m4_ifdef(`GREENPLUM',`DISTRIBUTED BY (text_svec)') 
     '; 
 


### PR DESCRIPTION
Jira: MADLIB-461

GPDB apparently chooses hash aggregate although svec doesn't support it.
Use text type to make the plan correct.
