### PR TITLE
fix MADLIB-649

### DIFF
--- a/src/ports/postgres/modules/kmeans/kmeans.py_in
+++ b/src/ports/postgres/modules/kmeans/kmeans.py_in
@@ -773,6 +773,23 @@ def kmeans( madlib_schema
                 , src_relation = src_relation
             );    
         __run_quietly( sql)
+
+        sql = '''SELECT count(*) AS cnt FROM
+                    (SELECT pid from {src_view} 
+                     GROUP BY pid HAVING count(*)>1 limit 1) l
+              '''.format(
+                src_view = src_view
+            );    
+        rv = __run_quietly( sql)
+
+        if (rv[0]['cnt'] > 0):
+            plpy.error('''
+                        '{src_relation}' has duplicate IDs 
+                        in column '{src_col_id}'
+                       '''.format(
+                        src_col_id = src_col_id
+                        , src_relation = src_relation
+                    ));
                     
     # Prepare the data set (skip all data points with any NULL values)
     info( 'Input:');


### PR DESCRIPTION
If the user provided ID is not unique, we should report an explicit error.

Currently, we do not report error at all. If we perform several join operation based on the supplied data, the performance degrades very quickly with the expanded data.
