### PR TITLE
Madpack: add pg_catalog prefix to version() call

### DIFF
--- a/src/madpack/madpack.py
+++ b/src/madpack/madpack.py
@@ -268,7 +268,7 @@ def __get_madlib_dbver(schema):
 ## # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 def __get_dbver():
     try:
-        versionStr = __run_sql_query("""SELECT version()""",
+        versionStr = __run_sql_query("""SELECT pg_catalog.version()""",
             True)[0]['version']
         if portid == 'postgres':
             match = re.search("PostgreSQL[a-zA-Z\s]*(\d+\.\d+)",


### PR DESCRIPTION
Jira: MADLIB-473

Users may have search_path with madlib, public and madpack gets confused
when calling version() function.  Add pg_catalog prefix to make sure it's
the one in the platform.
