### PR TITLE
Replace GREENPLUM macros in m4 with __GREENPLUM__

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -15,7 +15,6 @@ function(define_m4_macros OUT_M4_CMD_LINE OUT_M4_CODE)
     set(IN_FEATURES ${ARGN})
 
     set(MACROS
-        "${PORT_UC}"
         "__${PORT_UC}__"
         "__PORT__=${PORT_UC}"
         "__DBMS__=${DBMS}"

--- a/src/ports/postgres/modules/assoc_rules/assoc_rules.py_in
+++ b/src/ports/postgres/modules/assoc_rules/assoc_rules.py_in
@@ -127,7 +127,7 @@ def assoc_rules(madlib_schema, support, confidence, tid_col,
             lift        FLOAT8,
             conviction  FLOAT8
             )
-        m4_ifdef(`GREENPLUM',`DISTRIBUTED BY (ruleId)')""".format(output_schema)
+        m4_ifdef(`__GREENPLUM__',`DISTRIBUTED BY (ruleId)')""".format(output_schema)
         );
 
     # the auxiliary table for keeping the association rules
@@ -143,7 +143,7 @@ def assoc_rules(madlib_schema, support, confidence, tid_col,
             lift        FLOAT8,
             conviction  FLOAT8
             )
-        m4_ifdef(`GREENPLUM',`DISTRIBUTED BY (ruleId)')""");
+        m4_ifdef(`__GREENPLUM__',`DISTRIBUTED BY (ruleId)')""");
 
     # if the tid in the input table doesn't start with 1 and the IDs are not
     # continuous, then we will make the IDs start with 1 and continuous.
@@ -166,7 +166,7 @@ def assoc_rules(madlib_schema, support, confidence, tid_col,
                       {4}  IS NOT NULL
                 GROUP BY 1,2
              ) t
-             m4_ifdef(`GREENPLUM',`DISTRIBUTED BY (tid)')
+             m4_ifdef(`__GREENPLUM__',`DISTRIBUTED BY (tid)')
              """.format(tid_col, item_col, input_table, tid_col, item_col)
              );
 
@@ -195,7 +195,7 @@ def assoc_rules(madlib_schema, support, confidence, tid_col,
            GROUP BY item
         ) t
         WHERE cnt::FLOAT8 >= {0}
-        m4_ifdef(`GREENPLUM',`DISTRIBUTED BY (item_id)')
+        m4_ifdef(`__GREENPLUM__',`DISTRIBUTED BY (item_id)')
         """.format(min_supp_tranx));
 
     if verbose :
@@ -210,7 +210,7 @@ def assoc_rules(madlib_schema, support, confidence, tid_col,
          SELECT t1.tid, t2.item_id, t2.cnt
          FROM assoc_input_unique t1, assoc_item_uniq t2
          WHERE t1.item = t2.item_text
-         m4_ifdef(`GREENPLUM',`DISTRIBUTED BY (tid)')
+         m4_ifdef(`__GREENPLUM__',`DISTRIBUTED BY (tid)')
          """);
 
     if verbose :
@@ -233,7 +233,7 @@ def assoc_rules(madlib_schema, support, confidence, tid_col,
             support     FLOAT8,
             iteration   INT
             )
-        m4_ifdef(`GREENPLUM',`DISTRIBUTED BY (text_svec)')
+        m4_ifdef(`__GREENPLUM__',`DISTRIBUTED BY (text_svec)')
         """.format(madlib_schema));
 
     # this table keeps the patterns in the current iteration.
@@ -246,7 +246,7 @@ def assoc_rules(madlib_schema, support, confidence, tid_col,
             support     FLOAT8,
             tids        {1}.svec
             )
-        m4_ifdef(`GREENPLUM',`DISTRIBUTED BY (id)')
+        m4_ifdef(`__GREENPLUM__',`DISTRIBUTED BY (id)')
         """.format(madlib_schema, madlib_schema));
 
     plpy.execute("""
@@ -287,7 +287,7 @@ def assoc_rules(madlib_schema, support, confidence, tid_col,
             sid     BIGINT,
             did     BIGINT
             )
-         m4_ifdef(`GREENPLUM',`DISTRIBUTED BY (sid)')
+         m4_ifdef(`__GREENPLUM__',`DISTRIBUTED BY (sid)')
          """);
 
     # As two different svecs may have the same hash key,
@@ -301,7 +301,7 @@ def assoc_rules(madlib_schema, support, confidence, tid_col,
             support         FLOAT8,
             tids            {1}.svec
             )
-         m4_ifdef(`GREENPLUM',`DISTRIBUTED BY (id)')
+         m4_ifdef(`__GREENPLUM__',`DISTRIBUTED BY (id)')
          """.format(madlib_schema, madlib_schema));
 
     if verbose  :
@@ -446,7 +446,7 @@ def assoc_rules(madlib_schema, support, confidence, tid_col,
                 ) s1, assoc_item_uniq s2
              WHERE s1.pre_id = s2.item_id
              GROUP BY ruleId
-             m4_ifdef(`GREENPLUM',`DISTRIBUTED BY (ruleId)')
+             m4_ifdef(`__GREENPLUM__',`DISTRIBUTED BY (ruleId)')
              """);
 
         plpy.execute("DROP TABLE IF EXISTS post_tmp_table");
@@ -462,7 +462,7 @@ def assoc_rules(madlib_schema, support, confidence, tid_col,
                 ) s1, assoc_item_uniq s2
              WHERE s1.post_id = s2.item_id
              GROUP BY ruleId
-             m4_ifdef(`GREENPLUM',`DISTRIBUTED BY (ruleId)')
+             m4_ifdef(`__GREENPLUM__',`DISTRIBUTED BY (ruleId)')
              """);
 
         plpy.execute("""

--- a/src/ports/postgres/modules/bayes/bayes.sql_in
+++ b/src/ports/postgres/modules/bayes/bayes.sql_in
@@ -297,7 +297,7 @@ LANGUAGE sql IMMUTABLE;
 CREATE AGGREGATE MADLIB_SCHEMA.argmax(/*+ key */ INTEGER, /*+ value */ DOUBLE PRECISION) (
     SFUNC=MADLIB_SCHEMA.argmax_transition,
     STYPE=MADLIB_SCHEMA.ARGS_AND_VALUE_DOUBLE,
-    m4_ifdef(`GREENPLUM',`prefunc=MADLIB_SCHEMA.argmax_combine,')
+    m4_ifdef(`__GREENPLUM__',`prefunc=MADLIB_SCHEMA.argmax_combine,')
     FINALFUNC=MADLIB_SCHEMA.argmax_final
 );
 

--- a/src/ports/postgres/modules/convex/lmf.sql_in
+++ b/src/ports/postgres/modules/convex/lmf.sql_in
@@ -191,7 +191,7 @@ CREATE AGGREGATE MADLIB_SCHEMA.lmf_igd_step(
         /*+ scale_factor */     DOUBLE PRECISION) (
     STYPE=DOUBLE PRECISION[],
     SFUNC=MADLIB_SCHEMA.lmf_igd_transition,
-    m4_ifdef(`GREENPLUM',`prefunc=MADLIB_SCHEMA.lmf_igd_merge,')
+    m4_ifdef(`__GREENPLUM__',`prefunc=MADLIB_SCHEMA.lmf_igd_merge,')
     FINALFUNC=MADLIB_SCHEMA.lmf_igd_final,
     INITCOND='{0,0,0,0,0,0,0,0,0}'
 );

--- a/src/ports/postgres/modules/kmeans/kmeans.sql_in
+++ b/src/ports/postgres/modules/kmeans/kmeans.sql_in
@@ -865,7 +865,7 @@ BEGIN
             (SELECT generate_series(1,' || k || ') c) c 
         ) xyz
         , (SELECT generate_series(1,' || ppk || ') p) as p
-        m4_ifdef(`GREENPLUM',`DISTRIBUTED RANDOMLY')';
+        m4_ifdef(`__GREENPLUM__',`DISTRIBUTED RANDOMLY')';
 
     EXECUTE sql;
 

--- a/src/ports/postgres/modules/regress/linear.sql_in
+++ b/src/ports/postgres/modules/regress/linear.sql_in
@@ -338,6 +338,6 @@ CREATE AGGREGATE MADLIB_SCHEMA.linregr(
     SFUNC=MADLIB_SCHEMA.linregr_transition,
     STYPE=MADLIB_SCHEMA.bytea8,
     FINALFUNC=MADLIB_SCHEMA.linregr_final,
-    m4_ifdef(`GREENPLUM',`prefunc=MADLIB_SCHEMA.linregr_merge_states,')
+    m4_ifdef(`__GREENPLUM__',`prefunc=MADLIB_SCHEMA.linregr_merge_states,')
     INITCOND=''
 );

--- a/src/ports/postgres/modules/regress/logistic.sql_in
+++ b/src/ports/postgres/modules/regress/logistic.sql_in
@@ -289,7 +289,7 @@ CREATE AGGREGATE MADLIB_SCHEMA.logregr_cg_step(
     
     STYPE=DOUBLE PRECISION[],
     SFUNC=MADLIB_SCHEMA.logregr_cg_step_transition,
-    m4_ifdef(`GREENPLUM',`prefunc=MADLIB_SCHEMA.logregr_cg_step_merge_states,')
+    m4_ifdef(`__GREENPLUM__',`prefunc=MADLIB_SCHEMA.logregr_cg_step_merge_states,')
     FINALFUNC=MADLIB_SCHEMA.logregr_cg_step_final,
     INITCOND='{0,0,0,0,0,0}'
 );
@@ -306,7 +306,7 @@ CREATE AGGREGATE MADLIB_SCHEMA.logregr_irls_step(
     
     STYPE=DOUBLE PRECISION[],
     SFUNC=MADLIB_SCHEMA.logregr_irls_step_transition,
-    m4_ifdef(`GREENPLUM',`prefunc=MADLIB_SCHEMA.logregr_irls_step_merge_states,')
+    m4_ifdef(`__GREENPLUM__',`prefunc=MADLIB_SCHEMA.logregr_irls_step_merge_states,')
     FINALFUNC=MADLIB_SCHEMA.logregr_irls_step_final,
     INITCOND='{0,0,0}'
 );
@@ -323,7 +323,7 @@ CREATE AGGREGATE MADLIB_SCHEMA.logregr_igd_step(
     
     STYPE=DOUBLE PRECISION[],
     SFUNC=MADLIB_SCHEMA.logregr_igd_step_transition,
-    m4_ifdef(`GREENPLUM',`prefunc=MADLIB_SCHEMA.logregr_igd_step_merge_states,')
+    m4_ifdef(`__GREENPLUM__',`prefunc=MADLIB_SCHEMA.logregr_igd_step_merge_states,')
     INITCOND='{0,0,0,0}'
 );
 

--- a/src/ports/postgres/modules/regress/multilogistic.sql_in
+++ b/src/ports/postgres/modules/regress/multilogistic.sql_in
@@ -242,7 +242,7 @@ CREATE AGGREGATE MADLIB_SCHEMA.mlogregr_irls_step(
 
     STYPE=DOUBLE PRECISION[],
     SFUNC=MADLIB_SCHEMA.mlogregr_irls_step_transition,
-    m4_ifdef(`GREENPLUM',`prefunc=MADLIB_SCHEMA.mlogregr_irls_step_merge_states,')
+    m4_ifdef(`__GREENPLUM__',`prefunc=MADLIB_SCHEMA.mlogregr_irls_step_merge_states,')
     FINALFUNC=MADLIB_SCHEMA.mlogregr_irls_step_final,
     INITCOND='{0,0,0,0}'
 );

--- a/src/ports/postgres/modules/svd_mf/svdmf.py_in
+++ b/src/ports/postgres/modules/svd_mf/svdmf.py_in
@@ -126,37 +126,37 @@ def svdmf_run_full( madlib_schema, input_matrix, col_name, row_name, value, num_
 		row_num INT, 
 		col_num INT,
 		val FLOAT
-	) m4_ifdef( `GREENPLUM', `DISTRIBUTED BY (row_num, col_num)');
+	) m4_ifdef( `__GREENPLUM__', `DISTRIBUTED BY (row_num, col_num)');
 	DROP TABLE IF EXISTS S1;
 	CREATE TEMP TABLE S1(
 		col_num INT,
 		row_num INT,
 		val FLOAT
-	) m4_ifdef( `GREENPLUM', `DISTRIBUTED BY (col_num)');
+	) m4_ifdef( `__GREENPLUM__', `DISTRIBUTED BY (col_num)');
 	DROP TABLE IF EXISTS S2;
 	CREATE TEMP TABLE S2(
 		col_num INT,
 		row_num INT,
 		val FLOAT
-	) m4_ifdef( `GREENPLUM', `DISTRIBUTED BY (col_num)');
+	) m4_ifdef( `__GREENPLUM__', `DISTRIBUTED BY (col_num)');
 	DROP TABLE IF EXISTS D1;
 	CREATE TEMP TABLE D1(
 		row_num INT,
 		col_num INT,
 		val FLOAT
-	) m4_ifdef( `GREENPLUM', `DISTRIBUTED BY (row_num)');
+	) m4_ifdef( `__GREENPLUM__', `DISTRIBUTED BY (row_num)');
 	DROP TABLE IF EXISTS D2;
 	CREATE TEMP TABLE D2(
 		row_num INT,
 		col_num INT,
 		val FLOAT
-	) m4_ifdef( `GREENPLUM', `DISTRIBUTED BY (row_num)');
+	) m4_ifdef( `__GREENPLUM__', `DISTRIBUTED BY (row_num)');
 	DROP TABLE IF EXISTS e;
 	CREATE TABLE e(
 		row_num INT, 
 		col_num INT,
 		val FLOAT
-	) m4_ifdef( `GREENPLUM', `DISTRIBUTED BY (row_num,col_num)');
+	) m4_ifdef( `__GREENPLUM__', `DISTRIBUTED BY (row_num,col_num)');
 	''';
 	plpy.execute(sql);
 


### PR DESCRIPTION
JIRA: MADLIB 639

Files updated: 
 src/ports/postgres/modules/assoc_rules/assoc_rules.py_in
 src/ports/postgres/modules/bayes/bayes.sql_in
 src/ports/postgres/modules/convex/lmf.sql_in
 src/ports/postgres/modules/kmeans/kmeans.sql_in
 src/ports/postgres/modules/regress/linear.sql_in
 src/ports/postgres/modules/regress/logistic.sql_in
 src/ports/postgres/modules/regress/multilogistic.sql_in
 src/ports/postgres/modules/svd_mf/svdmf.py_in
