### PR TITLE
Update documentation for linear regression

### DIFF
--- a/src/ports/postgres/modules/regress/linear.sql_in
+++ b/src/ports/postgres/modules/regress/linear.sql_in
@@ -208,7 +208,7 @@ sql> SELECT (linregr(price, array[1, bedroom, bath, size])).p_values FROM houses
 \verbatim
 sql> \x on
 Expanded display is on.
-sql> SELECT (linregr(price, array[1, bedroom, bath, size])).* FROM houses;
+sql> SELECT (r).* FROM (SELECT linregr(price, array[1, bedroom, bath, size]) as r FROM houses) q;
 -[ RECORD 1 ]+----------------------------------------------------------------------------
 coef         | {27923.4334170641,-35524.7753390234,2269.34393735323,130.793920208133}
 r2           | 0.745374010140315


### PR DESCRIPTION
I updated the following file regarding MADLIB-664:
src/ports/postgres/modules/regress/linear.sql_in
