### PR TITLE
mullogistic: fix madlib 670.

### DIFF
--- a/src/modules/regress/multilogistic.cpp
+++ b/src/modules/regress/multilogistic.cpp
@@ -237,8 +237,8 @@ mlogregr_irls_step_transition::run(AnyType &args) {
         if (numCategories < 1)
                 throw std::domain_error("Number of cateogires must be at least 2");
 
-        if (category > numCategories)
-                throw std::domain_error("You have entered a category > numCategories"
+        if (category > numCategories || category<0)
+                throw std::domain_error("You have entered an invalid category. "
                     "Categories must be of values {0,1... numCategories-1}");
 
         // Init the state (requires x.size() and category.size())

--- a/src/modules/regress/multilogistic.cpp
+++ b/src/modules/regress/multilogistic.cpp
@@ -237,10 +237,6 @@ mlogregr_irls_step_transition::run(AnyType &args) {
         if (numCategories < 1)
                 throw std::domain_error("Number of cateogires must be at least 2");
 
-        if (category > numCategories || category<0)
-                throw std::domain_error("You have entered an invalid category. "
-                    "Categories must be of values {0,1... numCategories-1}");
-
         // Init the state (requires x.size() and category.size())
         state.initialize(*this, static_cast<uint16_t>(x.size())
                                                     , static_cast<uint16_t>(numCategories));
@@ -252,8 +248,13 @@ mlogregr_irls_step_transition::run(AnyType &args) {
         }
     }
 
-
-
+    /*  
+     * This check should be done for each iteration. Only checking the first 
+     * run is not enough.
+     */ 
+    if (category > numCategories || category < 0)
+        throw std::domain_error("You have entered an invalid category. "
+            "Categories must be of values {0,1... numCategories-1}");
 
     // Now do the transition step
     state.numRows++;

--- a/src/ports/postgres/modules/regress/multilogistic.py_in
+++ b/src/ports/postgres/modules/regress/multilogistic.py_in
@@ -157,8 +157,8 @@ def compute_mlogregr(MADlibSchema, source, depvar, numcategories, indepvar, opti
         source = source,
         updateExpr = """
             {MADlibSchema}.mlogregr_{optimizer}_step(
-                ({depvar})::INTEGER,
-                ({numcategories})::INTEGER,
+                ({depvar}),
+                ({numcategories}),
                 ({indepvar})::FLOAT8[],
                 {{state}}
             )

--- a/src/ports/postgres/modules/regress/multilogistic.sql_in
+++ b/src/ports/postgres/modules/regress/multilogistic.sql_in
@@ -380,7 +380,7 @@ BEGIN
     EXECUTE stmt INTO rec;
 
     IF (rec IS NOT NULL) THEN
-        RAISE EXCEPTION 'you have entered an invalid category outside of [%, %]', 
+        RAISE EXCEPTION 'category must be in [%, %]', 
             0, numcategories-1;
     END IF;
     

--- a/src/ports/postgres/modules/regress/multilogistic.sql_in
+++ b/src/ports/postgres/modules/regress/multilogistic.sql_in
@@ -372,18 +372,7 @@ BEGIN
     IF (rec IS NULL) THEN
         RAISE EXCEPTION 'the type of (%) in (%) must be integer', depvar, source;
     END IF;
-    
-    stmt= 'SELECT *  
-    FROM '||source||'  
-    WHERE '||depvar||'<0 OR '||depvar||'>'||numcategories-1||
-    ' LIMIT 1;';
-    EXECUTE stmt INTO rec;
-
-    IF (rec IS NOT NULL) THEN
-        RAISE EXCEPTION 'category must be in [%, %]', 
-            0, numcategories-1;
-    END IF;
-    
+        
     theIteration := (
         SELECT MADLIB_SCHEMA.compute_mlogregr($1, $2, $3, $4, $5, $6, $7)
     );

--- a/src/ports/postgres/modules/regress/multilogistic.sql_in
+++ b/src/ports/postgres/modules/regress/multilogistic.sql_in
@@ -346,7 +346,33 @@ DECLARE
     theIteration INTEGER;
     fnName VARCHAR;
     theResult MADLIB_SCHEMA.mlogregr_result;
+    stmt TEXT;
+    rec RECORD;
 BEGIN
+    stmt= 'SELECT atttypid 
+    FROM pg_attribute 
+    WHERE attrelid ='||quote_literal(source)||'::regclass AND
+          attnum > 0 AND 
+          (not attisdropped) AND
+          atttypid IN 
+          (
+              SELECT unnest
+                    (
+                        ARRAY[
+                            ''SMALLINT''::regtype::oid,
+                            ''INT''::regtype::oid, 
+                            ''BIGINT''::regtype::oid
+                            ]
+                    )
+          ) AND 
+          attname IN ('||quote_literal(depvar)||') LIMIT 1;';
+
+    EXECUTE stmt INTO rec;
+
+    IF (rec IS NULL) THEN
+        RAISE EXCEPTION 'The type of (%) in (%) must be integer', depvar, source;
+    END IF;
+
     theIteration := (
         SELECT MADLIB_SCHEMA.compute_mlogregr($1, $2, $3, $4, $5, $6, $7)
     );

--- a/src/ports/postgres/modules/regress/multilogistic.sql_in
+++ b/src/ports/postgres/modules/regress/multilogistic.sql_in
@@ -370,9 +370,20 @@ BEGIN
     EXECUTE stmt INTO rec;
 
     IF (rec IS NULL) THEN
-        RAISE EXCEPTION 'The type of (%) in (%) must be integer', depvar, source;
+        RAISE EXCEPTION 'the type of (%) in (%) must be integer', depvar, source;
     END IF;
+    
+    stmt= 'SELECT *  
+    FROM '||source||'  
+    WHERE '||depvar||'<0 OR '||depvar||'>'||numcategories-1||
+    ' LIMIT 1;';
+    EXECUTE stmt INTO rec;
 
+    IF (rec IS NOT NULL) THEN
+        RAISE EXCEPTION 'you have entered an invalid category outside of [%, %]', 
+            0, numcategories-1;
+    END IF;
+    
     theIteration := (
         SELECT MADLIB_SCHEMA.compute_mlogregr($1, $2, $3, $4, $5, $6, $7)
     );

--- a/src/ports/postgres/modules/regress/multilogistic.sql_in
+++ b/src/ports/postgres/modules/regress/multilogistic.sql_in
@@ -346,33 +346,7 @@ DECLARE
     theIteration INTEGER;
     fnName VARCHAR;
     theResult MADLIB_SCHEMA.mlogregr_result;
-    stmt TEXT;
-    rec RECORD;
 BEGIN
-    stmt= 'SELECT atttypid 
-    FROM pg_attribute 
-    WHERE attrelid ='||quote_literal(source)||'::regclass AND
-          attnum > 0 AND 
-          (not attisdropped) AND
-          atttypid IN 
-          (
-              SELECT unnest
-                    (
-                        ARRAY[
-                            ''SMALLINT''::regtype::oid,
-                            ''INT''::regtype::oid, 
-                            ''BIGINT''::regtype::oid
-                            ]
-                    )
-          ) AND 
-          attname IN ('||quote_literal(depvar)||') LIMIT 1;';
-
-    EXECUTE stmt INTO rec;
-
-    IF (rec IS NULL) THEN
-        RAISE EXCEPTION 'the type of (%) in (%) must be integer', depvar, source;
-    END IF;
-        
     theIteration := (
         SELECT MADLIB_SCHEMA.compute_mlogregr($1, $2, $3, $4, $5, $6, $7)
     );


### PR DESCRIPTION
Add more error checking for negative test cases. 

Make the algorithm's behavior consistent with the document.
