### PR TITLE
Retrieving column of a matrix & silhouette coefficient

### DIFF
--- a/src/modules/linalg/matrix_agg.cpp
+++ b/src/modules/linalg/matrix_agg.cpp
@@ -135,6 +135,14 @@ matrix_agg_final::run(AnyType& args) {
     return MappedMatrix(state.matrix.leftCols(state.numCols));
 }
 
+AnyType
+matrix_column::run(AnyType& args) {
+    MappedMatrix M = args[0].getAs<MappedMatrix>();
+    uint32_t column = args[1].getAs<uint32_t>();
+
+    return MappedColumnVector(M.col(column));
+}
+
 } // namespace linalg
 
 } // namespace modules

--- a/src/modules/linalg/matrix_agg.hpp
+++ b/src/modules/linalg/matrix_agg.hpp
@@ -13,3 +13,8 @@ DECLARE_UDF(linalg, matrix_agg_transition)
  * @brief Aggregate matrix from columns: Final function
  */
 DECLARE_UDF(linalg, matrix_agg_final)
+
+/**
+ * @brief Return the column of a matrix
+ */
+DECLARE_UDF(linalg, matrix_column)

--- a/src/modules/linalg/metric.hpp
+++ b/src/modules/linalg/metric.hpp
@@ -9,6 +9,11 @@
  */
 DECLARE_UDF(linalg, closest_column)
 
+/**
+ * @brief Find the columns in a matrix that are closest to a vector
+ */
+DECLARE_UDF(linalg, closest_columns)
+
 
 /**
  * @brief Compute the 2-norm
@@ -63,10 +68,14 @@ namespace linalg {
 // Use Eigen
 using namespace dbal::eigen_integration;
 
-template <class DistanceFunction>
-std::tuple<dbal::eigen_integration::Index, double>
-closestColumnAndDistance(const MappedMatrix& inMatrix,
-    const MappedColumnVector& inVector, DistanceFunction& inMetric);
+template <class DistanceFunction, class RandomAccessIterator>
+void
+closestColumnsAndDistances(
+    const MappedMatrix& inMatrix,
+    const MappedColumnVector& inVector,
+    DistanceFunction& inMetric,
+    RandomAccessIterator ioFirst,
+    RandomAccessIterator ioLast);
 
 } // namespace linalg
 

--- a/src/ports/postgres/dbconnector/TypeTraits_impl.hpp
+++ b/src/ports/postgres/dbconnector/TypeTraits_impl.hpp
@@ -267,6 +267,30 @@ struct TypeTraits<FunctionHandle> {
 };
 
 template <>
+struct TypeTraits<ArrayHandle<int32_t> >
+  : public TypeTraitsBase<ArrayHandle<int32_t> > {
+    enum { oid = INT4ARRAYOID };
+    enum { isMutable = dbal::Immutable };
+    enum { typeClass = dbal::ArrayType };
+    WITH_TO_PG_CONVERSION( PointerGetDatum(value.array()) );
+    WITH_TO_CXX_CONVERSION( madlib_DatumGetArrayTypeP(value) );
+};
+
+template <>
+struct TypeTraits<MutableArrayHandle<int32_t> >
+  : public TypeTraitsBase<MutableArrayHandle<int32_t> > {
+    enum { oid = INT4ARRAYOID };
+    enum { isMutable = dbal::Mutable };
+    enum { typeClass = dbal::ArrayType };
+    WITH_TO_PG_CONVERSION( PointerGetDatum(value.array()) );
+    WITH_TO_CXX_CONVERSION(
+        needMutableClone
+          ? madlib_DatumGetArrayTypePCopy(value)
+          : madlib_DatumGetArrayTypeP(value)
+    );
+};
+
+template <>
 struct TypeTraits<ArrayHandle<double> > {
     typedef ArrayHandle<double> value_type;
 

--- a/src/ports/postgres/dbconnector/dbconnector.hpp
+++ b/src/ports/postgres/dbconnector/dbconnector.hpp
@@ -95,6 +95,8 @@ namespace std {
     using tr1::bind;
     using tr1::function;
     using tr1::get;
+    using tr1::make_tuple;
+    using tr1::tie;
     using tr1::tuple;
 }
 

--- a/src/ports/postgres/modules/kmeans_new/kmeans_new.sql_in
+++ b/src/ports/postgres/modules/kmeans_new/kmeans_new.sql_in
@@ -314,7 +314,7 @@ CREATE TYPE MADLIB_SCHEMA.kmeans_new_state AS (
 CREATE FUNCTION MADLIB_SCHEMA.internal_execute_using_kmeans_args(
     sql VARCHAR, DOUBLE PRECISION[][], REGPROC, INTEGER, DOUBLE PRECISION
 ) RETURNS VOID
-IMMUTABLE
+VOLATILE
 CALLED ON NULL INPUT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'exec_sql_using';
@@ -334,7 +334,7 @@ AS $$PythonFunction(kmeans_new, kmeans_new, compute_kmeans)$$;
  * @brief Perform Lloyd's k-means local-search heuristic
  *
  * @param rel_source Name of the relation containing input points
- * @param expr_point Expression evaluting to point coordinates for each tuple
+ * @param expr_point Expression evaluating to point coordinates for each tuple
  * @param initial_centroids Matrix containing the initial centroids as columns
  * @param fn_squared_dist Name of a function with signature
  *     <tt>DOUBLE PRECISION[] x DOUBLE PRECISION[] -> DOUBLE PRECISION</tt> that
@@ -487,7 +487,7 @@ $$;
 CREATE FUNCTION MADLIB_SCHEMA.internal_execute_using_kmeanspp_seeding_args(
     sql VARCHAR, INT2, REGPROC, DOUBLE PRECISION[][]
 ) RETURNS VOID
-IMMUTABLE
+VOLATILE
 CALLED ON NULL INPUT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'exec_sql_using';
@@ -505,7 +505,7 @@ LANGUAGE plpythonu VOLATILE;
  * @brief k-Means++ Seeding
  *
  * @param rel_source Name of the relation containing input points
- * @param expr_point Name of the column containing the point coordinates
+ * @param expr_point Expression evaluating to point coordinates for each tuple
  * @param k Number of centroids
  * @param fn_squared_dist Name of a function with signature
  *     <tt>DOUBLE PRECISION[] x DOUBLE PRECISION[] -> DOUBLE PRECISION</tt> that
@@ -697,7 +697,7 @@ $$;
 CREATE FUNCTION MADLIB_SCHEMA.internal_execute_using_kmeans_random_seeding_args(
     sql VARCHAR, INT2, DOUBLE PRECISION[][]
 ) RETURNS VOID
-IMMUTABLE
+VOLATILE
 CALLED ON NULL INPUT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'exec_sql_using';
@@ -715,7 +715,7 @@ LANGUAGE plpythonu VOLATILE;
  * @brief k-Means Random Seeding
  *
  * @param rel_source Name of the relation containing input points
- * @param expr_point Name of the column containing the point coordinates
+ * @param expr_point Expression evaluating to point coordinates for each tuple
  * @param k Number of centroids
  * @param initial_centroids A matrix containing up to \f$ k \f$ columns as
  *     columns. kmeanspp_seeding() proceeds exactly as if these centroids had
@@ -895,7 +895,7 @@ CREATE FUNCTION MADLIB_SCHEMA.internal_execute_using_kmeans_args(
     fn_squared_dist VARCHAR, agg_mean VARCHAR, max_num_iterations INTEGER,
     min_frac_reassigned DOUBLE PRECISION
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
-IMMUTABLE
+VOLATILE
 CALLED ON NULL INPUT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'exec_sql_using';
@@ -948,8 +948,8 @@ BEGIN
             ),
             $3, $4, $5, $6)
             $sql$,
-            rel_source, expr_point,
-            fn_squared_dist, agg_mean, max_num_iterations, min_frac_reassigned)
+        rel_source, expr_point,
+        fn_squared_dist, agg_mean, max_num_iterations, min_frac_reassigned)
         INTO theResult;
     RETURN theResult;
 END;
@@ -1016,4 +1016,99 @@ LANGUAGE sql AS $$
         $1, $2,
         $3, $4,
         'MADLIB_SCHEMA.squared_dist_norm2', 'MADLIB_SCHEMA.avg', 20, 0.001)
+$$;
+
+
+/**
+ * @internal
+ * @brief Execute a SQL command where $1, ..., $3 are substituted with the
+ *     given arguments.
+ */
+CREATE FUNCTION MADLIB_SCHEMA.internal_execute_using_silhouette_args(
+    sql VARCHAR, centroids DOUBLE PRECISION[][], fn_dist REGPROC
+) RETURNS DOUBLE PRECISION
+STABLE
+CALLED ON NULL INPUT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'exec_sql_using';
+
+/**
+ * @brief Compute a simplified version of the silhouette coefficient
+ *
+ * @param rel_source Name of the relation containing input points
+ * @param expr_point Expression evaluating to point coordinates \f$ x_i \f$ for
+ *     each tuple
+ * @param centroids Matrix \f$ M = (\vec{m_0} \dots \vec{m_{k-1}})
+ *     \in \mathbb{R}^{d \times k} \f$ with \f$ k \f$ columns, where column
+ *     \f$ i \f$ contains the position of centroid \f$ i \f$.
+ * @param fn_dist Name of a function with signature
+ *     <tt>DOUBLE PRECISION[] x DOUBLE PRECISION[] -> DOUBLE PRECISION</tt> that
+ *     returns the distance between two points
+ * @return For each point \f$ x_i \f$, let
+ *     \f$ d_1( x_i ) \f$ and \f$ d_2( x_i ) \f$ be the distance to the closest
+ *     and 2nd-closest centroid, respectively. If there is more than one
+ *     closest centroids then \f$ d_1( x_i ) = d_2( x_i )\f$.
+ *     The return value is the average, over all points \f$ x_i \f$, of
+ *     \f[
+ *         \frac{d_2( x_i ) - d_1(x_i)}{d_2(x_i)},
+ *     \f]
+ *     where 0/0 is interpreted as 0.
+ *     Clearly, the simplified silhouette coefficient assumes values in
+ *     \f$ [0,1] \f$.
+ */
+CREATE FUNCTION MADLIB_SCHEMA.simple_silhouette(
+    rel_source VARCHAR,
+    expr_point VARCHAR,
+    centroids DOUBLE PRECISION[][],
+    fn_dist VARCHAR /*+ DEFAULT 'dist_norm2' */
+) RETURNS DOUBLE PRECISION
+STABLE
+STRICT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    class_rel_source REGCLASS;
+    proc_fn_dist REGPROCEDURE;
+BEGIN
+    class_rel_source := rel_source;
+    proc_fn_dist := fn_dist
+        || '(DOUBLE PRECISION[], DOUBLE PRECISION[])';
+    IF (SELECT prorettype != 'DOUBLE PRECISION'::regtype OR proisagg = TRUE
+        FROM pg_proc WHERE oid = proc_fn_dist) THEN
+        RAISE EXCEPTION 'Distance function has wrong signature or is not a simple function.';
+    END IF;
+
+    RETURN MADLIB_SCHEMA.internal_execute_using_silhouette_args($sql$
+        SELECT
+            avg(CASE
+                    WHEN distances[2] = 0 THEN 0
+                    ELSE (distances[2] - distances[1]) / distances[2]
+                END)
+        FROM (
+            SELECT
+                (MADLIB_SCHEMA.closest_columns(
+                    $1,
+                    $sql$ || expr_point || $sql$,
+                    2::INT2,
+                    $2
+                )).distances
+            FROM
+                $sql$ || textin(regclassout(class_rel_source)) || $sql$
+        ) AS two_shortest_distances
+        $sql$,
+        centroids, proc_fn_dist);
+END;
+$$;
+
+CREATE FUNCTION MADLIB_SCHEMA.simple_silhouette(
+    rel_source VARCHAR,
+    expr_point VARCHAR,
+    centroids DOUBLE PRECISION[][]
+) RETURNS DOUBLE PRECISION
+STABLE
+STRICT
+LANGUAGE sql
+AS $$
+    SELECT MADLIB_SCHEMA.simple_silhouette($1, $2, $3,
+        'MADLIB_SCHEMA.dist_norm2')
 $$;

--- a/src/ports/postgres/modules/linalg/linalg.sql_in
+++ b/src/ports/postgres/modules/linalg/linalg.sql_in
@@ -306,3 +306,18 @@ AGGREGATE MADLIB_SCHEMA.matrix_agg(
     FINALFUNC=MADLIB_SCHEMA.matrix_agg_final,
     INITCOND='{0,0,0}'
 );
+
+/**
+ * @brief Return the column of a matrix
+ *
+ * @param matrix Two-dimensional matrix
+ * @param col Column of the matrix to return (0-based index)
+ */
+CREATE FUNCTION MADLIB_SCHEMA.matrix_column(
+    matrix DOUBLE PRECISION[][],
+    col INTEGER
+) RETURNS DOUBLE PRECISION[]
+LANGUAGE c
+IMMUTABLE
+STRICT
+AS 'MODULE_PATHNAME';

--- a/src/ports/postgres/modules/linalg/linalg.sql_in
+++ b/src/ports/postgres/modules/linalg/linalg.sql_in
@@ -153,7 +153,7 @@ STRICT;
  * @brief closest_column return type
  */
 CREATE TYPE MADLIB_SCHEMA.closest_column_result AS (
-    column_id INT2,
+    column_id INTEGER,
     distance DOUBLE PRECISION
 );
 
@@ -173,8 +173,8 @@ CREATE TYPE MADLIB_SCHEMA.closest_column_result AS (
  *     that is closest to \f$ x \f$. In case of ties, the first such index is
  *     returned. That is, \c columns_id is the minimum element in the set
  *     \f$ \arg\min_{i=0,\dots,l-1} \operatorname{dist}(\vec{m_i}, \vec x) \f$.
- *  - <tt>distance</tt> - The minimum distance between any column of \f$ M \f$
- *     and \f$ x \f$. That is,
+ *  - <tt>distance DOUBLE PRECISION</tt> - The minimum distance between any
+ *     column of \f$ M \f$ and \f$ x \f$. That is,
  *     \f$ \min_{i=0,\dots,l-1} \operatorname{dist}(\vec{m_i}, \vec x) \f$.
  */
 CREATE FUNCTION MADLIB_SCHEMA.closest_column(
@@ -186,6 +186,42 @@ AS 'MODULE_PATHNAME'
 LANGUAGE C
 IMMUTABLE
 STRICT;
+
+/*
+ * @brief closest_columns return type
+ */
+CREATE TYPE MADLIB_SCHEMA.closest_columns_result AS (
+    column_ids INTEGER[],
+    distances DOUBLE PRECISION[]
+);
+
+/**
+ * @brief Given matrix \f$ M \f$ and vector \f$ \vec x \f$ compute the columns
+ *     of \f$ M \f$ that are closest to \f$ \vec x \f$
+ *
+ * This function does essentially the same as \ref closest_column(), except that
+ * it allows to specify the number of closest columns to return. The return
+ * value is a composite value:
+ *  - <tt>columns_ids INTEGER[]</tt> - The 0-based indices of the \c num columns
+ *     of \f$ M \f$ that are closest to \f$ x \f$. In case of ties, the first
+ *     such indices are returned.
+ *  - <tt>distances DOUBLE PRECISION[]</tt> - The distances between the columns
+ *     of \f$ M \f$ with indices in \c columns_ids and \f$ x \f$. That is,
+ *     <tt>distances[i]</tt> contains
+ *     \f$ \operatorname{dist}(\vec{m_j}, \vec x) \f$, where \f$ j = \f$
+ *     <tt>columns_ids[i]</tt>.
+ */
+CREATE FUNCTION MADLIB_SCHEMA.closest_columns(
+    M DOUBLE PRECISION[][],
+    x DOUBLE PRECISION[],
+    num INT2,
+    dist REGPROC
+) RETURNS MADLIB_SCHEMA.closest_columns_result
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE
+STRICT;
+
 
 CREATE FUNCTION MADLIB_SCHEMA.avg_vector_transition(
     state DOUBLE PRECISION[],

--- a/src/ports/postgres/modules/linalg/test/linalg.sql_in
+++ b/src/ports/postgres/modules/linalg/test/linalg.sql_in
@@ -144,3 +144,12 @@ SELECT assert(
     'Incorrect normalized average of vectors'
 )
 FROM some_vectors;
+
+WITH dummy AS (
+    SELECT ARRAY[ARRAY[1,2],ARRAY[3,4]]::DOUBLE PRECISION[][] AS matrix
+)
+SELECT assert(
+    madlib.matrix_column(matrix, 0) = ARRAY[1,2]::DOUBLE PRECISION[] AND
+    madlib.matrix_column(matrix, 1) = ARRAY[3,4]::DOUBLE PRECISION[],
+    'Vector returned does not match column in matrix.')
+FROM dummy;

--- a/src/ports/postgres/modules/linalg/test/linalg.sql_in
+++ b/src/ports/postgres/modules/linalg/test/linalg.sql_in
@@ -122,6 +122,51 @@ SELECT assert(
     ) AS ignored
 ) AS ignored;
 
+SELECT
+    closest_columns(
+        ARRAY[
+            ARRAY[0,0],
+            ARRAY[0,1],
+            ARRAY[1,0],
+            ARRAY[0,1]
+        ]::DOUBLE PRECISION[][],
+        ARRAY[.5,.5]::DOUBLE PRECISION[],
+        2::INT2,
+        'squared_dist_norm2'
+    );
+
+/* All values in the following test are exact sums of powers of 2, so
+ * floating-point arithmetic needs to be exact. */
+SELECT assert(
+    closest_columns(matrix, ARRAY[.5,.5]::DOUBLE PRECISION[], num, metric)
+        = (ARRAY[0,1]::INTEGER[], ARRAY[0.5,0.5]::DOUBLE PRECISION[]) AND
+
+    closest_columns(matrix, ARRAY[.25,.25]::DOUBLE PRECISION[], num, metric)
+        = (ARRAY[0,1]::INTEGER[], ARRAY[0.125,0.625]::DOUBLE PRECISION[]) AND
+
+    closest_columns(matrix, ARRAY[.75,.25]::DOUBLE PRECISION[], num, metric)
+        = (ARRAY[1,0]::INTEGER[], ARRAY[0.125,0.625]::DOUBLE PRECISION[]) AND
+
+    closest_columns(matrix, ARRAY[.25,.75]::DOUBLE PRECISION[], num, metric)
+        = (ARRAY[3,0]::INTEGER[], ARRAY[0.125,0.625]::DOUBLE PRECISION[]) AND
+
+    closest_columns(matrix, ARRAY[.25,.5]::DOUBLE PRECISION[], num, metric)
+        = (ARRAY[0,3]::INTEGER[], ARRAY[0.3125,0.3125]::DOUBLE PRECISION[]),
+
+    'Incorrect closest columns.')
+FROM (
+    SELECT
+        ARRAY[
+            ARRAY[0,0],
+            ARRAY[1,0],
+            ARRAY[1,1],
+            ARRAY[0,1]
+        ]::DOUBLE PRECISION[][] AS matrix,
+        2::INT2 AS num,
+        'squared_dist_norm2'::REGPROC AS metric
+) AS ignored;
+
+
 CREATE TABLE some_vectors (
     id SERIAL,
     x FLOAT8[]


### PR DESCRIPTION
Contains 2 commits:

Function for retrieving column of a matrix

Jira: MADLIB-682

The following query returns NULL in PostgreSQL:
SELECT matrix[1] FROM (SELECT ARRAY[ARRAY[1,2], ARRAY[3,4]] matrix) q;

Reason: Since PostgreSQL does not attach dimensionality to the array type
information, it is unknown during parsing whether matrix[1] is an expression of
type INTEGER or INTEGER[]. We still want to be able to retrieve columns (or rows)
from matrices. I therefore added a function that handles this special case.

New k-means: Simplified silhouette function

Jira: MADLIB-681

Implemented a function to compute the simplified silhouette coefficient.
Additions for this functions in other parts of the code:

Matrix operations:
- Function that returns the two closest columns in a matrix (relative to a given
  vector).

C++ AL:
- Support for INTEGER arrays
