### PR TITLE
Install create_table_as() workaround also on PostgreSQL

### DIFF
--- a/doc/mainpage.dox.in
+++ b/doc/mainpage.dox.in
@@ -115,11 +115,8 @@ and included third-party libraries can be found inside the
     @defgroup grp_sample Random Sampling
     @ingroup grp_support
     
-    @defgroup grp_compatibiity Compatibility
+    @defgroup grp_compatibility Compatibility
     @ingroup grp_support
-
-        @defgroup grp_gp_compat Greenplum Compatibility
-        @ingroup grp_compatibiity
 
     @defgroup grp_utilities DB Administrator Utilities
     @ingroup grp_support

--- a/src/ports/postgres/modules/compatibility/compatibility.sql_in
+++ b/src/ports/postgres/modules/compatibility/compatibility.sql_in
@@ -2,53 +2,58 @@
  *
  * @file compatibility.sql_in
  *
- * @brief SQL functions for Greenplum compatibility
+ * @brief Compatibility SQL functions
  *
- * @sa For a brief overview of Greenplum compatibility functions, see the
- *     module description \ref grp_gp_compat.
+ * @sa For a brief overview of compatibility functions, see the
+ *     module description \ref grp_compatibility.
  *
  *//* ----------------------------------------------------------------------- */
 
+m4_include(`SQLCommon.m4')
+m4_changequote(<!,!>)
+
+
 /**
-@addtogroup grp_gp_compat
+@addtogroup grp_compatibility
 
 @about
 
-The Greenplum compatibility module privdes Greenplum-specific implementations
-for functionality that cannot be implemented using standard SQL -- be it due to
-known limitations in support of the SQL standard or bugs.
+The compatibility module replicates standard SQL functionality that cannot be
+used on all platforms supported by MADlib -- be it due to incomplete
+implementation of the SQL standard or bugs.
 
 This module contains workarounds for the following issues:
 
 - <tt>CREATE TABLE <em>table_name</em> AS <em>query</em></tt> statements where
   <em>query</em> contains certain MADlib functions fails with the error
   “function cannot execute on segment because it issues a non-SELECT statement”
-  (on Greenplum before version 4.2).
+  (Greenplum versions before version 4.2, and in rare special cases also later
+  versions).
   The workaround is:
   <pre>SELECT \ref create_table_as('<em>table_name</em>', $$
     <em>query</em>
 $$, 'BY (<em>column</em>, [...]) | RANDOMLY');</pre>
 - <tt>INSERT INTO <em>table_name</em> <em>query</em></tt> where <em>query</em>
   contains certain MADlib functions fails with the error “function cannot
-  execute on segment because it issues a non-SELECT statement” (on Greenplum
-  before version 4.2). The workaround is:
+  execute on segment because it issues a non-SELECT statement” (Greenplum
+  versions before version 4.2, and in rare special cases also later versions).
+  The workaround is:
   <pre>SELECT \ref insert_into('<em>table_name</em>', $$
     <em>query</em>
 $$);</pre>
 
 @note
-These functions are not installed on other DBMSs (and not needed there). On
-Greenplum 4.2 and later, they are installed only for backward compatibility,
-but not otherwise needed.
+These functions are not needed on PostgreSQL and are usually not needed on
+Greenplum 4.2 and later. However, they are always installed for compatibility
+with other platforms.
 Workarounds should be used only when necessary. For portability and best
 performance, standard SQL should be prefered whenever possible.
 
 @literature
 
-[1] Greenplum Admin Guide, <tt>$GPHOME/docs/GPAdminGuide.pdf</tt>.
+[1] Greenplum Admin Guide
 
-@sa File greenplum/modules/compatibility/compatibility.sql_in (documenting the
-    SQL functions)
+@sa File compatibility.sql_in (documenting the SQL functions)
 
 */
 
@@ -153,7 +158,11 @@ BEGIN
         'CREATE ' || whatToCreate || ' ' || "inTableName" || ' AS
         SELECT * FROM (' || "inSQL" || ') AS _madlib_ignore
         WHERE FALSE
-        DISTRIBUTED ' || "inDistributed";
+m4_ifdef(<!__GREENPLUM__!>,<!
+        DISTRIBUTED ' || "inDistributed"
+!>,<!
+        ';
+!>)
 
     PERFORM MADLIB_SCHEMA.insert_into("inTableName", "inSQL");
 END;
@@ -169,7 +178,8 @@ $$;
  * @param inSQL A SELECT command.
  * @param inDistributed The Greenplum Database distribution policy for the
  *     table. This can be either \c RANDOMLY, which is the default, or
- *     <tt>BY (<em>column</em>, [...])</tt>.
+ *     <tt>BY (<em>column</em>, [...])</tt>. This parameter is ignored on
+ *     PostgreSQL.
  *
  * @usage
  * Use in the same way as the <tt>CREATE TABLE AS</tt> statement:
@@ -281,3 +291,5 @@ AS $$
     SELECT MADLIB_SCHEMA.internal_create_table_as(TRUE,
         $1, $2, 'RANDOMLY');
 $$;
+
+m4_changequote(<!`!>,<!'!>)

--- a/src/ports/postgres/modules/compatibility/test/compatibility.sql_in
+++ b/src/ports/postgres/modules/compatibility/test/compatibility.sql_in
@@ -1,31 +1,31 @@
 ---------------------------------------------------------------------------
--- Install-check Rules: 
+-- Install-check Rules:
 -- --------------------
 -- 1) Any DB objects should be created w/o schema prefix,
 --    since this test file is executed in a separate schema context.
--- 2) There should be no uncommented DROP statements in this script. All objects 
+-- 2) There should be no uncommented DROP statements in this script. All objects
 --    created in the default schema will be cleaned-up outside of this script.
 -- 3) For all other install-check rules please refer to:
 --    https://github.com/madlib/madlib/wiki/Unit-Test-Guide
 ---------------------------------------------------------------------------
 
 ---------------------------------------------------------------------------
--- Setup: 
+-- Setup:
 ---------------------------------------------------------------------------
-CREATE FUNCTION run_some_non_select_stmnts() 
-RETURNS TEXT AS $$ 
+CREATE FUNCTION run_some_non_select_stmnts()
+RETURNS TEXT AS $$
 DECLARE
     rand  TEXT;
 BEGIN
 
     SELECT INTO rand round( random() * 10000)::TEXT;
-    
+
     EXECUTE 'CREATE TEMP TABLE __madlib_compatibility_test_table_' || rand || '
     AS SELECT generate_series(1,100) as x';
 
-    RETURN 'Created __madlib_gp_compat_table_' || rand;
-    
-END $$ 
+    RETURN 'Created compat_table_' || rand;
+
+END $$
 LANGUAGE plpgsql VOLATILE;
 
 ---------------------------------------------------------------------------
@@ -34,13 +34,13 @@ LANGUAGE plpgsql VOLATILE;
 --
 -- create_table_as()
 --
-SELECT MADLIB_SCHEMA.create_table_as( 
-    '__madlib_gp_compat_table_1', 
+SELECT MADLIB_SCHEMA.create_table_as(
+    'compat_table_1',
     $$ SELECT * FROM run_some_non_select_stmnts() as x $$
 );
 
-SELECT MADLIB_SCHEMA.create_table_as( 
-    '__madlib_gp_compat_table_2', 
+SELECT MADLIB_SCHEMA.create_table_as(
+    'compat_table_2',
     $$ SELECT * FROM run_some_non_select_stmnts() as x $$,
     'by (x)'
 );
@@ -48,13 +48,13 @@ SELECT MADLIB_SCHEMA.create_table_as(
 --
 -- create_temp_table_as()
 --
-SELECT MADLIB_SCHEMA.create_temp_table_as( 
-    '__madlib_gp_compat_temp_table_1', 
+SELECT MADLIB_SCHEMA.create_temp_table_as(
+    'compat_temp_table_1',
     $$ SELECT * FROM run_some_non_select_stmnts() as x $$
 );
 
-SELECT MADLIB_SCHEMA.create_temp_table_as( 
-    '__madlib_gp_compat_temp_table_2', 
+SELECT MADLIB_SCHEMA.create_temp_table_as(
+    'compat_temp_table_2',
     $$ SELECT * FROM run_some_non_select_stmnts() as x $$,
     'by (x)'
 );
@@ -62,13 +62,13 @@ SELECT MADLIB_SCHEMA.create_temp_table_as(
 --
 -- create_temporary_table_as()
 --
-SELECT MADLIB_SCHEMA.create_temporary_table_as( 
-    '__madlib_gp_compat_temporary_table_1', 
+SELECT MADLIB_SCHEMA.create_temporary_table_as(
+    'compat_temporary_table_1',
     $$ SELECT * FROM run_some_non_select_stmnts() as x $$
 );
 
-SELECT MADLIB_SCHEMA.create_temporary_table_as( 
-    '__madlib_gp_compat_temporary_table_2', 
+SELECT MADLIB_SCHEMA.create_temporary_table_as(
+    'compat_temporary_table_2',
     $$ SELECT * FROM run_some_non_select_stmnts() as x $$,
     'by (x)'
 );
@@ -76,7 +76,7 @@ SELECT MADLIB_SCHEMA.create_temporary_table_as(
 --
 -- Test with logistic regression
 --
-CREATE TABLE __madlib_gp_logreg_data AS
+CREATE TABLE logreg_data AS
 SELECT
     random() < 1 / (1 + exp(-MADLIB_SCHEMA.array_dot(
         array[0.4, -1.0, 0.7]::DOUBLE PRECISION[], x))
@@ -85,14 +85,13 @@ FROM (
     SELECT
         array[1, random(), random()]::DOUBLE PRECISION[] AS x
     FROM generate_series(0,9) AS i
-) AS q
-DISTRIBUTED RANDOMLY;
+) AS q;
 
 SELECT MADLIB_SCHEMA.create_temporary_table_as(
-    '__madlib_gp_compat_temporary_table_3', $$
-    SELECT * FROM MADLIB_SCHEMA.logregr('__madlib_gp_logreg_data', 'y', 'x')
+    'compat_temporary_table_3', $$
+    SELECT * FROM MADLIB_SCHEMA.logregr('logreg_data', 'y', 'x')
 $$);
 
-SELECT MADLIB_SCHEMA.insert_into('__madlib_gp_compat_temporary_table_3', $$
-    SELECT * FROM MADLIB_SCHEMA.logregr('__madlib_gp_logreg_data', 'y', 'x')
+SELECT MADLIB_SCHEMA.insert_into('compat_temporary_table_3', $$
+    SELECT * FROM MADLIB_SCHEMA.logregr('logreg_data', 'y', 'x')
 $$);


### PR DESCRIPTION
Jira: MADLIB-691

It is convenient to have a uniform interface for CREATE TABLE ... AS, e.g.,
when writing test cases that should run unmodified on all supported
platforms. Obviously, we then can rely on nothing more than the least common
denominator – which is that CTAS is defunct, and our SELECT create_table_as()
workaround has to be used.

In other words, the compatibility module should also be installed for the
PostgreSQL port.
