### PR TITLE
Build support for PostgreSQL 9.2

### DIFF
--- a/methods/cart/src/pg_gp/dt.c
+++ b/methods/cart/src/pg_gp/dt.c
@@ -2334,7 +2334,12 @@ Datum table_exists(PG_FUNCTION_ARGS)
     input = PG_GETARG_TEXT_PP(0);
 
     names = textToQualifiedNameList(input);
-    relid = RangeVarGetRelid(makeRangeVarFromNameList(names), true);
+    relid = RangeVarGetRelid(
+        makeRangeVarFromNameList(names),
+#if PG_VERSION_NUM >= 90200
+        NoLock,
+#endif
+        true);
     PG_RETURN_BOOL(OidIsValid(relid));
 }
 PG_FUNCTION_INFO_V1(table_exists);

--- a/src/ports/postgres/9.2/CMakeLists.txt
+++ b/src/ports/postgres/9.2/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_current_postgresql_version()
+add_extension_support()

--- a/src/ports/postgres/cmake/FindPostgreSQL_9_2.cmake
+++ b/src/ports/postgres/cmake/FindPostgreSQL_9_2.cmake
@@ -1,0 +1,2 @@
+set(_FIND_PACKAGE_FILE "${CMAKE_CURRENT_LIST_FILE}")
+include("${CMAKE_CURRENT_LIST_DIR}/FindPostgreSQL.cmake")


### PR DESCRIPTION
Jira: MADLIB-662

The decision-tree code contained the function table_exists(), which calls
RangeVarGetRelid(), which used to be a two-parameter function, but is now a
three-paremter macro.
