### PR TITLE
Multinomial logistic: Fix MADLIB-665

### DIFF
--- a/src/modules/regress/logistic.cpp
+++ b/src/modules/regress/logistic.cpp
@@ -8,7 +8,7 @@
  * least-squares method.
  *
  *//* ----------------------------------------------------------------------- */
-
+#include <limits>
 #include <dbconnector/dbconnector.hpp>
 #include <modules/shared/HandleTraits.hpp>
 #include <modules/prob/boost.hpp>
@@ -295,7 +295,7 @@ logregr_cg_step_final::run(AnyType &args) {
         // Note: This is testing whether state.beta < 0 if state.beta were
         // assigned according to Polak-Ribière
         if (dot(state.gradNew, gradNewMinusGrad)
-            / dot(state.grad, state.grad) < 0) state.beta = 0;
+            / dot(state.grad, state.grad) <= std::numeric_limits<double>::denorm_min()) state.beta = 0;
 
         // d_k = g_k - beta_k * d_{k-1}
         state.dir = state.gradNew - state.beta * state.dir;

--- a/src/ports/postgres/modules/regress/multilogistic.sql_in
+++ b/src/ports/postgres/modules/regress/multilogistic.sql_in
@@ -108,6 +108,7 @@ The training data is expected to be of the following form:\n
 )</pre>
 
 @usage
+- The number of independent variables cannot exceed 65535.
 - Get vector of coefficients \f$ \boldsymbol c \f$ and all diagnostic
   statistics:\n
   <pre>SELECT * FROM \ref mlogregr(


### PR DESCRIPTION
Multinomial logistic regression: Added variable number limitation to documentation

Jira: MADLIB-665

In multinomial logistic regression, the number of independent variables cannot
exceed 65535. This limitation was added to the usage section of the
documentation.
