### PR TITLE
Design document updates, k-means naming improvements

### DIFF
--- a/doc/design/design.tex
+++ b/doc/design/design.tex
@@ -34,6 +34,7 @@
 \usepackage{xspace}                    % Correct spaces after \newcommand definitions
 \usepackage[noend]{algpseudocode}      % algorithm environment
 \usepackage{listings}                  % Code snippets
+\usepackage{bbding}
 
 
 % BEGIN Doc Layout
@@ -96,6 +97,9 @@
 	    {\href{http://dl.acm.org/citation.cfm?id=#1}{\nolinkurl{#1}}}
 	    {\nolinkurl{#1}}}
 	\makeatother
+	
+	\newlist{moduleinfo}{description}{2}	\setlist[moduleinfo]{style=multiline,labelindent=\leftmargini,leftmargin=3cm,rightmargin=\leftmargini,font=\bfseries}
+	\newlist{modulehistory}{description}{2}	\setlist[modulehistory]{style=multiline,leftmargin=1.1cm}
 % END Doc Layout
 
 % BEGIN General Definitions
@@ -134,6 +138,8 @@
 	\makeatletter
 	\newcommand{\symlabel}[2]{\def\@currentlabel{\texttt{#1}}\texttt{#1}\label{#2}}
 	\makeatother
+	
+	\newcommand{\Warning}[1]{\marginpar[\HandRight]{\HandLeft}\textbf{#1}}
 
 	% BEGIN Algorithms
 	\theoremstyle{algorithm}
@@ -194,6 +200,8 @@
 		morekeywords={table,scratch,channel,interface,periodic,bloom,state,bootstrap,morph,monotone,lset,lbool,lmax,lmap}
 	}
 	% END lstlisting environments
+	
+	\lstnewenvironment{sql}[1][]{\lstset{language=SQL,gobble=4,emphstyle=\textit,#1}}{}
 % END General Definitions
 
 \bibliography{../literature.bib}

--- a/doc/design/modules/crf.tex
+++ b/doc/design/modules/crf.tex
@@ -46,7 +46,7 @@ Note:We hard code sigma to $100$ in the implementation which follows other CRF p
 $E_{p\lambda(Y|x)}F(Y,x)$ is computed using a variant of the forward-backward algorithm:
 
     \[E_{p\lambda(Y|x)}F(Y,x) = \sum_y p\lambda(y|x)F(y,x) = \sum_i\frac{\alpha_{i-1}(f_i*M_i)\beta_i^T}{Z_\lambda(x)}\]
-    \[$Z_\lambda(x) = \alpha_I.1^T$\]
+    \[Z_\lambda(x) = \alpha_I.1^T\]
     where $\alpha_i$ and $\beta_i$ the forward and backward state cost vectors defined by\\
   \[\alpha_i = 
     \begin{cases}
@@ -299,8 +299,9 @@ But there is no arrays of struct type, we had to represent it with one dimention
 Also we have to store the features for a document using  array of doubles instead of array of struct. 
 
 \subsection{Training Data Feature Extraction}
-Given training data, SQLs are writen to extract all the features. It happened that any type of features mentioned above can be extracted out by one single SQL clause which makes the code succinct. We illustrate the training data feature extraction by SQL clause examples.\\
-\paragram{Sample Feature Extraction SQLs for edge features and regex features}
+Given training data, SQLs are writen to extract all the features. It happened that any type of features mentioned above can be extracted out by one single SQL clause which makes the code succinct. We illustrate the training data feature extraction by SQL clause examples.
+
+\paragraph{Sample Feature Extraction SQLs for edge features and regex features}
 \begin{itemize}
 \item $SQL_1$:\\
 \begin{lstlisting}[language=SQL,gobble=4]
@@ -317,7 +318,7 @@ Given training data, SQLs are writen to extract all the features. It happened th
 \end{lstlisting}
 \end{itemize}
 
-\paragram{Build the feature dictionary and assign each feature with a unique feature id}
+\paragraph{Build the feature dictionary and assign each feature with a unique feature id}
 \begin{itemize}
 \item $SQL_3$\\ 
 \begin{lstlisting}[language=SQL,gobble=4]
@@ -330,7 +331,7 @@ Given training data, SQLs are writen to extract all the features. It happened th
 \end{lstlisting}
 \end{itemize}
 
-\paragram{Generate sparse\_r table}
+\paragraph{Generate sparse\_r table}
 \begin{itemize}
 \item $SQL_3$\\ 
 \begin{lstlisting}[language=SQL,gobble=4]
@@ -457,7 +458,8 @@ The dictionary constains all the tokens and the number of times they appear in t
   $viterbi\_mtbl$ and  $viterbi\_rtbl$. The $viterbi\_mtbl$
   table and a $viterbi\_rtbl$ table are used to calculate the best label
   sequence for each sentence.
-\paragram{Sample Feature Extraction SQLs}
+
+\paragraph{Sample Feature Extraction SQLs}
 \begin{itemize}
 \item $SQL_1$: Extracting unique tokens:\\
               \begin{lstlisting}[language=SQL,gobble=4]

--- a/doc/design/modules/k-means.tex
+++ b/doc/design/modules/k-means.tex
@@ -1,33 +1,41 @@
 % When using TeXShop on the Mac, let it know the root document. The following must be one of the first 20 lines.
 % !TEX root = ../design.tex
 
-\chapter[k-Means Clustering]{$k$-Means Clustering}
+\chapter[Clustering (k-means et al.)]{Clustering ($k$-Means et al.)}
+
+\begin{moduleinfo}
+\item[Author] \href{mailto:Florian.Schoppmann@emc.com}{Florian Schoppmann} (version 0.5 only)
+\item[History]
+	\begin{modulehistory}
+		\item[v0.5] Initial revision of design document, complete rewrite of module, arbitrary user-specifyable distance and recentering functions
+		\item[v0.3] Multiple seedings methods (kmeans++, random, user-specified list of centroids), multiple distance functions (corresponding recentering function hard-coded), simplified silhouette coefficient as goodness-of-fit measure
+		\item[v0.1] Initial version, always use kmeans++ for seeding
+	\end{modulehistory}
+\end{moduleinfo}
+
 
 % Abstract. What is the problem we want to solve?
-Clustering refers to the problem of partitioning a set of objects into homogeneous subsets, i.e., such that objects in the same group have \emph{similar} properties. In $k$-means clustering,
-one is given $n$ points $x_1, \dots, x_n \in \R^d$, and the goal is
-to position $k$ centroids $c_1, \dots, c_k \in \R^d$ so that the sum of squared
-distances between each point and its closest centroid is minimized. A cluster
-is identified by its centroid and consists of all points for which this
-centroid is closest. Formally, we wish to minimize the following objective
-function:
+Clustering refers to the problem of partitioning a set of objects into homogeneous subsets, i.e., such that objects in the same group have \emph{similar} properties. Arguably the best-known clustering problem is \emph{$k$-means}. Here, one is given $n$ points $x_1, \dots, x_n \in \R^d$, and the goal is to position $k$ centroids $c_1, \dots, c_k \in \R^d$ so that the sum of squared Euclidean distances between each point and its closest centroid is minimized. A cluster is identified by its centroid and consists of all points for which this centroid is closest. Formally, we wish to minimize the following objective function:
 \begin{gather*}
-    (c_1, \dots, c_k) \mapsto \sum_{i=1}^n \min_{j=1}^k \dist(x_i, c_j)^2
+    (c_1, \dots, c_k) \mapsto \sum_{i=1}^n \min_{j=1}^k \dist(x_i, c_j) \SiM,
 \end{gather*}
+where $\dist(x,y) := \| x - y \|_2^2$. A straightforward generalization of the above minimization problem is to choose a different metric $\dist$. Strictly speaking, this is no longer $k$-means; for instance, choosing $\dist(x,y) = \| x - y\|_1$ yields the $k$-median problem instead.
+
+Despite certain reservations, we follow the practice of many authors and use ``$k$-means'' also to refer to a particular algorithm (as opposed to an optimization problem), as discussed below.
 
 \section{Overview of Algorithms} \label{sec:kmeans:Algorithms}
 
 % Explain the algorithm at a high-level -- do not talk about specific variations or implementation details. Give some theoretical background: Is the problem hard? What results can we expect?
-$k$-means clustering is NP-hard in general Euclidean space (even for just two clusters) \cite{ADH09a} and for a general number of clusters (even in the plane) \cite{MNV10a}. However, the local-search heuristic proposed by \citeauthor{L82a}~\cite{L82a} performs reasonably well in practice. In fact, it is so ubiquitous today that it is often referred to as the standard algorithm or even just the $k$-means algorithm. At a high level, it works as follows:
+The $k$-means problem is NP-hard in general Euclidean space (even for just two clusters) \cite{ADH09a} and for a general number of clusters (even in the plane) \cite{MNV10a}. However, the local-search heuristic proposed by \citeauthor{L82a}~\cite{L82a} performs reasonably well in practice. In fact, it is so ubiquitous today that it is often referred to as the standard algorithm or even just the $k$-means algorithm. At a high level, it works as follows:
 
 \begin{enumerate}
 	\item Seeding phase: Find initial positions for $k$ centroids $c_1, \dots, c_k$.
 	\item Assign each point $x_1, \dots, x_n$ to its closest centroid. \label{enum:kmeans_abstract_points}
-	\item Reposition each centroid to the barycenter (mean) of all points assigned to it.
+	\item Move each centroid $c$ to a position that minimizes the sum of distances between $c$ and each point assigned to $c$. (Note that if ``distance'' refers to the squared Euclidean distance, then this position is the barycenter/mean of all points assigned to $c$.)
 	\item If convergence has been reached, stop. Otherwise, goto \eqref{enum:kmeans_abstract_points}.
 \end{enumerate}
 
-Since the value of the objective function decreases in every step, and there is only a finite number of clusterings, the algorithm is guaranteed to converge to a local minimum \cite[Section~16.4]{CS08a}. While it is known that there are instances for which the $k$-means algorithm takes exponentially many steps~\cite{V09a}, it has been shown that $k$-means has polynomial smoothed complexity \cite{AMR09a}---thus giving some theoretical explanation for good results in practice. With a clever seeding technique, $k$-means is moreover $O(\log k)$-competitive \cite{AV07a}.
+Since the value of the objective function decreases in every step, and there are only finitely many clusterings, the algorithm is guaranteed to converge to a local minimum \cite[Section~16.4]{CS08a}. While it is known that there are instances for which \citeauthor{L82a}'s heuristic takes exponentially many steps~\cite{V09a}, it has been shown that the algorithm has polynomial smoothed complexity \cite{AMR09a}---thus giving some theoretical explanation for good results in practice. With a clever seeding technique, \citeauthor{L82a}'s heuristic is moreover $O(\log k)$-competitive \cite{AV07a}.
 
 
 \subsection{Algorithm Variants}
@@ -73,7 +81,7 @@ Uniform-at-random sampling just uses the algorithms described in Section~\ref{se
 
 \subsection[k-means++]{$k$-means++}
 
-\texttt{$k$-means++} seeding \cite{AV07a} starts with a single centroid chosen randomly among the input points. It then iteratively chooses new centroids from the input points until there are a total of $k$ centroids. The probability for picking a particular point is proportional to its minimum squared distance to any existing centroid. Intuitively, \texttt{$k$-means++} favors seedings where centroids are spread out over the whole range of the input points, while at the same time not being too susceptible to outliers.
+\texttt{$k$-means++} seeding \cite{AV07a} starts with a single centroid chosen randomly among the input points. It then iteratively chooses new centroids from the input points until there are a total of $k$ centroids. The probability for picking a particular point is proportional to its minimum distance to any existing centroid. Intuitively, \texttt{$k$-means++} favors seedings where centroids are spread out over the whole range of the input points, while at the same time not being too susceptible to outliers.
 
 \subsubsection{Formal Description}
 
@@ -86,7 +94,7 @@ Uniform-at-random sampling just uses the algorithms described in Section~\ref{se
 		\State $C \set \{ \text{initial centroid chosen uniformly at random from } P \}$ \label{alg:kmeanspp:firstCentroid}
 	\EndIf
 	\While{$|C| < k$} \label{alg:kmeans++:for}
-		\State $C \set C \cup \{ \text{random $p \in P$ with probability proportional to }\min_{c \in C} \dist(p,c)^2 \}$ \label{alg:kmeanspp:nextcentroid}
+		\State $C \set C \cup \{ \text{random $p \in P$ with probability proportional to }\min_{c \in C} \dist(p,c) \}$ \label{alg:kmeanspp:nextcentroid}
 	\EndWhile
 \end{algorithmic}
 \end{algorithm}
@@ -108,10 +116,10 @@ The number of distance calculations could be reduced by a factor of $k$ if we st
 \alginput{Number of desired centroids $k$, set $P$ of points in $\R^d$, metric $\dist$, \\
 	set $C$ of initial centroids}
 \algoutput{Set of centroids $C$}
-\algprecond{For all $p \in P: \delta[p] = \min_{c \in C} \dist(p, c)^2$ (or $\delta[p] = \infty$ if $C = \emptyset$)}
+\algprecond{For all $p \in P: \delta[p] = \min_{c \in C} \dist(p, c)$ (or $\delta[p] = \infty$ if $C = \emptyset$)}
 \begin{algorithmic}[1]
 	\While{$|C| < k$} \label{alg:kmeans++ext:for}
-		\State $\mathit{lastCentroid} \set \ref{sym:weighted_sample}(P, \delta^2)$ \label{alg:kmeans++ext:nextCentroid} \Comment{$\delta^2$ denotes the mapping $p \mapsto \delta[p]^2$}
+		\State $\mathit{lastCentroid} \set \ref{sym:weighted_sample}(P, \delta)$ \label{alg:kmeans++ext:nextCentroid} \Comment{$\delta$ denotes the mapping $p \mapsto \delta[p]$}
 		\State $C \set C \cup \{ \mathit{lastCentroid} \}$
 		\For{$p \in P$} \label{alg:kmeans++ext:pointLoop}
 			\If{$\dist(p, \mathit{lastCentroid}) < \delta[p]$}
@@ -146,11 +154,6 @@ In general, the performance benefit of explicitly storing points (i.e., choosing
 		relation
 		\\\midrule
 		In &
-		\texttt{expr\_id} &
-		Tuple identifier, each tuple corresponds to a point $p \in P$ &
-		\specialcell{l}{expression\\ (integer)}
-		\\\midrule
-		In &
 		\texttt{expr\_point} &
 		Point coordinates, i.e., the point $p$ &
 		\specialcell{l}{expression\\ (floating-point vector)}
@@ -161,8 +164,8 @@ In general, the performance benefit of explicitly storing points (i.e., choosing
 		integer
 		\\\midrule
 		In &
-		\texttt{fn\_squared\_dist} &
-		Function returning the squared distance between two vectors &
+		\texttt{fn\_dist} &
+		Function returning the distance between two vectors &
 		function
 		\\\midrule
 		In &
@@ -180,32 +183,20 @@ In general, the performance benefit of explicitly storing points (i.e., choosing
 
 \paragraph{Components} The set of centroids $C$ is stored as a dense floating-point matrix that contains the centroids as columns vectors. Algoritm~\ref{alg:kmeans++} can be (roughly) translated into SQL as follow. We assume here that all function arguments are available as constants, and the matrix containing the centroids as columns is available as \texttt{centroids}. Line~\ref{alg:kmeanspp:firstCentroid} becomes:
 \begin{lstlisting}[language=SQL,gobble=4]
-    SELECT ARRAY[(
-        SELECT CAST($expr_point AS DOUBLE PRECISION[])
-        FROM $rel_source
-        WHERE $expr_id = (
-            SELECT weighted_sample($expr_id, 1)
-            FROM $rel_source
-        )
-    )]
+    SELECT ARRAY[weighted_sample($expr_point, 1)]
+    FROM $rel_source
 \end{lstlisting}
 Line~\ref{alg:kmeanspp:nextcentroid} is implemented using essentially the following SQL.
-\begin{lstlisting}[language=SQL,gobble=4]
-    SELECT centroids || $expr_point
-    FROM $rel_source
-    WHERE $expr_id = (
-        SELECT
-            weighted_sample(
-                $expr_id, (
-                closest_column(
-                    centroids,
-                    $expr_point,
-                    fn_squared_dist
-                )).distance
-            )
-        FROM $rel_source
-    )
-\end{lstlisting}
+\begin{sql}[emph={centroids,fn_dist}]
+    SELECT centroids || weighted_sample(
+        $expr_point, (
+            closest_column(
+                centroids,
+                $expr_point,
+                fn_dist
+        )).distance
+    ) FROM $rel_source
+\end{sql}
 See Section~\ref{sec:matrix:closestColumn} for a description of \ref{sym:closestColumn}.
 
 \subsubsection{Historical Implementations}
@@ -270,11 +261,6 @@ Algorithm~\ref{alg:kmeans} is implemented as the user-defined function \symlabel
 		relation
 		\\\midrule
 		In &
-		\texttt{expr\_id} &
-		Tuple identifier, each tuple corresponds to a point $p \in P$ &
-		\specialcell{l}{expression\\ (integer)}
-		\\\midrule
-		In &
 		\texttt{expr\_point} &
 		Point coordinates, i.e., the point $p$ &
 		\specialcell{l}{expression\\ (floating-point vector)}
@@ -285,13 +271,13 @@ Algorithm~\ref{alg:kmeans} is implemented as the user-defined function \symlabel
 		floating-point matrix
 		\\\midrule
 		In &
-		\texttt{fn\_squared\_dist} &
-		Function returning the squared distance between two vectors &
+		\texttt{fn\_dist} &
+		Function returning the distance between two vectors &
 		function
 		\\\midrule
 		In &
-		\texttt{agg\_mean} &
-		Aggregate returning the mean of a set of points &
+		\texttt{agg\_centroid} &
+		Aggregate returning the centroid for a set of points &
 		function
 		\\\midrule
 		In &
@@ -313,28 +299,65 @@ Algorithm~\ref{alg:kmeans} is implemented as the user-defined function \symlabel
 
 \paragraph{Components}
 
-The set of centroids $C$ is stored as a dense floating-point matrix that contains the centroids as columns vectors. Algoritm~\ref{alg:kmeans} can be (roughly) translated into SQL as follow. We assume here that all function arguments are available as constants, and the matrix containing the centroids is available as \texttt{centroids}. Line~\ref{alg:kmeans:MoveCentroids} becomes:
+The set of centroids $C$ is stored as a dense floating-point matrix that contains the centroids as columns vectors. Algoritm~\ref{alg:kmeans} can be (roughly) translated into SQL as follow. We assume here that all function arguments are available as constants, and the matrix containing the centroids is available as \texttt{centroids}. (These variables, which are unbound in the SQL statement, are shown in italic font.) Line~\ref{alg:kmeans:MoveCentroids} becomes:
 %
-\begin{lstlisting}[language=SQL,gobble=4]
+\begin{sql}[emph={centroids,fn_dist}]
     SELECT matrix_agg(_centroid)
     FROM (
-        SELECT $agg_mean(_point) AS _centroid
+        SELECT $agg_centroid(_point) AS _centroid
         FROM (
             SELECT
                 $expr_point AS _point,
                 (closest_column(
                     centroids,
                     $expr_point,
-                    fn_squared_dist
+                    fn_dist
                 )).column_id AS _new_centroid_id
             FROM $rel_source
         ) AS _points_with_assignments
         GROUP BY _new_centroid_id
     ) AS _new_centroids
-\end{lstlisting}
+\end{sql}
 See Section~\ref{sec:matrix:matrixAgg} for a description of \ref{sym:matrixAgg}.
 
-It is a a good idea to also compute the number of reassigned centroids, so that both line~\ref{alg:kmeans:MoveCentroids} and the convergence check in line~\ref{alg:kmeans:ConvergenceCond} can be computed with one pass over the data. To that end, we extend the inner-most query to also compute the previous closest centroid (i.e., we do a second \ref{sym:closestColumn} call where we pass matrix \texttt{old\_centroids} as first argument). During the aggregations in the two outer queries, we can then count (or sum up, respectively) the number of points that have been reassigned.
+It is a good idea to also compute the number of reassigned centroids, so that both line~\ref{alg:kmeans:MoveCentroids} and the convergence check in line~\ref{alg:kmeans:ConvergenceCond} can be computed with one pass over the data. To that end, we extend the inner-most query to also compute the previous closest centroid (i.e., we do a second \ref{sym:closestColumn} call where we pass matrix \texttt{old\_centroids} as first argument). During the aggregations in the two outer queries, we can then count (or sum up, respectively) the number of points that have been reassigned.
+
+A caveat during testing whether a point has been reassigned is that centroid IDs are not constant over iterations: \ref{sym:closestColumn} returns a column index in the matrix \texttt{centroids}, and this matrix is the result of the \ref{sym:matrixAgg} aggregate---hence, the order of the columns is non-deterministic. We therefore cannot directly compare a column index from iteration $i$ to a column index from iteration $i - 1$, but instead need to translate the ``new'' index into an ``old'' index first. In order to do that, we extend the outermost query and also build up an array \texttt{old\_centroid\_ids}, where position $i$ will contain the column index that centroid $i$ had in the previous iteration. \Warning{A crucial assumption on the DBMS backend here is that the two aggregates \texttt{array\_agg} and \ref{sym:matrixAgg} see all tuples in the same order.} Putting everything together, the query becomes:
+%
+\begin{sql}[emph={centroids,old_centroids,old_centroid_ids,fn_dist}]
+    SELECT
+        matrix_agg(_centroid),        -- New value for: centroids
+        array_agg(_new_centroid_id),  -- New value for: old_centroid_ids
+        sum(_objective_fn),           -- New value for: objective_fn
+        CAST(sum(_num_reassigned) AS DOUBLE PRECISION) / sum(_num_points) -- New value for: frac_reassigned
+    FROM (
+        SELECT
+            (_new_centroid).column_id AS _new_centroid_id,
+            sum((_new_centroid).distance) AS _objective_fn,
+            count(*) AS _num_points,
+            sum(
+                CAST(old_centroid_ids[(_new_centroid).column_id + 1] != _old_centroid_id AS INTEGER)
+            ) AS _num_reassigned,
+            $agg_centroid(_point) AS _centroid
+        FROM (
+            SELECT
+                $expr_point AS _point,
+                closest_column(
+                    centroids,
+                    $expr_point,
+                    fn_dist
+                ) AS _new_centroid,
+                (closest_column(
+                    old_centroids,
+                    $expr_point,
+                    fn_dist
+                )).column_id AS _old_centroid_id
+            FROM $rel_source
+        ) AS _points_with_assignments
+        GROUP BY (_new_centroid).column_id
+    ) AS _new_centroids
+\end{sql}
+
 
 Finally, line~\ref{alg:kmeans:Reseed} is simply implemented by calling function \ref{sym:kmeans++}. For a slight performance benefit, this function call should be guarded by a check if the number of centroids is lower than $k$.
 

--- a/doc/design/modules/matrix-operations.tex
+++ b/doc/design/modules/matrix-operations.tex
@@ -3,6 +3,14 @@
 
 \chapter{Matrix Operations}
 
+\begin{moduleinfo}
+\item[Author] \href{mailto:Florian.Schoppmann@emc.com}{Florian Schoppmann}
+\item[History]
+	\begin{modulehistory}
+		\item[v0.5] Initial revision
+	\end{modulehistory}
+\end{moduleinfo}
+
 % Abstract. What is the problem we want to solve?
 While dense and sparse matrices are native objects for MADlib, they are not part of the SQL standard. It is therefore essential to provide bridges between SQL types and MADlib types, as well provide a ground set of primitive functions that can be used in SQL.
 

--- a/doc/design/modules/sampling.tex
+++ b/doc/design/modules/sampling.tex
@@ -3,6 +3,14 @@
 
 \chapter{Sampling}
 
+\begin{moduleinfo}
+\item[Author] \href{mailto:Florian.Schoppmann@emc.com}{Florian Schoppmann}
+\item[History]
+	\begin{modulehistory}
+		\item[v0.5] Initial revision
+	\end{modulehistory}
+\end{moduleinfo}
+
 \section{Sampling without Replacement} \label{sec:SampingWOReplacement}
 
 Given a list of known size $n$ through that we can iterate with arbitrary increments, sampling $m$ elements without replacement can be implemented in time $O(m)$, i.e., proportional to the sample size and independent of the list size \cite{V84a}. Even if the list size $n$ is unknown in advance, sampling can still be implemented in time $O(m(1 + \log \frac nm))$ \cite{V85a}.
@@ -127,9 +135,9 @@ Algorithm~\ref{alg:WeightedSample} is implemented as the user-defined aggregate 
 		\toprule%
 		\textbf{Column} & \textbf{Description} & \textbf{Type}
 		\\\otoprule
-		\texttt{id} &
-		Row identifier, each row corresponds to an $a \in A$. There is no need to enforce uniqueness. If an identifier occurs multiple times, the probability of sampling this identifier is proportional to the sum of its weights. &
-		integer
+		\texttt{value} &
+		Row identifier, each row corresponds to an $a \in A$. There is no need to enforce uniqueness. If a value occurs multiple times, the probability of sampling this value is proportional to the sum of its weights. &
+		\textit{generic}
 		\\\midrule
 		\texttt{weight} &
 		weight for row, corresponds to $w[a]$ &
@@ -138,7 +146,7 @@ Algorithm~\ref{alg:WeightedSample} is implemented as the user-defined aggregate 
 	\end{tabularx}
 \end{center}
 %
-While it would be desirable for \texttt{id} to be of generic type, this would also require a generic transition type (see below). However, this is currently not supported in PostgreSQL and Greenplum.
+While it would be desirable to define a user-defined aggregate with a first argument of generic type, this would require a generic transition type (see below). Unfortunately, this is currently not supported in PostgreSQL and Greenplum. However, the internal C++ accumulator type is a generic template class, i.e., only the SQL interface contains redundancies.
 
 \paragraph{Output}
 
@@ -157,9 +165,9 @@ Value of column \texttt{id} in row that was selected.
 				corresponds to $W$ in Algorithm~\ref{alg:WeightedSample} &
 				floating-point
 				\\\midrule
-				\texttt{sample\_id} &
-				corresponds to $\Sample$ in Algorithm~\ref{alg:WeightedSample}, takes value of column \texttt{id} &
-				integer
+				\texttt{sample} &
+				corresponds to $\Sample$ in Algorithm~\ref{alg:WeightedSample}, takes value of column \texttt{value} &
+				\textit{generic}
 				\\\bottomrule
 			\end{tabularx}
 		\end{center}

--- a/methods/cart/src/pg_gp/dt.c
+++ b/methods/cart/src/pg_gp/dt.c
@@ -2334,12 +2334,11 @@ Datum table_exists(PG_FUNCTION_ARGS)
     input = PG_GETARG_TEXT_PP(0);
 
     names = textToQualifiedNameList(input);
-    relid = RangeVarGetRelid(
-        makeRangeVarFromNameList(names),
 #if PG_VERSION_NUM >= 90200
-        NoLock,
+    relid = RangeVarGetRelid(makeRangeVarFromNameList(names), NoLock, true);
+#else
+    relid = RangeVarGetRelid(makeRangeVarFromNameList(names), true);
 #endif
-        true);
     PG_RETURN_BOOL(OidIsValid(relid));
 }
 PG_FUNCTION_INFO_V1(table_exists);

--- a/src/modules/linalg/metric.cpp
+++ b/src/modules/linalg/metric.cpp
@@ -94,15 +94,6 @@ distNorm1(
 }
 
 double
-squaredDistNorm1(
-    const MappedColumnVector& inX,
-    const MappedColumnVector& inY) {
-
-    double l1norm = (inX - inY).lpNorm<1>();
-    return l1norm * l1norm;
-}
-
-double
 distNorm2(
     const MappedColumnVector& inX,
     const MappedColumnVector& inY) {
@@ -119,7 +110,7 @@ squaredDistNorm2(
 }
 
 double
-squaredAngle(
+distAngle(
     const MappedColumnVector& inX,
     const MappedColumnVector& inY) {
 
@@ -128,20 +119,18 @@ squaredAngle(
         cosine = 1;
     else if (cosine < -1)
         cosine = -1;
-    double angle = std::acos(cosine);
-    return angle * angle;
+    return std::acos(cosine);
 }
 
 double
-squaredTanimoto(
+distTanimoto(
     const MappedColumnVector& inX,
     const MappedColumnVector& inY) {
 
     // Note that this is not a metric in general!
     double dotProduct = dot(inX, inY);
     double tanimoto = inX.squaredNorm() + inY.squaredNorm();
-    tanimoto = (tanimoto - 2 * dotProduct) / (tanimoto - dotProduct);
-    return tanimoto * tanimoto;
+    return (tanimoto - 2 * dotProduct) / (tanimoto - dotProduct);
 }
 
 /**
@@ -172,11 +161,11 @@ closestColumnsAndDistancesShortcut(
     else if (inDist.funcPtr() == funcPtr<dist_norm1>())
         closestColumnsAndDistances(inMatrix, inVector, distNorm1,
             ioFirst, ioLast);
-    else if (inDist.funcPtr() == funcPtr<squared_angle>())
-        closestColumnsAndDistances(inMatrix, inVector, squaredAngle,
+    else if (inDist.funcPtr() == funcPtr<dist_angle>())
+        closestColumnsAndDistances(inMatrix, inVector, distAngle,
             ioFirst, ioLast);
-    else if (inDist.funcPtr() == funcPtr<squared_tanimoto>())
-        closestColumnsAndDistances(inMatrix, inVector, squaredTanimoto,
+    else if (inDist.funcPtr() == funcPtr<dist_tanimoto>())
+        closestColumnsAndDistances(inMatrix, inVector, distTanimoto,
             ioFirst, ioLast);
     else
         closestColumnsAndDistances(inMatrix, inVector, inDist,
@@ -240,13 +229,21 @@ closest_columns::run(AnyType& args) {
 
 
 AnyType
+norm1::run(AnyType& args) {
+    return static_cast<double>(args[0].getAs<MappedColumnVector>().lpNorm<1>());
+}
+
+AnyType
 norm2::run(AnyType& args) {
     return static_cast<double>(args[0].getAs<MappedColumnVector>().norm());
 }
 
 AnyType
-norm1::run(AnyType& args) {
-    return static_cast<double>(args[0].getAs<MappedColumnVector>().lpNorm<1>());
+dist_norm1::run(AnyType& args) {
+    return distNorm1(
+        args[0].getAs<MappedColumnVector>(),
+        args[1].getAs<MappedColumnVector>()
+    );
 }
 
 AnyType
@@ -261,14 +258,6 @@ dist_norm2::run(AnyType& args) {
 }
 
 AnyType
-dist_norm1::run(AnyType& args) {
-    return distNorm1(
-        args[0].getAs<MappedColumnVector>(),
-        args[1].getAs<MappedColumnVector>()
-    );
-}
-
-AnyType
 squared_dist_norm2::run(AnyType& args) {
     return squaredDistNorm2(
         args[0].getAs<MappedColumnVector>(),
@@ -277,24 +266,16 @@ squared_dist_norm2::run(AnyType& args) {
 }
 
 AnyType
-squared_dist_norm1::run(AnyType& args) {
-    return squaredDistNorm1(
+dist_angle::run(AnyType& args) {
+    return distAngle(
         args[0].getAs<MappedColumnVector>(),
         args[1].getAs<MappedColumnVector>()
     );
 }
 
 AnyType
-squared_angle::run(AnyType& args) {
-    return squaredAngle(
-        args[0].getAs<MappedColumnVector>(),
-        args[1].getAs<MappedColumnVector>()
-    );
-}
-
-AnyType
-squared_tanimoto::run(AnyType& args) {
-    return squaredTanimoto(
+dist_tanimoto::run(AnyType& args) {
+    return distTanimoto(
         args[0].getAs<MappedColumnVector>(),
         args[1].getAs<MappedColumnVector>()
     );

--- a/src/modules/linalg/metric.hpp
+++ b/src/modules/linalg/metric.hpp
@@ -16,19 +16,14 @@ DECLARE_UDF(linalg, closest_columns)
 
 
 /**
- * @brief Compute the 2-norm
- */
-DECLARE_UDF(linalg, norm2)
-
-/**
  * @brief Compute the 1-norm
  */
 DECLARE_UDF(linalg, norm1)
 
 /**
- * @brief Compute the Euclidean distance between two dense vectors
+ * @brief Compute the 2-norm
  */
-DECLARE_UDF(linalg, dist_norm2)
+DECLARE_UDF(linalg, norm2)
 
 /**
  * @brief Compute the squared Manhattan distance between two dense vectors
@@ -36,24 +31,24 @@ DECLARE_UDF(linalg, dist_norm2)
 DECLARE_UDF(linalg, dist_norm1)
 
 /**
+ * @brief Compute the Euclidean distance between two dense vectors
+ */
+DECLARE_UDF(linalg, dist_norm2)
+
+/**
  * @brief Compute the squared Euclidean distance between two dense vectors
  */
 DECLARE_UDF(linalg, squared_dist_norm2)
 
 /**
- * @brief Compute the squared Manhattan distance between two dense vectors
+ * @brief Compute the angle between two dense vectors
  */
-DECLARE_UDF(linalg, squared_dist_norm1)
+DECLARE_UDF(linalg, dist_angle)
 
 /**
- * @brief Compute the squared angle between two dense vectors
+ * @brief Compute the Tanimoto "distance" between two dense vectors
  */
-DECLARE_UDF(linalg, squared_angle)
-
-/**
- * @brief Compute the squared Tanimoto "distance" between two dense vectors
- */
-DECLARE_UDF(linalg, squared_tanimoto)
+DECLARE_UDF(linalg, dist_tanimoto)
 
 
 #ifndef MADLIB_MODULES_LINALG_LINALG_HPP

--- a/src/ports/postgres/modules/kmeans_new/kmeans_new.py_in
+++ b/src/ports/postgres/modules/kmeans_new/kmeans_new.py_in
@@ -234,7 +234,7 @@ def compute_kmeanspp_seeding(schema_madlib, rel_args, rel_state, rel_source,
                                     WHERE _iteration = {iteration}
                                 ),
                                 _src.{expr_point},
-                                (SELECT fn_squared_dist FROM {rel_args})
+                                (SELECT fn_dist FROM {rel_args})
                             )).distance
                         )
                 FROM {rel_source} AS _src
@@ -301,7 +301,7 @@ def compute_kmeans_random_seeding(schema_madlib, rel_args, rel_state,
     return iterationCtrl.iteration
 
 def compute_kmeans(schema_madlib, rel_args, rel_state, rel_source,
-    expr_point, agg_mean, **kwargs):
+    expr_point, agg_centroid, **kwargs):
     """
     Driver function for Lloyd's k-means local-search heuristic
 
@@ -328,7 +328,7 @@ def compute_kmeans(schema_madlib, rel_args, rel_state, rel_source,
         schema_madlib = schema_madlib,
         rel_source = rel_source,
         expr_point = expr_point,
-        agg_mean = agg_mean)
+        agg_centroid = agg_centroid)
     with iterationCtrl as it:
         # Create the initial inter-iteration state of type kmeans_new_state
         it.update("""
@@ -373,7 +373,7 @@ m4_ifdef(<!__GREENPLUM__!>,<!m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,,<!
                                 AS INTEGER
                             )
                         ) AS _num_reassigned,
-                        {agg_mean}(_point) AS _centroid
+                        {agg_centroid}(_point) AS _centroid
                     FROM (
                         SELECT
                             -- PostgreSQL/Greenplum tuning:
@@ -386,7 +386,7 @@ m4_ifdef(<!__GREENPLUM__!>,<!m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,,<!
                                     WHERE _iteration = {iteration}
                                 ),
                                 _src.{expr_point},
-                                (SELECT fn_squared_dist FROM {rel_args})
+                                (SELECT fn_dist FROM {rel_args})
                             ) AS _new_centroid,
                             ({schema_madlib}.closest_column(
                                 (
@@ -394,7 +394,7 @@ m4_ifdef(<!__GREENPLUM__!>,<!m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,,<!
                                     WHERE _iteration = {iteration} - 1
                                 ),
                                 _src.{expr_point},
-                                (SELECT fn_squared_dist FROM {rel_args})
+                                (SELECT fn_dist FROM {rel_args})
                             )).column_id AS _old_centroid_id
                         FROM {rel_source} AS _src
                     ) AS _points_with_assignments
@@ -414,7 +414,7 @@ m4_ifdef(<!__GREENPLUM__!>,<!m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,,<!
                                 '{expr_point}',
                                 (SELECT CAST(k AS INT2) FROM {rel_args}),
                                 textin(regprocout(
-                                    (SELECT fn_squared_dist FROM {rel_args})
+                                    (SELECT fn_dist FROM {rel_args})
                                 )),
                                 (
                                     SELECT (_state).centroids FROM {rel_state}

--- a/src/ports/postgres/modules/kmeans_new/kmeans_new.sql_in
+++ b/src/ports/postgres/modules/kmeans_new/kmeans_new.sql_in
@@ -18,15 +18,17 @@ m4_include(`SQLCommon.m4')
 
 Clustering refers to the problem of partitioning a set of objects according to
 some problem-dependent measure of <em>similarity</em>. In the k-means variant,
-one is given \f$ n \f$ points \f$ x_1, \dots, x_n \in \mathbb R^d \f$, and the goal is
-to position \f$ k \f$ centroids \f$ c_1, \dots, c_k \in \mathbb R^d \f$ so that the sum of squared
-distances between each point and its closest centroid is minimized. (A cluster
-is identified by its centroid and consists of all points for which this
-centroid is closest.) Formally, we wish to minimize the following objective
-function:
+one is given \f$ n \f$ points \f$ x_1, \dots, x_n \in \mathbb R^d \f$, and the
+goal is to position \f$ k \f$ centroids \f$ c_1, \dots, c_k \in \mathbb R^d \f$
+so that the sum of \em distances between each point and its closest centroid is
+minimized. Each centroid represents a cluster that consists of all points to
+which this centroid is closest. Formally, we wish to minimize the following
+objective function:
 \f[
-    (c_1, \dots, c_k) \mapsto \sum_{i=1}^n \min_{j=1}^k \operatorname{dist}(x_i, c_j)^2
+    (c_1, \dots, c_k) \mapsto \sum_{i=1}^n \min_{j=1}^k \operatorname{dist}(x_i, c_j)
 \f]
+In the most common case, \f$ \operatorname{dist} \f$ is the square of the
+Euclidean distance.
 
 This problem is computationally difficult (NP-hard), yet the
 local-search heuristic proposed by Lloyd [4] performs reasonably well in
@@ -37,12 +39,13 @@ often referred to as the <em>standard algorithm</em> or even just the
 -# Seed the \f$ k \f$ centroids (see below)
 -# Repeat until convergence:
  -# Assign each point to its closest centroid
- -# Move each centroid to the barycenter (mean) of all points currently
-    assigned to it
--# Convergence is achieved when no points change their assignments during step 2a.
+ -# Move each centroid to a position that minimizes the sum of distances in this
+    cluster
+-# Convergence is achieved when no points change their assignments during step
+   2a.
 
-This algorithm is guaranteed to converge to a local optimum, as it can be
-shown that the objective function decreases in every step.
+Since the objective function decreases in every step, this algorithm is
+guaranteed to converge to a local optimum.
 
 @implementation
 
@@ -60,7 +63,7 @@ The following methods are available for the centroid seeding:
    iteratively choose new
    centroids from the input points until there is a total of \f$ k \f$
    centroids. The probability for picking a particular point is proportional to
-   its minimum squared distance to any existing centroid.
+   its minimum distance to any existing centroid.
    \n
    Intuitively, kmeans++ favors seedings where centroids are spread out over the
    whole range of the input points, while at the same time not being too
@@ -324,7 +327,7 @@ CREATE FUNCTION MADLIB_SCHEMA.internal_compute_kmeans(
     rel_state VARCHAR,
     rel_source VARCHAR,
     expr_point VARCHAR,
-    agg_mean VARCHAR)
+    agg_centroid VARCHAR)
 RETURNS INTEGER
 VOLATILE
 LANGUAGE plpythonu
@@ -336,14 +339,18 @@ AS $$PythonFunction(kmeans_new, kmeans_new, compute_kmeans)$$;
  * @param rel_source Name of the relation containing input points
  * @param expr_point Expression evaluating to point coordinates for each tuple
  * @param initial_centroids Matrix containing the initial centroids as columns
- * @param fn_squared_dist Name of a function with signature
+ * @param fn_dist Name of a function with signature
  *     <tt>DOUBLE PRECISION[] x DOUBLE PRECISION[] -> DOUBLE PRECISION</tt> that
- *     returns the square of the distance between two points. The default is
- *     the \ref squared_dist_norm2(float8[],float8[]) "squared Euclidean distance".
- * @param agg_mean Name of an aggregate function with signature
- *     <tt>DOUBLE PRECISION[] -> DOUBLE PRECISION[]</tt> that returns the mean
- *     of a (non-empty) set of points. The default is
- *     the \ref avg(float8[]) "average (barycenter in Euclidean space)".
+ *     returns the distance between two points. The default is the
+ *     \ref squared_dist_norm2(float8[],float8[]) "squared Euclidean distance".
+ * @param agg_centroid Name of an aggregate function with signature
+ *     <tt>DOUBLE PRECISION[] -> DOUBLE PRECISION[]</tt> that, for each group
+ *     of points, returns a centroid. In order for Lloyd's local-search
+ *     heuristic to provably converge and to return a local minimum, this
+ *     centroid should minimize the sum of distances between each point in the
+ *     group and the centroid. The default is the
+ *     \ref avg(float8[]) "average (mean/barycenter in Euclidean space)",
+ *     which satisfies this property if <tt>fn_dist = 'squared_dist_norm2'</tt>.
  * @param max_num_iterations Maximum number of iterations
  * @param min_frac_reassigned Fraction of reassigned points below which
  *     convergence is assumed and the algorithm terminates
@@ -358,8 +365,8 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeans(
     rel_source VARCHAR,
     expr_point VARCHAR,
     initial_centroids DOUBLE PRECISION[][],
-    fn_squared_dist VARCHAR /*+ DEFAULT 'squared_dist_norm2' */,
-    agg_mean VARCHAR /*+ DEFAULT 'avg' */,
+    fn_dist VARCHAR /*+ DEFAULT 'squared_dist_norm2' */,
+    agg_centroid VARCHAR /*+ DEFAULT 'avg' */,
     max_num_iterations INTEGER /*+ DEFAULT 20 */,
     min_frac_reassigned DOUBLE PRECISION /*+ DEFAULT 0.001 */
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result AS $$
@@ -368,19 +375,19 @@ DECLARE
     theResult MADLIB_SCHEMA.kmeans_new_result;
     oldClientMinMessages VARCHAR;
     class_rel_source REGCLASS;
-    proc_fn_squared_dist REGPROCEDURE;
-    proc_agg_mean REGPROCEDURE;
+    proc_fn_dist REGPROCEDURE;
+    proc_agg_centroid REGPROCEDURE;
 BEGIN
     class_rel_source := rel_source;
-    proc_fn_squared_dist := fn_squared_dist
+    proc_fn_dist := fn_dist
         || '(DOUBLE PRECISION[], DOUBLE PRECISION[])';
     IF (SELECT prorettype != 'DOUBLE PRECISION'::regtype OR proisagg = TRUE
-        FROM pg_proc WHERE oid = proc_fn_squared_dist) THEN
-        RAISE EXCEPTION 'Squared-distance function has wrong signature or is not a simple function.';
+        FROM pg_proc WHERE oid = proc_fn_dist) THEN
+        RAISE EXCEPTION 'Distance function has wrong signature or is not a simple function.';
     END IF;
-    proc_agg_mean := agg_mean || '(DOUBLE PRECISION[])';
+    proc_agg_centroid := agg_centroid || '(DOUBLE PRECISION[])';
     IF (SELECT prorettype != 'DOUBLE PRECISION[]'::regtype OR proisagg = FALSE
-        FROM pg_proc WHERE oid = proc_agg_mean) THEN
+        FROM pg_proc WHERE oid = proc_agg_centroid) THEN
         RAISE EXCEPTION 'Mean aggregate has wrong signature or is not an aggregate.';
     END IF;
 
@@ -400,10 +407,10 @@ BEGIN
         CREATE TABLE pg_temp._madlib_kmeans_args AS
         SELECT
             $1 AS initial_centroids, array_upper($1, 1) AS k,
-            $2 AS fn_squared_dist, $3 AS max_num_iterations,
+            $2 AS fn_dist, $3 AS max_num_iterations,
             $4 AS min_frac_reassigned;
         $sql$,
-        initial_centroids, proc_fn_squared_dist, max_num_iterations,
+        initial_centroids, proc_fn_dist, max_num_iterations,
         min_frac_reassigned);
     EXECUTE 'SET client_min_messages TO ' || oldClientMinMessages;
 
@@ -413,7 +420,7 @@ BEGIN
     theIteration := MADLIB_SCHEMA.internal_compute_kmeans('_madlib_kmeans_args',
             '_madlib_kmeans_state',
             textin(regclassout(class_rel_source)), expr_point,
-            textin(regprocout(proc_agg_mean)));
+            textin(regprocout(proc_agg_centroid)));
 
     -- Retrieve result from state table and return it
     EXECUTE
@@ -436,8 +443,8 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeans(
     rel_source VARCHAR,
     expr_point VARCHAR,
     initial_centroids DOUBLE PRECISION[][],
-    fn_squared_dist VARCHAR,
-    agg_mean VARCHAR,
+    fn_dist VARCHAR,
+    agg_centroid VARCHAR,
     max_num_iterations INTEGER
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
@@ -450,8 +457,8 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeans(
     rel_source VARCHAR,
     expr_point VARCHAR,
     initial_centroids DOUBLE PRECISION[][],
-    fn_squared_dist VARCHAR,
-    agg_mean VARCHAR
+    fn_dist VARCHAR,
+    agg_centroid VARCHAR
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
 STRICT
@@ -463,7 +470,7 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeans(
     rel_source VARCHAR,
     expr_point VARCHAR,
     initial_centroids DOUBLE PRECISION[][],
-    fn_squared_dist VARCHAR
+    fn_dist VARCHAR
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
 STRICT
@@ -507,9 +514,9 @@ LANGUAGE plpythonu VOLATILE;
  * @param rel_source Name of the relation containing input points
  * @param expr_point Expression evaluating to point coordinates for each tuple
  * @param k Number of centroids
- * @param fn_squared_dist Name of a function with signature
+ * @param fn_dist Name of a function with signature
  *     <tt>DOUBLE PRECISION[] x DOUBLE PRECISION[] -> DOUBLE PRECISION</tt> that
- *     returns the square of the distance between two points
+ *     returns the distance between two points
  * @param initial_centroids A matrix containing up to \f$ k \f$ columns as
  *     columns. kmeanspp_seeding() proceeds exactly as if these centroids had
  *     already been generated in previous iterations. This parameter may be
@@ -520,7 +527,7 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeanspp_seeding(
     rel_source VARCHAR,
     expr_point VARCHAR,
     k INT2,
-    fn_squared_dist VARCHAR /*+ DEFAULT 'squared_dist_norm2' */,
+    fn_dist VARCHAR /*+ DEFAULT 'squared_dist_norm2' */,
     initial_centroids DOUBLE PRECISION[][] /*+ DEFAULT NULL */
 ) RETURNS DOUBLE PRECISION[][] AS $$
 DECLARE
@@ -528,14 +535,14 @@ DECLARE
     theResult DOUBLE PRECISION[][];
     oldClientMinMessages VARCHAR;
     class_rel_source REGCLASS;
-    proc_fn_squared_dist REGPROCEDURE;
+    proc_fn_dist REGPROCEDURE;
 BEGIN
     class_rel_source := rel_source;
-    proc_fn_squared_dist := fn_squared_dist
+    proc_fn_dist := fn_dist
         || '(DOUBLE PRECISION[], DOUBLE PRECISION[])';
     IF (SELECT prorettype != 'DOUBLE PRECISION'::regtype OR proisagg = TRUE
-        FROM pg_proc WHERE oid = proc_fn_squared_dist) THEN
-        RAISE EXCEPTION 'Squared-distance function has wrong signature or is not a simple function.';
+        FROM pg_proc WHERE oid = proc_fn_dist) THEN
+        RAISE EXCEPTION 'Distance function has wrong signature or is not a simple function.';
     END IF;
 
     -- We first setup the argument table. Rationale: We want to avoid all data
@@ -552,9 +559,9 @@ BEGIN
     PERFORM MADLIB_SCHEMA.internal_execute_using_kmeanspp_seeding_args($sql$
         DROP TABLE IF EXISTS pg_temp._madlib_kmeanspp_args;
         CREATE TEMPORARY TABLE _madlib_kmeanspp_args AS
-        SELECT $1 AS k, $2 AS fn_squared_dist, $3 AS initial_centroids;
+        SELECT $1 AS k, $2 AS fn_dist, $3 AS initial_centroids;
         $sql$,
-        k, proc_fn_squared_dist, initial_centroids);
+        k, proc_fn_dist, initial_centroids);
     EXECUTE 'SET client_min_messages TO ' || oldClientMinMessages;
 
     -- Perform acutal computation.
@@ -581,7 +588,7 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeanspp_seeding(
     rel_source VARCHAR,
     expr_point VARCHAR,
     k INT2,
-    fn_squared_dist VARCHAR
+    fn_dist VARCHAR
 ) RETURNS DOUBLE PRECISION[][]
 LANGUAGE sql AS $$
     SELECT MADLIB_SCHEMA.kmeanspp_seeding($1, $2, $3, $4, NULL)
@@ -608,10 +615,10 @@ $$;
         rel_source,
         expr_point,
         k,
-        fn_squared_dist
+        fn_dist
     ),
-    fn_squared_dist,
-    agg_mean,
+    fn_dist,
+    agg_centroid,
     max_num_iterations,
     min_frac_reassigned
 )</pre>
@@ -620,8 +627,8 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeanspp(
     rel_source VARCHAR,
     expr_point VARCHAR,
     k INT2,
-    fn_squared_dist VARCHAR /*+ DEFAULT 'squared_dist_norm2' */,
-    agg_mean VARCHAR /*+ DEFAULT 'avg' */,
+    fn_dist VARCHAR /*+ DEFAULT 'squared_dist_norm2' */,
+    agg_centroid VARCHAR /*+ DEFAULT 'avg' */,
     max_num_iterations INTEGER /*+ DEFAULT 20 */,
     min_frac_reassigned DOUBLE PRECISION /*+ DEFAULT 0.001 */
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
@@ -637,8 +644,8 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeanspp(
     rel_source VARCHAR,
     expr_point VARCHAR,
     k INT2,
-    fn_squared_dist VARCHAR,
-    agg_mean VARCHAR,
+    fn_dist VARCHAR,
+    agg_centroid VARCHAR,
     max_num_iterations INTEGER
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
@@ -653,8 +660,8 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeanspp(
     rel_source VARCHAR,
     expr_point VARCHAR,
     k INT2,
-    fn_squared_dist VARCHAR,
-    agg_mean VARCHAR
+    fn_dist VARCHAR,
+    agg_centroid VARCHAR
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
 STRICT
@@ -668,7 +675,7 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeanspp(
     rel_source VARCHAR,
     expr_point VARCHAR,
     k INT2,
-    fn_squared_dist VARCHAR
+    fn_dist VARCHAR
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
 STRICT
@@ -734,7 +741,7 @@ DECLARE
     theResult DOUBLE PRECISION[][];
     oldClientMinMessages VARCHAR;
     class_rel_source REGCLASS;
-    proc_fn_squared_dist REGPROCEDURE;
+    proc_fn_dist REGPROCEDURE;
 BEGIN
     class_rel_source := rel_source;
 
@@ -799,8 +806,8 @@ $$;
         expr_point,
         k
     ),
-    fn_squared_dist,
-    agg_mean,
+    fn_dist,
+    agg_centroid,
     max_num_iterations,
     min_frac_reassigned
 )</pre>
@@ -809,8 +816,8 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeans_random(
     rel_source VARCHAR,
     expr_point VARCHAR,
     k INT2,
-    fn_squared_dist VARCHAR /*+ DEFAULT 'squared_dist_norm2' */,
-    agg_mean VARCHAR /*+ DEFAULT 'avg' */,
+    fn_dist VARCHAR /*+ DEFAULT 'squared_dist_norm2' */,
+    agg_centroid VARCHAR /*+ DEFAULT 'avg' */,
     max_num_iterations INTEGER /*+ DEFAULT 20 */,
     min_frac_reassigned DOUBLE PRECISION /*+ DEFAULT 0.001 */
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
@@ -826,8 +833,8 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeans_random(
     rel_source VARCHAR,
     expr_point VARCHAR,
     k INT2,
-    fn_squared_dist VARCHAR,
-    agg_mean VARCHAR,
+    fn_dist VARCHAR,
+    agg_centroid VARCHAR,
     max_num_iterations INTEGER
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
@@ -843,8 +850,8 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeans_random(
     rel_source VARCHAR,
     expr_point VARCHAR,
     k INT2,
-    fn_squared_dist VARCHAR,
-    agg_mean VARCHAR
+    fn_dist VARCHAR,
+    agg_centroid VARCHAR
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
 STRICT
@@ -859,7 +866,7 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeans_random(
     rel_source VARCHAR,
     expr_point VARCHAR,
     k INT2,
-    fn_squared_dist VARCHAR
+    fn_dist VARCHAR
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
 STRICT
@@ -892,7 +899,7 @@ $$;
  */
 CREATE FUNCTION MADLIB_SCHEMA.internal_execute_using_kmeans_args(
     sql VARCHAR, rel_source VARCHAR, expr_point VARCHAR,
-    fn_squared_dist VARCHAR, agg_mean VARCHAR, max_num_iterations INTEGER,
+    fn_dist VARCHAR, agg_centroid VARCHAR, max_num_iterations INTEGER,
     min_frac_reassigned DOUBLE PRECISION
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
@@ -911,21 +918,21 @@ AS 'MODULE_PATHNAME', 'exec_sql_using';
     rel_source,
     expr_point,
     (SELECT \ref matrix_agg($expr_centroid) FROM $rel_initial_centroids),
-    fn_squared_dist,
-    agg_mean,
+    fn_dist,
+    agg_centroid,
     max_num_iterations,
     min_frac_reassigned
 )</pre>
- * where <tt>$expr_centroid</tt> and <tt>$rel_source</tt> denote textual
- * substituions.
+ * where <tt>$expr_centroid</tt> and <tt>$rel_initial_centroids</tt> denote
+ * textual substituions.
  */
 CREATE FUNCTION MADLIB_SCHEMA.kmeans(
     rel_source VARCHAR,
     expr_point VARCHAR,
     rel_initial_centroids VARCHAR,
     expr_centroid VARCHAR,
-    fn_squared_dist VARCHAR /*+ DEFAULT 'squared_dist_norm2' */,
-    agg_mean VARCHAR /*+ DEFAULT 'avg' */,
+    fn_dist VARCHAR /*+ DEFAULT 'squared_dist_norm2' */,
+    agg_centroid VARCHAR /*+ DEFAULT 'avg' */,
     max_num_iterations INTEGER /*+ DEFAULT 20 */,
     min_frac_reassigned DOUBLE PRECISION /*+ DEFAULT 0.001 */
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
@@ -949,7 +956,7 @@ BEGIN
             $3, $4, $5, $6)
             $sql$,
         rel_source, expr_point,
-        fn_squared_dist, agg_mean, max_num_iterations, min_frac_reassigned)
+        fn_dist, agg_centroid, max_num_iterations, min_frac_reassigned)
         INTO theResult;
     RETURN theResult;
 END;
@@ -960,8 +967,8 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeans(
     expr_point VARCHAR,
     rel_initial_centroids VARCHAR,
     expr_centroid VARCHAR,
-    fn_squared_dist VARCHAR,
-    agg_mean VARCHAR,
+    fn_dist VARCHAR,
+    agg_centroid VARCHAR,
     max_num_iterations INTEGER
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
@@ -977,8 +984,8 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeans(
     expr_point VARCHAR,
     rel_initial_centroids VARCHAR,
     expr_centroid VARCHAR,
-    fn_squared_dist VARCHAR,
-    agg_mean VARCHAR
+    fn_dist VARCHAR,
+    agg_centroid VARCHAR
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
 STRICT
@@ -993,7 +1000,7 @@ CREATE FUNCTION MADLIB_SCHEMA.kmeans(
     expr_point VARCHAR,
     rel_initial_centroids VARCHAR,
     expr_centroid VARCHAR,
-    fn_squared_dist VARCHAR
+    fn_dist VARCHAR
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
 STRICT

--- a/src/ports/postgres/modules/linalg/linalg.sql_in
+++ b/src/ports/postgres/modules/linalg/linalg.sql_in
@@ -23,6 +23,20 @@ Linear-algebra functions.
 */
 
 /**
+ * @brief 1-norm of a vector
+ *
+ * @param x Vector \f$ \vec x = (x_1, \dots, x_n) \f$
+ * @return \f$ \| x \|_1 = \sum_{i=1}^n |x_i| \f$
+ */
+CREATE FUNCTION MADLIB_SCHEMA.norm1(
+    x DOUBLE PRECISION[]
+) RETURNS DOUBLE PRECISION
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE
+STRICT;
+
+/**
  * @brief 2-norm of a vector
  *
  * @param x Vector \f$ \vec x = (x_1, \dots, x_n) \f$
@@ -37,13 +51,15 @@ IMMUTABLE
 STRICT;
 
 /**
- * @brief 1-norm of a vectors
+ * @brief 1-norm of the difference between two vectors
  *
  * @param x Vector \f$ \vec x = (x_1, \dots, x_n) \f$
- * @return \f$ \| x \|_1 = \sum_{i=1}^n |x_i| \f$
+ * @param y Vector \f$ \vec y = (y_1, \dots, y_n) \f$
+ * @return \f$ \| x - y \|_1 = \sum_{i=1}^n |x_i - y_i| \f$
  */
-CREATE FUNCTION MADLIB_SCHEMA.norm1(
-    x DOUBLE PRECISION[]
+CREATE FUNCTION MADLIB_SCHEMA.dist_norm1(
+    x DOUBLE PRECISION[],
+    y DOUBLE PRECISION[]
 ) RETURNS DOUBLE PRECISION
 AS 'MODULE_PATHNAME'
 LANGUAGE C
@@ -58,22 +74,6 @@ STRICT;
  * @return \f$ \| x - y \|_2 = \sqrt{\sum_{i=1}^n (x_i - y_i)^2} \f$
  */
 CREATE FUNCTION MADLIB_SCHEMA.dist_norm2(
-    x DOUBLE PRECISION[],
-    y DOUBLE PRECISION[]
-) RETURNS DOUBLE PRECISION
-AS 'MODULE_PATHNAME'
-LANGUAGE C
-IMMUTABLE
-STRICT;
-
-/**
- * @brief 1-norm of the difference between two vectors
- *
- * @param x Vector \f$ \vec x = (x_1, \dots, x_n) \f$
- * @param y Vector \f$ \vec y = (y_1, \dots, y_n) \f$
- * @return \f$ \| x - y \|_1 = \sum_{i=1}^n |x_i - y_i| \f$
- */
-CREATE FUNCTION MADLIB_SCHEMA.dist_norm1(
     x DOUBLE PRECISION[],
     y DOUBLE PRECISION[]
 ) RETURNS DOUBLE PRECISION
@@ -99,30 +99,14 @@ IMMUTABLE
 STRICT;
 
 /**
- * @brief Squared 1-norm of the difference between two vectors
- *
- * @param x Vector \f$ \vec x = (x_1, \dots, x_n) \f$
- * @param y Vector \f$ \vec y = (y_1, \dots, y_n) \f$
- * @return \f$ \| x - y \|_1^2 = \left( \sum_{i=1}^n |x_i - y_i| \right)^2 \f$
- */
-CREATE FUNCTION MADLIB_SCHEMA.squared_dist_norm1(
-    x DOUBLE PRECISION[],
-    y DOUBLE PRECISION[]
-) RETURNS DOUBLE PRECISION
-AS 'MODULE_PATHNAME'
-LANGUAGE C
-IMMUTABLE
-STRICT;
-
-/**
- * @brief Squared angle between two vectors
+ * @brief Angle between two vectors
  *
  * @param x Vector \f$ \vec x = (x_1, \dots, x_n) \f$
  * @param y Vector \f$ \vec y = (y_1, \dots, y_n) \f$
  * @return \f$ \arccos\left(\frac{\langle \vec x, \vec y \rangle}
- *                               {\| \vec x \| \cdot \| \vec y \|}\right)^2 \f$
+ *                               {\| \vec x \| \cdot \| \vec y \|}\right) \f$
  */
-CREATE FUNCTION MADLIB_SCHEMA.squared_angle(
+CREATE FUNCTION MADLIB_SCHEMA.dist_angle(
     x DOUBLE PRECISION[],
     y DOUBLE PRECISION[]
 ) RETURNS DOUBLE PRECISION
@@ -132,15 +116,15 @@ IMMUTABLE
 STRICT;
 
 /**
- * @brief Squared angle between two vectors
+ * @brief Tanimoto distance between two vectors
  *
  * @param x Vector \f$ \vec x = (x_1, \dots, x_n) \f$
  * @param y Vector \f$ \vec y = (y_1, \dots, y_n) \f$
- * @return \f$ \left(1 - \frac{\langle \vec x, \vec y \rangle}
+ * @return \f$ 1 - \frac{\langle \vec x, \vec y \rangle}
  *                            {\| \vec x \|^2 \cdot \| \vec y \|^2
- *                                - \langle \vec x, \vec y \rangle}\right)^2 \f$
+ *                                - \langle \vec x, \vec y \rangle} \f$
  */
-CREATE FUNCTION MADLIB_SCHEMA.squared_tanimoto(
+CREATE FUNCTION MADLIB_SCHEMA.dist_tanimoto(
     x DOUBLE PRECISION[],
     y DOUBLE PRECISION[]
 ) RETURNS DOUBLE PRECISION
@@ -180,12 +164,24 @@ CREATE TYPE MADLIB_SCHEMA.closest_column_result AS (
 CREATE FUNCTION MADLIB_SCHEMA.closest_column(
     M DOUBLE PRECISION[][],
     x DOUBLE PRECISION[],
-    dist REGPROC
+    dist REGPROC /*+ DEFAULT 'squared_dist_norm2' */
 ) RETURNS MADLIB_SCHEMA.closest_column_result
-AS 'MODULE_PATHNAME'
-LANGUAGE C
 IMMUTABLE
-STRICT;
+STRICT
+LANGUAGE C
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION MADLIB_SCHEMA.closest_column(
+    M DOUBLE PRECISION[][],
+    x DOUBLE PRECISION[]
+) RETURNS MADLIB_SCHEMA.closest_column_result
+IMMUTABLE
+STRICT
+LANGUAGE sql
+AS $$
+    SELECT MADLIB_SCHEMA.closest_column($1, $2,
+        'MADLIB_SCHEMA.squared_dist_norm2')
+$$;
 
 /*
  * @brief closest_columns return type
@@ -215,13 +211,25 @@ CREATE FUNCTION MADLIB_SCHEMA.closest_columns(
     M DOUBLE PRECISION[][],
     x DOUBLE PRECISION[],
     num INT2,
-    dist REGPROC
+    dist REGPROC /*+ DEFAULT 'squared_dist_norm2' */
 ) RETURNS MADLIB_SCHEMA.closest_columns_result
-AS 'MODULE_PATHNAME'
-LANGUAGE C
 IMMUTABLE
-STRICT;
+STRICT
+LANGUAGE C
+AS 'MODULE_PATHNAME';
 
+CREATE FUNCTION MADLIB_SCHEMA.closest_columns(
+    M DOUBLE PRECISION[][],
+    x DOUBLE PRECISION[],
+    num INT2
+) RETURNS MADLIB_SCHEMA.closest_columns_result
+IMMUTABLE
+STRICT
+LANGUAGE sql
+AS $$
+    SELECT MADLIB_SCHEMA.closest_columns($1, $2, $3,
+        'MADLIB_SCHEMA.squared_dist_norm2')
+$$;
 
 CREATE FUNCTION MADLIB_SCHEMA.avg_vector_transition(
     state DOUBLE PRECISION[],

--- a/src/ports/postgres/modules/linalg/test/linalg.sql_in
+++ b/src/ports/postgres/modules/linalg/test/linalg.sql_in
@@ -20,22 +20,22 @@ SELECT assert(
 
 SELECT assert(
     relative_error(
-        dist_norm2(
-            ARRAY[-1.2,  0,  10,  5, 3,   9],
-            ARRAY[10.1, 43, 5.2, 13, 3, -10]),
-        sqrt((10.1 + 1.2)^2 + 43^2 + (10 - 5.2)^2 + (13 - 5)^2 + (9 + 10)^2)
-    ) < 1e-5,
-    'Incorrect distance w.r.t. 2-norm'
-);
-
-SELECT assert(
-    relative_error(
         dist_norm1(
             ARRAY[-1.2,  0,  10,  5, 3,   9],
             ARRAY[10.1, 43, 5.2, 13, 3, -10]),
         (10.1 + 1.2) + 43 + (10 - 5.2) + (13 - 5) + (9 + 10)
     ) < 1e-5,
     'Incorrect distance w.r.t. 1-norm'
+);
+
+SELECT assert(
+    relative_error(
+        dist_norm2(
+            ARRAY[-1.2,  0,  10,  5, 3,   9],
+            ARRAY[10.1, 43, 5.2, 13, 3, -10]),
+        sqrt((10.1 + 1.2)^2 + 43^2 + (10 - 5.2)^2 + (13 - 5)^2 + (9 + 10)^2)
+    ) < 1e-5,
+    'Incorrect distance w.r.t. 2-norm'
 );
 
 SELECT assert(
@@ -50,23 +50,13 @@ SELECT assert(
 
 SELECT assert(
     relative_error(
-        squared_dist_norm1(
-            ARRAY[-1.2,  0,  10,  5, 3,   9],
-            ARRAY[10.1, 43, 5.2, 13, 3, -10]),
-        ((10.1 + 1.2) + 43 + (10 - 5.2) + (13 - 5) + (9 + 10))^2
-    ) < 1e-5,
-    'Incorrect squared distance w.r.t. 1-norm'
-);
-
-SELECT assert(
-    relative_error(
-        squared_angle(x, y),
+        dist_angle(x, y),
         acos(
             ((10.1 * -1.2) + (10 * 5.2) + (13 * 5) + (3 * 3) + (9 * -10)) /
             (norm2(x) * norm2(y))
-        )^2
+        )
     ) < 1e-5,
-    'Incorrect squared angle'
+    'Incorrect angle'
 ) FROM (
     SELECT ARRAY[-1.2,  0,  10,  5, 3,   9] AS x,
            ARRAY[10.1, 43, 5.2, 13, 3, -10] AS y
@@ -74,12 +64,12 @@ SELECT assert(
 
 SELECT assert(
     relative_error(
-        squared_tanimoto(x, y),
+        dist_tanimoto(x, y),
         (
             1. - dot / (norm2(x)^2 + norm2(y)^2 - dot)
-        )^2
+        )
     ) < 1e-5,
-    'Incorrect squared Tanimoto'
+    'Incorrect Tanimoto distance'
 ) FROM (
     SELECT ARRAY[-1.2,  0,  10,  5, 3,   9] AS x,
            ARRAY[10.1, 43, 5.2, 13, 3, -10] AS y,


### PR DESCRIPTION
Changes:
- Fix compilation warning introduced with commit 845210b
- With k-means allowing to supply arbitrary distance functions and recentering
  aggregates, the name k-means has become a bit of a misnomer. E.g., by supplying
  the 1-norm as distance function and the element-wise median as recentering
  aggregate we would compute a local minimum for the k-medians problem.
  Due to the previous narrow focus on only the Euclidean case, the distance
  parameter used to be called 'fn_squared_dist' and the recentering parameter
  'agg_mean'. I replace them by 'fn_dist' and 'agg_centroid'.
- Along the same lines, I removed the distance functions 'squared_dist_1norm',
  'squared_angle', and 'squared_tanimoto', and only kept 'dist_1norm', 'dist_angle',
  and 'dist_tanimoto'.
- Added default parameters to madlib.closest_column
- Added author and version information to some modules in the design document

Jiras:
- MADLIB-692, MADLIB-662
