### PR TITLE
Fix for Jira Madlib-574

### DIFF
--- a/src/modules/regress/logistic.cpp
+++ b/src/modules/regress/logistic.cpp
@@ -8,7 +8,7 @@
  * least-squares method.
  *
  *//* ----------------------------------------------------------------------- */
-
+#include <limits>
 #include <dbconnector/dbconnector.hpp>
 #include <modules/shared/HandleTraits.hpp>
 #include <modules/prob/boost.hpp>
@@ -295,7 +295,7 @@ logregr_cg_step_final::run(AnyType &args) {
         // Note: This is testing whether state.beta < 0 if state.beta were
         // assigned according to Polak-Ribière
         if (dot(state.gradNew, gradNewMinusGrad)
-            / dot(state.grad, state.grad) < 0) state.beta = 0;
+            / dot(state.grad, state.grad) <= std::numeric_limits<double>::denorm_min()) state.beta = 0;
 
         // d_k = g_k - beta_k * d_{k-1}
         state.dir = state.gradNew - state.beta * state.dir;

--- a/src/ports/postgres/modules/regress/multilogistic.sql_in
+++ b/src/ports/postgres/modules/regress/multilogistic.sql_in
@@ -108,6 +108,7 @@ The training data is expected to be of the following form:\n
 )</pre>
 
 @usage
+- The number of independent variables cannot exceed 65535.
 - Get vector of coefficients \f$ \boldsymbol c \f$ and all diagnostic
   statistics:\n
   <pre>SELECT * FROM \ref mlogregr(


### PR DESCRIPTION
   Logistic regression: Fixed a minor problem with direction restart in cg

```
Jira: MADLIB-574

In the conjugate gradient method, the direction is restarted when
Polak-Ribière's beta <= 0 instead of <0.

Reason: In the Polak-Ribière (PR) fomula, beta is chosen as max(0,PR'beta),
so Hestenes-Stiefel's (HS) beta needs to be 0 when PR's beta <= 0 (not <0).
Otherwise, without the "=", HS's beta will blow up at the optimum solution.

Instead of comparing with 0, a small number is used.
```
