### PR TITLE
DT Test: Removed use of madlib schema for test

### DIFF
--- a/methods/cart/src/pg_gp/sql/dt_test.sql_in
+++ b/methods/cart/src/pg_gp/sql/dt_test.sql_in
@@ -1,7 +1,6 @@
 m4_include(`SQLCommon.m4')
 
-DROP TABLE IF EXISTS MADLIB_SCHEMA.golf_dt_test;
-CREATE TABLE MADLIB_SCHEMA.golf_dt_test (
+CREATE TABLE golf_dt_test (
     id          INT,
     outlook     TEXT,
     temperature DOUBLE PRECISION,
@@ -10,23 +9,22 @@ CREATE TABLE MADLIB_SCHEMA.golf_dt_test (
     class       TEXT
 ) m4_ifdef(`__GREENPLUM__',`DISTRIBUTED BY (id)');
 
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (1, 'sunny', 85, 85, ' false', ' Do not Play');
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (3, 'overcast', 83, 78, ' false', ' Play');
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (5, 'rain', 68, 80, ' false', ' Play');
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (7, 'overcast', 64, 65, ' true', ' Play');
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (9, 'sunny', 69, 70, ' false', ' Play');
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (11, 'sunny', 75, 70, ' true', ' Play');
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (13, 'overcast', 81, 75, ' false', ' Play');
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (2, 'sunny', 80, 90, ' true', ' Do not Play');
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (4, 'rain', 70, 96, ' false', ' Play');
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (6, 'rain', 65, 70, ' true', ' Do not Play');
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (8, 'sunny', 72, 95, ' false', ' Do not Play');
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (10, 'rain', 75, 80, ' false', ' Play');
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (12, 'overcast', 72, 90, ' true', ' Play');
-INSERT INTO MADLIB_SCHEMA.golf_dt_test VALUES (14, 'rain', 71, 80, ' true', ' Do not Play');
+INSERT INTO golf_dt_test VALUES (1, 'sunny', 85, 85, ' false', ' Do not Play');
+INSERT INTO golf_dt_test VALUES (3, 'overcast', 83, 78, ' false', ' Play');
+INSERT INTO golf_dt_test VALUES (5, 'rain', 68, 80, ' false', ' Play');
+INSERT INTO golf_dt_test VALUES (7, 'overcast', 64, 65, ' true', ' Play');
+INSERT INTO golf_dt_test VALUES (9, 'sunny', 69, 70, ' false', ' Play');
+INSERT INTO golf_dt_test VALUES (11, 'sunny', 75, 70, ' true', ' Play');
+INSERT INTO golf_dt_test VALUES (13, 'overcast', 81, 75, ' false', ' Play');
+INSERT INTO golf_dt_test VALUES (2, 'sunny', 80, 90, ' true', ' Do not Play');
+INSERT INTO golf_dt_test VALUES (4, 'rain', 70, 96, ' false', ' Play');
+INSERT INTO golf_dt_test VALUES (6, 'rain', 65, 70, ' true', ' Do not Play');
+INSERT INTO golf_dt_test VALUES (8, 'sunny', 72, 95, ' false', ' Do not Play');
+INSERT INTO golf_dt_test VALUES (10, 'rain', 75, 80, ' false', ' Play');
+INSERT INTO golf_dt_test VALUES (12, 'overcast', 72, 90, ' true', ' Play');
+INSERT INTO golf_dt_test VALUES (14, 'rain', 71, 80, ' true', ' Do not Play');
 
-DROP TABLE IF EXISTS MADLIB_SCHEMA.crx_dt_test;
-CREATE TABLE MADLIB_SCHEMA.crx_dt_test (
+CREATE TABLE crx_dt_test (
     id      INTEGER,
     a1      TEXT,
     a2      DOUBLE PRECISION,
@@ -46,499 +44,499 @@ CREATE TABLE MADLIB_SCHEMA.crx_dt_test (
     a16     TEXT
 ) m4_ifdef(`__GREENPLUM__',`DISTRIBUTED BY (id)');
 
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (2, 'a', 58.670000000000002, 4.46, 'u', 'g', 'q', 'h', 3.04, 't', 't', 6, 'f', 'g', 43, 560, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (4, 'b', 27.829999999999998, 1.54, 'u', 'g', 'w', 'v', 3.75, 't', 't', 5, 't', 'g', 100, 3, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (6, 'b', 32.079999999999998, 4, 'u', 'g', 'm', 'v', 2.5, 't', 'f', 0, 't', 'g', 360, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (8, 'a', 22.920000000000002, 11.585000000000001, 'u', 'g', 'cc', 'v', 0.040000000000000001, 't', 'f', 0, 'f', 'g', 80, 1349, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (10, 'b', 42.5, 4.915, 'y', 'p', 'w', 'v', 3.165, 't', 'f', 0, 't', 'g', 52, 1442, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (12, 'b', 29.920000000000002, 1.835, 'u', 'g', 'c', 'h', 4.335, 't', 'f', 0, 'f', 'g', 260, 200, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (14, 'b', 48.079999999999998, 6.04, 'u', 'g', 'k', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 0, 2690, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (16, 'b', 36.670000000000002, 4.415, 'y', 'p', 'k', 'v', 0.25, 't', 't', 10, 't', 'g', 320, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (18, 'a', 23.25, 5.875, 'u', 'g', 'q', 'v', 3.1699999999999999, 't', 't', 10, 'f', 'g', 120, 245, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (20, 'a', 19.170000000000002, 8.5850000000000009, 'u', 'g', 'cc', 'h', 0.75, 't', 't', 7, 'f', 'g', 96, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (22, 'b', 23.25, 1, 'u', 'g', 'c', 'v', 0.83499999999999996, 't', 'f', 0, 'f', 's', 300, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (24, 'a', 27.420000000000002, 14.5, 'u', 'g', 'x', 'h', 3.085, 't', 't', 1, 'f', 'g', 120, 11, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (26, 'a', 15.83, 0.58499999999999996, 'u', 'g', 'c', 'h', 1.5, 't', 't', 2, 'f', 'g', 100, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (28, 'b', 56.579999999999998, 18.5, 'u', 'g', 'd', 'bb', 15, 't', 't', 17, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (30, 'b', 42.079999999999998, 1.04, 'u', 'g', 'w', 'v', 5, 't', 't', 6, 't', 'g', 500, 10000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (32, 'b', 42, 9.7899999999999991, 'u', 'g', 'x', 'h', 7.96, 't', 't', 8, 'f', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (34, 'a', 36.75, 5.125, 'u', 'g', 'e', 'v', 5, 't', 'f', 0, 't', 'g', 0, 4000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (36, 'b', 27.829999999999998, 1.5, 'u', 'g', 'w', 'v', 2, 't', 't', 11, 't', 'g', 434, 35, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (38, 'a', 23, 11.75, 'u', 'g', 'x', 'h', 0.5, 't', 't', 2, 't', 'g', 300, 551, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (40, 'b', 54.579999999999998, 9.4149999999999991, 'u', 'g', 'ff', 'ff', 14.414999999999999, 't', 't', 11, 't', 'g', 30, 300, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (42, 'b', 28.920000000000002, 15, 'u', 'g', 'c', 'h', 5.335, 't', 't', 11, 'f', 'g', 0, 2283, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (44, 'b', 39.579999999999998, 13.914999999999999, 'u', 'g', 'w', 'v', 8.625, 't', 't', 6, 't', 'g', 70, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (46, 'b', 54.329999999999998, 6.75, 'u', 'g', 'c', 'h', 2.625, 't', 't', 11, 't', 'g', 0, 284, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (48, 'b', 31.920000000000002, 4.46, 'u', 'g', 'cc', 'h', 6.04, 't', 't', 3, 'f', 'g', 311, 300, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (50, 'b', 23.920000000000002, 0.66500000000000004, 'u', 'g', 'c', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 100, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (52, 'b', 26, 1, 'u', 'g', 'q', 'v', 1.75, 't', 'f', 0, 't', 'g', 280, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (54, 'b', 34.920000000000002, 2.5, 'u', 'g', 'w', 'v', 0, 't', 'f', 0, 't', 'g', 239, 200, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (56, 'b', 23.329999999999998, 11.625, 'y', 'p', 'w', 'v', 0.83499999999999996, 't', 'f', 0, 't', 'g', 160, 300, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (58, 'b', 44.329999999999998, 0.5, 'u', 'g', 'i', 'h', 5, 't', 'f', 0, 't', 'g', 320, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (60, 'b', 43.25, 3, 'u', 'g', 'q', 'h', 6, 't', 't', 11, 'f', 'g', 80, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (62, 'b', 31.670000000000002, 16.164999999999999, 'u', 'g', 'd', 'v', 3, 't', 't', 9, 'f', 'g', 250, 730, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (64, 'a', 20.420000000000002, 0.83499999999999996, 'u', 'g', 'q', 'v', 1.585, 't', 't', 1, 'f', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (66, 'b', 34.170000000000002, 1.54, 'u', 'g', 'cc', 'v', 1.54, 't', 't', 1, 't', 'g', 520, 50000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (68, 'b', 25.5, 0.375, 'u', 'g', 'm', 'v', 0.25, 't', 't', 3, 'f', 'g', 260, 15108, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (70, 'b', 35.170000000000002, 25.125, 'u', 'g', 'x', 'h', 1.625, 't', 't', 1, 't', 'g', 515, 500, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (72, 'b', 34.829999999999998, 4, 'u', 'g', 'd', 'bb', 12.5, 't', 'f', 0, 't', 'g', NULL, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (74, 'b', 44.25, 0.5, 'u', 'g', 'm', 'v', 10.75, 't', 'f', 0, 'f', 's', 400, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (76, 'b', 20.670000000000002, 5.29, 'u', 'g', 'q', 'v', 0.375, 't', 't', 1, 'f', 'g', 160, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (78, 'a', 19.170000000000002, 0.58499999999999996, 'y', 'p', 'aa', 'v', 0.58499999999999996, 't', 'f', 0, 't', 'g', 160, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (80, 'b', 21.5, 9.75, 'u', 'g', 'c', 'v', 0.25, 't', 'f', 0, 'f', 'g', 140, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (82, 'a', 27.670000000000002, 1.5, 'u', 'g', 'm', 'v', 2, 't', 'f', 0, 'f', 's', 368, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (84, 'a', NULL, 3.5, 'u', 'g', 'd', 'v', 3, 't', 'f', 0, 't', 'g', 300, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (86, 'b', 37.170000000000002, 4, 'u', 'g', 'c', 'bb', 5, 't', 'f', 0, 't', 's', 280, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (88, 'b', 25.670000000000002, 2.21, 'y', 'p', 'aa', 'v', 4, 't', 'f', 0, 'f', 'g', 188, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (90, 'a', 49, 1.5, 'u', 'g', 'j', 'j', 0, 't', 'f', 0, 't', 'g', 100, 27, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (92, 'b', 31.420000000000002, 15.5, 'u', 'g', 'c', 'v', 0.5, 't', 'f', 0, 'f', 'g', 120, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (94, 'b', 52.329999999999998, 1.375, 'y', 'p', 'c', 'h', 9.4600000000000009, 't', 'f', 0, 't', 'g', 200, 100, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (96, 'a', 28.579999999999998, 3.54, 'u', 'g', 'i', 'bb', 0.5, 't', 'f', 0, 't', 'g', 171, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (98, 'b', NULL, 0.5, 'u', 'g', 'c', 'bb', 0.83499999999999996, 't', 'f', 0, 't', 's', 320, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (100, 'a', 28.5, 1, 'u', 'g', 'q', 'v', 1, 't', 't', 2, 't', 'g', 167, 500, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (102, 'b', 35.25, 16.5, 'y', 'p', 'c', 'v', 4, 't', 'f', 0, 'f', 'g', 80, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (104, 'b', 25, 12, 'u', 'g', 'k', 'v', 2.25, 't', 't', 2, 't', 'g', 120, 5, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (106, 'b', 54.829999999999998, 15.5, 'u', 'g', 'e', 'z', 0, 't', 't', 20, 'f', 'g', 152, 130, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (108, 'a', 25, 11, 'y', 'p', 'aa', 'v', 4.5, 't', 'f', 0, 'f', 'g', 120, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (110, 'a', 19.75, 0.75, 'u', 'g', 'c', 'v', 0.79500000000000004, 't', 't', 5, 't', 'g', 140, 5, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (112, 'a', 24.5, 1.04, 'y', 'p', 'ff', 'ff', 0.5, 't', 't', 3, 'f', 'g', 180, 147, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (114, 'a', 33.75, 0.75, 'u', 'g', 'k', 'bb', 1, 't', 't', 3, 't', 'g', 212, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (116, 'a', 25.420000000000002, 1.125, 'u', 'g', 'q', 'v', 1.29, 't', 't', 2, 'f', 'g', 200, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (118, 'b', 52.5, 6.5, 'u', 'g', 'k', 'v', 6.29, 't', 't', 15, 'f', 'g', 0, 11202, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (120, 'a', 20.75, 10.335000000000001, 'u', 'g', 'cc', 'h', 0.33500000000000002, 't', 't', 1, 't', 'g', 80, 50, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (122, 'b', 25.670000000000002, 12.5, 'u', 'g', 'cc', 'v', 1.21, 't', 't', 67, 't', 'g', 140, 258, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (124, 'a', 44.170000000000002, 6.665, 'u', 'g', 'q', 'v', 7.375, 't', 't', 3, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (126, 'b', 34.920000000000002, 5, 'u', 'g', 'x', 'h', 7.5, 't', 't', 6, 't', 'g', 0, 1000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (128, 'b', 22.75, 11, 'u', 'g', 'q', 'v', 2.5, 't', 't', 7, 't', 'g', 100, 809, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (130, 'a', 28.420000000000002, 3.5, 'u', 'g', 'w', 'v', 0.83499999999999996, 't', 'f', 0, 'f', 's', 280, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (132, 'b', 20.420000000000002, 1.835, 'u', 'g', 'c', 'v', 2.25, 't', 't', 1, 'f', 'g', 100, 150, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (134, 'b', 36.25, 5, 'u', 'g', 'c', 'bb', 2.5, 't', 't', 6, 'f', 'g', 0, 367, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (136, 'b', 48.579999999999998, 6.5, 'u', 'g', 'q', 'h', 6, 't', 'f', 0, 't', 'g', 350, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (138, 'b', 33.579999999999998, 2.75, 'u', 'g', 'm', 'v', 4.25, 't', 't', 6, 'f', 'g', 204, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (140, 'a', 26.920000000000002, 13.5, 'u', 'g', 'q', 'h', 5, 't', 't', 2, 'f', 'g', 0, 5000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (142, 'a', 56.5, 16, 'u', 'g', 'j', 'ff', 0, 't', 't', 15, 'f', 'g', 0, 247, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (144, 'b', 22.329999999999998, 11, 'u', 'g', 'w', 'v', 2, 't', 't', 1, 'f', 'g', 80, 278, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (146, 'b', 32.829999999999998, 2.5, 'u', 'g', 'cc', 'h', 2.75, 't', 't', 6, 'f', 'g', 160, 2072, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (148, 'a', 40.329999999999998, 7.54, 'y', 'p', 'q', 'h', 8, 't', 't', 14, 'f', 'g', 0, 2300, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (150, 'a', 52.829999999999998, 15, 'u', 'g', 'c', 'v', 5.5, 't', 't', 14, 'f', 'g', 0, 2200, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (152, 'a', 58.329999999999998, 10, 'u', 'g', 'q', 'v', 4, 't', 't', 14, 'f', 'g', 0, 1602, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (154, 'b', 23.079999999999998, 2.5, 'u', 'g', 'c', 'v', 1.085, 't', 't', 11, 't', 'g', 60, 2184, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (156, 'a', 21.670000000000002, 11.5, 'y', 'p', 'j', 'j', 0, 't', 't', 11, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (158, 'a', 68.670000000000002, 15, 'u', 'g', 'e', 'z', 0, 't', 't', 14, 'f', 'g', 0, 3376, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (160, 'b', 34.079999999999998, 0.080000000000000002, 'y', 'p', 'm', 'bb', 0.040000000000000001, 't', 't', 1, 't', 'g', 280, 2000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (162, 'b', 44, 2, 'u', 'g', 'm', 'v', 1.75, 't', 't', 2, 't', 'g', 0, 15, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (164, 'b', 32, 1.75, 'y', 'p', 'e', 'h', 0.040000000000000001, 't', 'f', 0, 't', 'g', 393, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (166, 'a', 40.829999999999998, 10, 'u', 'g', 'q', 'h', 1.75, 't', 'f', 0, 'f', 'g', 29, 837, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (168, 'a', 32.329999999999998, 0.54000000000000004, 'u', 'g', 'cc', 'v', 0.040000000000000001, 't', 'f', 0, 'f', 'g', 440, 11177, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (170, 'b', 37.5, 1.125, 'y', 'p', 'd', 'v', 1.5, 'f', 'f', 0, 't', 'g', 431, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (172, 'b', 41.329999999999998, 0, 'u', 'g', 'c', 'bb', 15, 't', 'f', 0, 'f', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (174, 'a', 49.829999999999998, 13.585000000000001, 'u', 'g', 'k', 'h', 8.5, 't', 'f', 0, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (176, 'b', 27, 1.5, 'y', 'p', 'w', 'v', 0.375, 't', 'f', 0, 't', 'g', 260, 1065, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (178, 'a', 26.079999999999998, 8.6649999999999991, 'u', 'g', 'aa', 'v', 1.415, 't', 'f', 0, 'f', 'g', 160, 150, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (180, 'b', 20.170000000000002, 8.1699999999999999, 'u', 'g', 'aa', 'v', 1.96, 't', 't', 14, 'f', 'g', 60, 158, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (182, 'a', 21.25, 2.335, 'u', 'g', 'i', 'bb', 0.5, 't', 't', 4, 'f', 's', 80, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (184, 'a', 57.079999999999998, 19.5, 'u', 'g', 'c', 'v', 5.5, 't', 't', 7, 'f', 'g', 0, 3000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (186, 'b', 48.75, 8.5, 'u', 'g', 'c', 'h', 12.5, 't', 't', 9, 'f', 'g', 181, 1655, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (188, 'b', 40.579999999999998, 5, 'u', 'g', 'c', 'v', 5, 't', 't', 7, 'f', 'g', 0, 3065, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (190, 'a', 33.079999999999998, 4.625, 'u', 'g', 'q', 'h', 1.625, 't', 't', 2, 'f', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (192, 'b', 42, 0.20499999999999999, 'u', 'g', 'i', 'h', 5.125, 't', 'f', 0, 'f', 'g', 400, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (194, 'b', 22.670000000000002, 1.585, 'y', 'p', 'w', 'v', 3.085, 't', 't', 6, 'f', 'g', 80, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (196, 'b', 28.25, 5.04, 'y', 'p', 'c', 'bb', 1.5, 't', 't', 8, 't', 'g', 144, 7, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (198, 'b', 48.170000000000002, 7.625, 'u', 'g', 'w', 'h', 15.5, 't', 't', 12, 'f', 'g', 0, 790, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (200, 'b', 22.579999999999998, 10.039999999999999, 'u', 'g', 'x', 'v', 0.040000000000000001, 't', 't', 9, 'f', 'g', 60, 396, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (202, 'a', 41.329999999999998, 1, 'u', 'g', 'i', 'bb', 2.25, 't', 'f', 0, 't', 'g', 0, 300, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (204, 'a', 20.75, 10.25, 'u', 'g', 'q', 'v', 0.70999999999999996, 't', 't', 2, 't', 'g', 49, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (206, 'a', 35.420000000000002, 12, 'u', 'g', 'q', 'h', 14, 't', 't', 8, 'f', 'g', 0, 6590, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (208, 'b', 28.670000000000002, 9.3350000000000009, 'u', 'g', 'q', 'h', 5.665, 't', 't', 6, 'f', 'g', 381, 168, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (210, 'b', 39.5, 4.25, 'u', 'g', 'c', 'bb', 6.5, 't', 't', 16, 'f', 'g', 117, 1210, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (212, 'b', 24.329999999999998, 6.625, 'y', 'p', 'd', 'v', 5.5, 't', 'f', 0, 't', 's', 100, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (214, 'b', 23.079999999999998, 11.5, 'u', 'g', 'i', 'v', 3.5, 't', 't', 9, 'f', 'g', 56, 742, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (216, 'b', 48.170000000000002, 3.5, 'u', 'g', 'aa', 'v', 3.5, 't', 'f', 0, 'f', 's', 230, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (218, 'b', 55.920000000000002, 11.5, 'u', 'g', 'ff', 'ff', 5, 't', 't', 5, 'f', 'g', 0, 8851, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (220, 'a', 18.920000000000002, 9.25, 'y', 'p', 'c', 'v', 1, 't', 't', 4, 't', 'g', 80, 500, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (222, 'b', 65.420000000000002, 11, 'u', 'g', 'e', 'z', 20, 't', 't', 7, 't', 'g', 22, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (224, 'a', 18.829999999999998, 9.5399999999999991, 'u', 'g', 'aa', 'v', 0.085000000000000006, 't', 'f', 0, 'f', 'g', 100, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (226, 'b', 23.25, 4, 'u', 'g', 'c', 'bb', 0.25, 't', 'f', 0, 't', 'g', 160, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (228, 'a', 22.5, 8.4600000000000009, 'y', 'p', 'x', 'v', 2.46, 'f', 'f', 0, 'f', 'g', 164, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (230, 'b', 22.079999999999998, 11, 'u', 'g', 'cc', 'v', 0.66500000000000004, 't', 'f', 0, 'f', 'g', 100, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (232, 'a', 47.420000000000002, 3, 'u', 'g', 'x', 'v', 13.875, 't', 't', 2, 't', 'g', 519, 1704, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (234, 'b', 27.670000000000002, 13.75, 'u', 'g', 'w', 'v', 5.75, 't', 'f', 0, 't', 'g', 487, 500, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (236, 'a', 20.670000000000002, 1.835, 'u', 'g', 'q', 'v', 2.085, 't', 't', 5, 'f', 'g', 220, 2503, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (238, 'b', 21.329999999999998, 7.5, 'u', 'g', 'aa', 'v', 1.415, 't', 't', 1, 'f', 'g', 80, 9800, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (240, 'b', 38.170000000000002, 10.125, 'u', 'g', 'x', 'v', 2.5, 't', 't', 6, 'f', 'g', 520, 196, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (242, 'b', 48.25, 25.085000000000001, 'u', 'g', 'w', 'v', 1.75, 't', 't', 3, 'f', 'g', 120, 14, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (244, 'a', 18.75, 7.5, 'u', 'g', 'q', 'v', 2.71, 't', 't', 5, 'f', 'g', NULL, 26726, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (246, 'b', 33.170000000000002, 3.04, 'y', 'p', 'c', 'h', 2.04, 't', 't', 1, 't', 'g', 180, 18027, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (248, 'a', 19.670000000000002, 0.20999999999999999, 'u', 'g', 'q', 'h', 0.28999999999999998, 't', 't', 11, 'f', 'g', 80, 99, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (250, 'b', 21.829999999999998, 11, 'u', 'g', 'x', 'v', 0.28999999999999998, 't', 't', 6, 'f', 'g', 121, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (252, 'b', 41.420000000000002, 5, 'u', 'g', 'q', 'h', 5, 't', 't', 6, 't', 'g', 470, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (254, 'b', 23.170000000000002, 11.125, 'u', 'g', 'x', 'h', 0.46000000000000002, 't', 't', 1, 'f', 'g', 100, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (257, 'b', 20, 11.045, 'u', 'g', 'c', 'v', 2, 'f', 'f', 0, 't', 'g', 136, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (259, 'a', 20.75, 9.5399999999999991, 'u', 'g', 'i', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 200, 1000, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (261, 'b', 32.75, 2.335, 'u', 'g', 'd', 'h', 5.75, 'f', 'f', 0, 't', 'g', 292, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (263, 'a', 48.170000000000002, 1.335, 'u', 'g', 'i', 'o', 0.33500000000000002, 'f', 'f', 0, 'f', 'g', 0, 120, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (265, 'b', 50.75, 0.58499999999999996, 'u', 'g', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', 145, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (267, 'b', 18.329999999999998, 1.21, 'y', 'p', 'e', 'dd', 0, 'f', 'f', 0, 'f', 'g', 100, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (269, 'b', 59.670000000000002, 1.54, 'u', 'g', 'q', 'v', 0.125, 't', 'f', 0, 't', 'g', 260, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (271, 'b', 37.579999999999998, 0, NULL, NULL, NULL, NULL, 0, 'f', 'f', 0, 'f', 'p', NULL, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (273, 'b', 18.079999999999998, 6.75, 'y', 'p', 'm', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 140, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (275, 'b', 30.670000000000002, 2.5, 'u', 'g', 'cc', 'h', 2.25, 'f', 'f', 0, 't', 's', 340, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (277, 'a', 19.170000000000002, 5.415, 'u', 'g', 'i', 'h', 0.28999999999999998, 'f', 'f', 0, 'f', 'g', 80, 484, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (279, 'b', 24.579999999999998, 13.5, 'y', 'p', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', NULL, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (281, 'b', 21.170000000000002, 0.875, 'y', 'p', 'c', 'h', 0.25, 'f', 'f', 0, 'f', 'g', 280, 204, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (283, 'b', 17.670000000000002, 4.46, 'u', 'g', 'c', 'v', 0.25, 'f', 'f', 0, 'f', 's', 80, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (285, 'b', 23.25, 12.625, 'u', 'g', 'c', 'v', 0.125, 'f', 't', 2, 'f', 'g', 0, 5552, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (287, 'a', NULL, 1.5, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 2, 't', 'g', 200, 105, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (289, 'b', 18.829999999999998, 0.41499999999999998, 'y', 'p', 'c', 'v', 0.16500000000000001, 'f', 't', 1, 'f', 'g', 200, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (291, 'b', 23, 0.75, 'u', 'g', 'm', 'v', 0.5, 'f', 'f', 0, 't', 's', 320, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (293, 'b', 25.420000000000002, 0.54000000000000004, 'u', 'g', 'w', 'v', 0.16500000000000001, 'f', 't', 1, 'f', 'g', 272, 444, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (295, 'a', 16.079999999999998, 0.33500000000000002, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 1, 'f', 'g', 160, 126, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (297, 'b', 69.170000000000002, 9, 'u', 'g', 'ff', 'ff', 4, 'f', 't', 1, 'f', 'g', 70, 6, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (299, 'b', 16.329999999999998, 2.75, 'u', 'g', 'aa', 'v', 0.66500000000000004, 'f', 't', 1, 'f', 'g', 80, 21, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (301, 'a', 57.579999999999998, 2, 'u', 'g', 'ff', 'ff', 6.5, 'f', 't', 1, 'f', 'g', 0, 10, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (303, 'b', 23.420000000000002, 1, 'u', 'g', 'c', 'v', 0.5, 'f', 'f', 0, 't', 's', 280, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (305, 'a', 24.75, 13.664999999999999, 'u', 'g', 'q', 'h', 1.5, 'f', 'f', 0, 'f', 'g', 280, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (307, 'b', 23.5, 2.75, 'u', 'g', 'ff', 'ff', 4.5, 'f', 'f', 0, 'f', 'g', 160, 25, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (309, 'b', 27.75, 1.29, 'u', 'g', 'k', 'h', 0.25, 'f', 'f', 0, 't', 's', 140, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (311, 'a', 24.829999999999998, 4.5, 'u', 'g', 'w', 'v', 1, 'f', 'f', 0, 't', 'g', 360, 6, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (313, 'a', 16.329999999999998, 0.20999999999999999, 'u', 'g', 'aa', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 200, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (315, 'b', 16.25, 0, 'y', 'p', 'aa', 'v', 0.25, 'f', 'f', 0, 'f', 'g', 60, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (317, 'b', 21.170000000000002, 0.25, 'y', 'p', 'c', 'h', 0.25, 'f', 'f', 0, 'f', 'g', 280, 204, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (319, 'b', 19.170000000000002, 0, 'y', 'p', 'm', 'bb', 0, 'f', 'f', 0, 't', 's', 500, 1, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (321, 'b', 21.25, 1.5, 'u', 'g', 'w', 'v', 1.5, 'f', 'f', 0, 'f', 'g', 150, 8, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (323, 'a', 33.670000000000002, 0.375, 'u', 'g', 'cc', 'v', 0.375, 'f', 'f', 0, 'f', 'g', 300, 44, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (325, 'b', 33.670000000000002, 1.25, 'u', 'g', 'w', 'v', 1.165, 'f', 'f', 0, 'f', 'g', 120, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (327, 'b', 30.170000000000002, 1.085, 'y', 'p', 'c', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 170, 179, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (329, 'b', 34.829999999999998, 2.5, 'y', 'p', 'w', 'v', 3, 'f', 'f', 0, 'f', 's', 200, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (331, 'b', 20.420000000000002, 0, NULL, NULL, NULL, NULL, 0, 'f', 'f', 0, 'f', 'p', NULL, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (333, 'b', 34.079999999999998, 2.5, 'u', 'g', 'c', 'v', 1, 'f', 'f', 0, 'f', 'g', 460, 16, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (335, 'b', 34.75, 2.5, 'u', 'g', 'cc', 'bb', 0.5, 'f', 'f', 0, 'f', 'g', 348, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (337, 'b', 47.329999999999998, 6.5, 'u', 'g', 'c', 'v', 1, 'f', 'f', 0, 't', 'g', 0, 228, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (339, 'a', 33.25, 3, 'y', 'p', 'aa', 'v', 2, 'f', 'f', 0, 'f', 'g', 180, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (341, 'a', 39.079999999999998, 4, 'u', 'g', 'c', 'v', 3, 'f', 'f', 0, 'f', 'g', 480, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (343, 'b', 26.920000000000002, 2.25, 'u', 'g', 'i', 'bb', 0.5, 'f', 'f', 0, 't', 'g', 640, 4000, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (345, 'b', 38.920000000000002, 1.75, 'u', 'g', 'k', 'v', 0.5, 'f', 'f', 0, 't', 'g', 300, 2, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (347, NULL, 32.25, 1.5, 'u', 'g', 'c', 'v', 0.25, 'f', 'f', 0, 't', 'g', 372, 122, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (349, 'b', 63.329999999999998, 0.54000000000000004, 'u', 'g', 'c', 'v', 0.58499999999999996, 't', 't', 3, 't', 'g', 180, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (351, 'a', 26.170000000000002, 2, 'u', 'g', 'j', 'j', 0, 'f', 'f', 0, 't', 'g', 276, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (353, 'b', 22.5, 11.5, 'y', 'p', 'm', 'v', 1.5, 'f', 'f', 0, 't', 'g', 0, 4000, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (355, 'b', 36.670000000000002, 2, 'u', 'g', 'i', 'v', 0.25, 'f', 'f', 0, 't', 'g', 221, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (357, 'b', 41.170000000000002, 1.335, 'u', 'g', 'd', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 168, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (359, 'b', 32.420000000000002, 3, 'u', 'g', 'd', 'v', 0.16500000000000001, 'f', 'f', 0, 't', 'g', 120, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (361, 'a', 30.25, 5.5, 'u', 'g', 'k', 'v', 5.5, 'f', 'f', 0, 't', 's', 100, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (363, 'b', 26.829999999999998, 0.54000000000000004, 'u', 'g', 'k', 'ff', 0, 'f', 'f', 0, 'f', 'g', 100, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (365, 'b', 24.420000000000002, 2, 'u', 'g', 'e', 'dd', 0.16500000000000001, 'f', 't', 2, 'f', 'g', 320, 1300, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (367, 'a', 22.75, 6.165, 'u', 'g', 'aa', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 220, 1000, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (369, 'a', 23.579999999999998, 11.5, 'y', 'p', 'k', 'h', 3, 'f', 'f', 0, 't', 'g', 20, 16, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (371, 'b', 33, 2.5, 'y', 'p', 'w', 'v', 7, 'f', 'f', 0, 't', 'g', 280, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (373, 'a', 45, 4.585, 'u', 'g', 'k', 'h', 1, 'f', 'f', 0, 't', 's', 240, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (1, 'b', 30.829999999999998, 0, 'u', 'g', 'w', 'v', 1.25, 't', 't', 1, 'f', 'g', 202, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (3, 'a', 24.5, 0.5, 'u', 'g', 'q', 'h', 1.5, 't', 'f', 0, 'f', 'g', 280, 824, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (5, 'b', 20.170000000000002, 5.625, 'u', 'g', 'w', 'v', 1.71, 't', 'f', 0, 'f', 's', 120, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (7, 'b', 33.170000000000002, 1.04, 'u', 'g', 'r', 'h', 6.5, 't', 'f', 0, 't', 'g', 164, 31285, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (9, 'b', 54.420000000000002, 0.5, 'y', 'p', 'k', 'h', 3.96, 't', 'f', 0, 'f', 'g', 180, 314, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (11, 'b', 22.079999999999998, 0.82999999999999996, 'u', 'g', 'c', 'h', 2.165, 'f', 'f', 0, 't', 'g', 128, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (13, 'a', 38.25, 6, 'u', 'g', 'k', 'v', 1, 't', 'f', 0, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (15, 'a', 45.829999999999998, 10.5, 'u', 'g', 'q', 'v', 5, 't', 't', 7, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (17, 'b', 28.25, 0.875, 'u', 'g', 'm', 'v', 0.95999999999999996, 't', 't', 3, 't', 'g', 396, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (19, 'b', 21.829999999999998, 0.25, 'u', 'g', 'd', 'h', 0.66500000000000004, 't', 'f', 0, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (21, 'b', 25, 11.25, 'u', 'g', 'c', 'v', 2.5, 't', 't', 17, 'f', 'g', 200, 1208, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (23, 'a', 47.75, 8, 'u', 'g', 'c', 'v', 7.875, 't', 't', 6, 't', 'g', 0, 1260, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (25, 'a', 41.170000000000002, 6.5, 'u', 'g', 'q', 'v', 0.5, 't', 't', 3, 't', 'g', 145, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (27, 'a', 47, 13, 'u', 'g', 'i', 'bb', 5.165, 't', 't', 9, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (29, 'b', 57.420000000000002, 8.5, 'u', 'g', 'e', 'h', 7, 't', 't', 3, 'f', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (31, 'b', 29.25, 14.789999999999999, 'u', 'g', 'aa', 'v', 5.04, 't', 't', 5, 't', 'g', 168, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (33, 'b', 49.5, 7.585, 'u', 'g', 'i', 'bb', 7.585, 't', 't', 15, 't', 'g', 0, 5000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (35, 'a', 22.579999999999998, 10.75, 'u', 'g', 'q', 'v', 0.41499999999999998, 't', 't', 5, 't', 'g', 0, 560, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (37, 'b', 27.25, 1.585, 'u', 'g', 'cc', 'h', 1.835, 't', 't', 12, 't', 'g', 583, 713, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (39, 'b', 27.75, 0.58499999999999996, 'y', 'p', 'cc', 'v', 0.25, 't', 't', 2, 'f', 'g', 260, 500, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (41, 'b', 34.170000000000002, 9.1699999999999999, 'u', 'g', 'c', 'v', 4.5, 't', 't', 12, 't', 'g', 0, 221, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (43, 'b', 29.670000000000002, 1.415, 'u', 'g', 'w', 'h', 0.75, 't', 't', 1, 'f', 'g', 240, 100, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (45, 'b', 56.420000000000002, 28, 'y', 'p', 'c', 'v', 28.5, 't', 't', 40, 'f', 'g', 0, 15, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (47, 'a', 41, 2.04, 'y', 'p', 'q', 'h', 0.125, 't', 't', 23, 't', 'g', 455, 1236, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (49, 'b', 41.5, 1.54, 'u', 'g', 'i', 'bb', 3.5, 'f', 'f', 0, 'f', 'g', 216, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (51, 'a', 25.75, 0.5, 'u', 'g', 'c', 'h', 0.875, 't', 'f', 0, 't', 'g', 491, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (53, 'b', 37.420000000000002, 2.04, 'u', 'g', 'w', 'v', 0.040000000000000001, 't', 'f', 0, 't', 'g', 400, 5800, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (55, 'b', 34.25, 3, 'u', 'g', 'cc', 'h', 7.415, 't', 'f', 0, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (57, 'b', 23.170000000000002, 0, 'u', 'g', 'cc', 'v', 0.085000000000000006, 't', 'f', 0, 'f', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (59, 'b', 35.170000000000002, 4.5, 'u', 'g', 'x', 'h', 5.75, 'f', 'f', 0, 't', 's', 711, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (61, 'b', 56.75, 12.25, 'u', 'g', 'm', 'v', 1.25, 't', 't', 4, 't', 'g', 200, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (63, 'a', 23.420000000000002, 0.79000000000000004, 'y', 'p', 'q', 'v', 1.5, 't', 't', 2, 't', 'g', 80, 400, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (65, 'b', 26.670000000000002, 4.25, 'u', 'g', 'cc', 'v', 4.29, 't', 't', 1, 't', 'g', 120, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (67, 'a', 36, 1, 'u', 'g', 'c', 'v', 2, 't', 't', 11, 'f', 'g', 0, 456, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (69, 'b', 19.420000000000002, 6.5, 'u', 'g', 'w', 'h', 1.46, 't', 't', 7, 'f', 'g', 80, 2954, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (71, 'b', 32.329999999999998, 7.5, 'u', 'g', 'e', 'bb', 1.585, 't', 'f', 0, 't', 's', 420, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (73, 'a', 38.579999999999998, 5, 'u', 'g', 'cc', 'v', 13.5, 't', 'f', 0, 't', 'g', 980, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (75, 'b', 44.829999999999998, 7, 'y', 'p', 'c', 'v', 1.625, 'f', 'f', 0, 'f', 'g', 160, 2, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (77, 'b', 34.079999999999998, 6.5, 'u', 'g', 'aa', 'v', 0.125, 't', 'f', 0, 't', 'g', 443, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (79, 'b', 21.670000000000002, 1.165, 'y', 'p', 'k', 'v', 2.5, 't', 't', 1, 'f', 'g', 180, 20, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (81, 'b', 49.579999999999998, 19, 'u', 'g', 'ff', 'ff', 0, 't', 't', 1, 'f', 'g', 94, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (83, 'b', 39.829999999999998, 0.5, 'u', 'g', 'm', 'v', 0.25, 't', 'f', 0, 'f', 's', 288, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (85, 'b', 27.25, 0.625, 'u', 'g', 'aa', 'v', 0.45500000000000002, 't', 'f', 0, 't', 'g', 200, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (87, 'b', NULL, 0.375, 'u', 'g', 'd', 'v', 0.875, 't', 'f', 0, 't', 's', 928, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (89, 'b', 34, 4.5, 'u', 'g', 'aa', 'v', 1, 't', 'f', 0, 't', 'g', 240, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (91, 'b', 62.5, 12.75, 'y', 'p', 'c', 'h', 5, 't', 'f', 0, 'f', 'g', 112, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (93, 'b', NULL, 5, 'y', 'p', 'aa', 'v', 8.5, 't', 'f', 0, 'f', 'g', 0, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (95, 'b', 28.75, 1.5, 'y', 'p', 'c', 'v', 1.5, 't', 'f', 0, 't', 'g', 0, 225, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (97, 'b', 23, 0.625, 'y', 'p', 'aa', 'v', 0.125, 't', 'f', 0, 'f', 'g', 180, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (99, 'a', 22.5, 11, 'y', 'p', 'q', 'v', 3, 't', 'f', 0, 't', 'g', 268, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (101, 'b', 37.5, 1.75, 'y', 'p', 'c', 'bb', 0.25, 't', 'f', 0, 't', 'g', 164, 400, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (103, 'b', 18.670000000000002, 5, 'u', 'g', 'q', 'v', 0.375, 't', 't', 2, 'f', 'g', 0, 38, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (105, 'b', 27.829999999999998, 4, 'y', 'p', 'i', 'h', 5.75, 't', 't', 2, 't', 'g', 75, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (107, 'b', 28.75, 1.165, 'u', 'g', 'k', 'v', 0.5, 't', 'f', 0, 'f', 's', 280, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (109, 'b', 40.920000000000002, 2.25, 'y', 'p', 'x', 'h', 10, 't', 'f', 0, 't', 'g', 176, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (111, 'b', 29.170000000000002, 3.5, 'u', 'g', 'w', 'v', 3.5, 't', 't', 3, 't', 'g', 329, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (113, 'b', 24.579999999999998, 12.5, 'u', 'g', 'w', 'v', 0.875, 't', 'f', 0, 't', 'g', 260, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (115, 'b', 20.670000000000002, 1.25, 'y', 'p', 'c', 'h', 1.375, 't', 't', 3, 't', 'g', 140, 210, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (117, 'b', 37.75, 7, 'u', 'g', 'q', 'h', 11.5, 't', 't', 7, 't', 'g', 300, 5, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (119, 'b', 57.829999999999998, 7.04, 'u', 'g', 'm', 'v', 14, 't', 't', 6, 't', 'g', 360, 1332, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (121, 'b', 39.920000000000002, 6.21, 'u', 'g', 'q', 'v', 0.040000000000000001, 't', 't', 1, 'f', 'g', 200, 300, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (123, 'a', 24.75, 12.5, 'u', 'g', 'aa', 'v', 1.5, 't', 't', 12, 't', 'g', 120, 567, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (125, 'a', 23.5, 9, 'u', 'g', 'q', 'v', 8.5, 't', 't', 5, 't', 'g', 120, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (127, 'b', 47.670000000000002, 2.5, 'u', 'g', 'm', 'bb', 2.5, 't', 't', 12, 't', 'g', 410, 2510, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (129, 'b', 34.420000000000002, 4.25, 'u', 'g', 'i', 'bb', 3.25, 't', 't', 2, 'f', 'g', 274, 610, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (131, 'b', 67.75, 5.5, 'u', 'g', 'e', 'z', 13, 't', 't', 1, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (133, 'a', 47.420000000000002, 8, 'u', 'g', 'e', 'bb', 6.5, 't', 't', 6, 'f', 'g', 375, 51100, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (135, 'b', 32.670000000000002, 5.5, 'u', 'g', 'q', 'h', 5.5, 't', 't', 12, 't', 'g', 408, 1000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (137, 'b', 39.920000000000002, 0.54000000000000004, 'y', 'p', 'aa', 'v', 0.5, 't', 't', 3, 'f', 'g', 200, 1000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (139, 'a', 18.829999999999998, 9.5, 'u', 'g', 'w', 'v', 1.625, 't', 't', 6, 't', 'g', 40, 600, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (141, 'a', 31.25, 3.75, 'u', 'g', 'cc', 'h', 0.625, 't', 't', 9, 't', 'g', 181, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (143, 'b', 43, 0.28999999999999998, 'y', 'p', 'cc', 'h', 1.75, 't', 't', 8, 'f', 'g', 100, 375, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (145, 'b', 27.25, 1.665, 'u', 'g', 'cc', 'h', 5.085, 't', 't', 9, 'f', 'g', 399, 827, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (147, 'b', 23.25, 1.5, 'u', 'g', 'q', 'v', 2.375, 't', 't', 3, 't', 'g', 0, 582, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (149, 'a', 30.5, 6.5, 'u', 'g', 'c', 'bb', 4, 't', 't', 7, 't', 'g', 0, 3065, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (151, 'a', 46.670000000000002, 0.46000000000000002, 'u', 'g', 'cc', 'h', 0.41499999999999998, 't', 't', 11, 't', 'g', 440, 6, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (153, 'b', 37.329999999999998, 6.5, 'u', 'g', 'm', 'h', 4.25, 't', 't', 12, 't', 'g', 93, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (155, 'b', 32.75, 1.5, 'u', 'g', 'cc', 'h', 5.5, 't', 't', 3, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (157, 'a', 28.5, 3.04, 'y', 'p', 'x', 'h', 2.54, 't', 't', 1, 'f', 'g', 70, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (159, 'b', 28, 2, 'u', 'g', 'k', 'h', 4.165, 't', 't', 2, 't', 'g', 181, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (161, 'b', 27.670000000000002, 2, 'u', 'g', 'x', 'h', 1, 't', 't', 4, 'f', 'g', 140, 7544, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (163, 'b', 25.079999999999998, 1.71, 'u', 'g', 'x', 'v', 1.665, 't', 't', 1, 't', 'g', 395, 20, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (165, 'a', 60.579999999999998, 16.5, 'u', 'g', 'q', 'v', 11, 't', 'f', 0, 't', 'g', 21, 10561, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (167, 'b', 19.329999999999998, 9.5, 'u', 'g', 'q', 'v', 1, 't', 'f', 0, 't', 'g', 60, 400, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (169, 'b', 36.670000000000002, 3.25, 'u', 'g', 'q', 'h', 9, 't', 'f', 0, 't', 'g', 102, 639, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (171, 'a', 25.079999999999998, 2.54, 'y', 'p', 'aa', 'v', 0.25, 't', 'f', 0, 't', 'g', 370, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (173, 'b', 56, 12.5, 'u', 'g', 'k', 'h', 8, 't', 'f', 0, 't', 'g', 24, 2028, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (175, 'b', 22.670000000000002, 10.5, 'u', 'g', 'q', 'h', 1.335, 't', 'f', 0, 'f', 'g', 100, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (177, 'b', 25, 12.5, 'u', 'g', 'aa', 'v', 3, 't', 'f', 0, 't', 's', 20, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (179, 'a', 18.420000000000002, 9.25, 'u', 'g', 'q', 'v', 1.21, 't', 't', 4, 'f', 'g', 60, 540, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (181, 'b', 47.670000000000002, 0.28999999999999998, 'u', 'g', 'c', 'bb', 15, 't', 't', 20, 'f', 'g', 0, 15000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (183, 'a', 20.670000000000002, 3, 'u', 'g', 'q', 'v', 0.16500000000000001, 't', 't', 3, 'f', 'g', 100, 6, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (185, 'a', 22.420000000000002, 5.665, 'u', 'g', 'q', 'v', 2.585, 't', 't', 7, 'f', 'g', 129, 3257, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (375, NULL, 28.170000000000002, 0.58499999999999996, 'u', 'g', 'aa', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 260, 1004, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (377, 'b', 28.670000000000002, 14.5, 'u', 'g', 'd', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 0, 286, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (379, 'b', 34.420000000000002, 1.335, 'u', 'g', 'i', 'bb', 0.125, 'f', 'f', 0, 't', 'g', 440, 4500, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (381, 'b', 43.170000000000002, 5, 'u', 'g', 'i', 'bb', 2.25, 'f', 'f', 0, 't', 'g', 141, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (383, 'a', 24.329999999999998, 2.5, 'y', 'p', 'i', 'bb', 4.5, 'f', 'f', 0, 'f', 'g', 200, 456, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (385, 'b', 22.079999999999998, 11.460000000000001, 'u', 'g', 'k', 'v', 1.585, 'f', 'f', 0, 't', 'g', 100, 1212, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (387, 'b', 22.579999999999998, 1.5, 'y', 'p', 'aa', 'v', 0.54000000000000004, 'f', 'f', 0, 't', 'g', 120, 67, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (389, 'b', 26.670000000000002, 14.585000000000001, 'u', 'g', 'i', 'bb', 0, 'f', 'f', 0, 't', 'g', 178, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (391, 'b', 15.17, 7, 'u', 'g', 'e', 'v', 1, 'f', 'f', 0, 'f', 'g', 600, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (393, 'b', 27.420000000000002, 12.5, 'u', 'g', 'aa', 'bb', 0.25, 'f', 'f', 0, 't', 'g', 720, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (395, 'b', 41.170000000000002, 1.25, 'y', 'p', 'w', 'v', 0.25, 'f', 'f', 0, 'f', 'g', 0, 195, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (397, 'b', 29.829999999999998, 2.04, 'y', 'p', 'x', 'h', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 128, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (399, 'b', 26.170000000000002, 12.5, 'y', 'p', 'k', 'h', 1.25, 'f', 'f', 0, 't', 'g', 0, 17, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (401, 'b', 20.75, 5.085, 'y', 'p', 'j', 'v', 0.28999999999999998, 'f', 'f', 0, 'f', 'g', 140, 184, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (403, 'a', 51.920000000000002, 6.5, 'u', 'g', 'i', 'bb', 3.085, 'f', 'f', 0, 't', 'g', 73, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (405, 'b', 34, 5.085, 'y', 'p', 'i', 'bb', 1.085, 'f', 'f', 0, 't', 'g', 480, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (407, 'a', 40.329999999999998, 8.125, 'y', 'p', 'k', 'v', 0.16500000000000001, 'f', 't', 2, 'f', 'g', NULL, 18, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (409, 'b', 16, 3.125, 'u', 'g', 'w', 'v', 0.085000000000000006, 'f', 't', 1, 'f', 'g', 0, 6, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (411, 'b', 31.25, 2.835, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 5, 'f', 'g', 176, 146, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (413, 'a', 22.670000000000002, 0.79000000000000004, 'u', 'g', 'i', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 144, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (415, 'b', 22.25, 0.46000000000000002, 'u', 'g', 'k', 'v', 0.125, 'f', 'f', 0, 't', 'g', 280, 55, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (417, 'b', 22.5, 0.125, 'y', 'p', 'k', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 200, 70, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (419, 'b', 38.420000000000002, 0.70499999999999996, 'u', 'g', 'c', 'v', 0.375, 'f', 't', 2, 'f', 'g', 225, 500, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (421, 'b', 35, 2.5, 'u', 'g', 'i', 'v', 1, 'f', 'f', 0, 't', 'g', 210, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (423, 'b', 29.420000000000002, 1.25, 'u', 'g', 'w', 'v', 1.75, 'f', 'f', 0, 'f', 'g', 200, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (425, 'b', 33.670000000000002, 2.165, 'u', 'g', 'c', 'v', 1.5, 'f', 'f', 0, 'f', 'p', 120, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (427, 'a', 27.670000000000002, 2.04, 'u', 'g', 'w', 'v', 0.25, 'f', 'f', 0, 't', 'g', 180, 50, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (429, 'b', 49.170000000000002, 2.29, 'u', 'g', 'ff', 'ff', 0.28999999999999998, 'f', 'f', 0, 'f', 'g', 200, 3, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (431, 'b', 51.829999999999998, 3, 'y', 'p', 'ff', 'ff', 1.5, 'f', 'f', 0, 'f', 'g', 180, 4, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (433, 'b', 21.829999999999998, 1.54, 'u', 'g', 'k', 'v', 0.085000000000000006, 'f', 'f', 0, 't', 'g', 356, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (435, 'b', 58.579999999999998, 2.71, 'u', 'g', 'c', 'v', 2.415, 'f', 'f', 0, 't', 'g', 320, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (437, 'b', 19.579999999999998, 0.58499999999999996, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 3, 'f', 'g', 350, 769, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (439, 'a', 27.170000000000002, 1.25, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 1, 'f', 'g', 92, 300, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (441, 'b', 23.079999999999998, 0, 'u', 'g', 'k', 'v', 1, 'f', 't', 11, 'f', 's', 0, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (443, 'b', 30.579999999999998, 2.71, 'y', 'p', 'm', 'v', 0.125, 'f', 'f', 0, 't', 's', 80, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (445, 'a', 17.670000000000002, 0, 'y', 'p', 'j', 'ff', 0, 'f', 'f', 0, 'f', 'g', 86, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (447, 'b', 16.5, 0.125, 'u', 'g', 'c', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 132, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (449, 'b', 31.25, 1.125, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 1, 'f', 'g', 96, 19, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (451, 'b', NULL, 3, 'y', 'p', 'i', 'bb', 7, 'f', 'f', 0, 'f', 'g', 0, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (453, 'b', 36.5, 4.25, 'u', 'g', 'q', 'v', 3.5, 'f', 'f', 0, 'f', 'g', 454, 50, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (455, 'b', 52.420000000000002, 1.5, 'u', 'g', 'd', 'v', 3.75, 'f', 'f', 0, 't', 'g', 0, 350, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (457, 'b', 34.579999999999998, 0, NULL, NULL, NULL, NULL, 0, 'f', 'f', 0, 'f', 'p', NULL, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (459, 'b', 36.170000000000002, 5.5, 'u', 'g', 'i', 'bb', 5, 'f', 'f', 0, 'f', 'g', 210, 687, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (461, 'a', 24.5, 2.415, 'y', 'p', 'c', 'v', 0, 'f', 'f', 0, 'f', 'g', 120, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (463, 'b', 21.920000000000002, 0.5, 'u', 'g', 'c', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 360, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (465, 'a', 23, 1.835, 'u', 'g', 'j', 'j', 0, 'f', 't', 1, 'f', 'g', 200, 53, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (467, 'b', 31.079999999999998, 3.085, 'u', 'g', 'c', 'v', 2.5, 'f', 't', 2, 't', 'g', 160, 41, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (469, 'b', 22.079999999999998, 2.335, 'u', 'g', 'k', 'v', 0.75, 'f', 'f', 0, 'f', 'g', 180, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (471, 'a', 21.920000000000002, 11.664999999999999, 'u', 'g', 'k', 'h', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 320, 5, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (473, 'b', 17.420000000000002, 6.5, 'u', 'g', 'i', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 60, 100, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (475, 'b', 20.670000000000002, 0.41499999999999998, 'u', 'g', 'c', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 0, 44, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (477, 'b', 23.579999999999998, 0.83499999999999996, 'u', 'g', 'i', 'h', 0.085000000000000006, 'f', 'f', 0, 't', 'g', 220, 5, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (479, 'b', 22.75, 11.5, 'u', 'g', 'i', 'v', 0.41499999999999998, 'f', 'f', 0, 'f', 'g', 0, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (481, 'a', 16.920000000000002, 0.5, 'u', 'g', 'i', 'v', 0.16500000000000001, 'f', 't', 6, 't', 'g', 240, 35, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (483, 'a', 17.329999999999998, 9.5, 'u', 'g', 'aa', 'v', 1.75, 'f', 't', 10, 't', 'g', 0, 10, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (485, 'b', 34.670000000000002, 1.0800000000000001, 'u', 'g', 'm', 'v', 1.165, 'f', 'f', 0, 'f', 's', 28, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (487, 'b', 28.170000000000002, 0.125, 'y', 'p', 'k', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 216, 2100, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (489, 'b', 18.829999999999998, 3.54, 'y', 'p', 'ff', 'ff', 0, 'f', 'f', 0, 't', 'g', 180, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (187, 'b', 40, 6.5, 'u', 'g', 'aa', 'bb', 3.5, 't', 't', 1, 'f', 'g', 0, 500, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (189, 'a', 28.670000000000002, 1.04, 'u', 'g', 'c', 'v', 2.5, 't', 't', 5, 't', 'g', 300, 1430, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (191, 'b', 21.329999999999998, 10.5, 'u', 'g', 'c', 'v', 3, 't', 'f', 0, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (193, 'b', 41.75, 0.95999999999999996, 'u', 'g', 'x', 'v', 2.5, 't', 'f', 0, 'f', 'g', 510, 600, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (195, 'b', 34.5, 4.04, 'y', 'p', 'i', 'bb', 8.5, 't', 't', 7, 't', 'g', 195, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (197, 'b', 33.170000000000002, 3.165, 'y', 'p', 'x', 'v', 3.165, 't', 't', 3, 't', 'g', 380, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (199, 'b', 27.579999999999998, 2.04, 'y', 'p', 'aa', 'v', 2, 't', 't', 3, 't', 'g', 370, 560, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (201, 'a', 24.079999999999998, 0.5, 'u', 'g', 'q', 'h', 1.25, 't', 't', 1, 'f', 'g', 0, 678, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (203, 'b', 24.829999999999998, 2.75, 'u', 'g', 'c', 'v', 2.25, 't', 't', 6, 'f', 'g', NULL, 600, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (205, 'b', 36.329999999999998, 2.125, 'y', 'p', 'w', 'v', 0.085000000000000006, 't', 't', 1, 'f', 'g', 50, 1187, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (207, 'a', 71.579999999999998, 0, NULL, NULL, NULL, NULL, 0, 'f', 'f', 0, 'f', 'p', NULL, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (209, 'b', 35.170000000000002, 2.5, 'u', 'g', 'k', 'v', 4.5, 't', 't', 7, 'f', 'g', 150, 1270, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (211, 'b', 39.329999999999998, 5.875, 'u', 'g', 'cc', 'h', 10, 't', 't', 14, 't', 'g', 399, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (213, 'b', 60.079999999999998, 14.5, 'u', 'g', 'ff', 'ff', 18, 't', 't', 15, 't', 'g', 0, 1000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (215, 'b', 26.670000000000002, 2.71, 'y', 'p', 'cc', 'v', 5.25, 't', 't', 1, 'f', 'g', 211, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (217, 'b', 41.170000000000002, 4.04, 'u', 'g', 'cc', 'h', 7, 't', 't', 8, 'f', 'g', 320, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (219, 'b', 53.920000000000002, 9.625, 'u', 'g', 'e', 'v', 8.6649999999999991, 't', 't', 5, 'f', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (221, 'a', 50.079999999999998, 12.539999999999999, 'u', 'g', 'aa', 'v', 2.29, 't', 't', 3, 't', 'g', 156, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (223, 'a', 17.579999999999998, 9, 'u', 'g', 'aa', 'v', 1.375, 't', 'f', 0, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (225, 'a', 37.75, 5.5, 'u', 'g', 'q', 'v', 0.125, 't', 'f', 0, 't', 'g', 228, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (227, 'b', 18.079999999999998, 5.5, 'u', 'g', 'k', 'v', 0.5, 't', 'f', 0, 'f', 'g', 80, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (229, 'b', 19.670000000000002, 0.375, 'u', 'g', 'q', 'v', 2, 't', 't', 2, 't', 'g', 80, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (231, 'b', 25.170000000000002, 3.5, 'u', 'g', 'cc', 'v', 0.625, 't', 't', 7, 'f', 'g', 0, 7059, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (233, 'b', 33.5, 1.75, 'u', 'g', 'x', 'h', 4.5, 't', 't', 4, 't', 'g', 253, 857, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (235, 'a', 58.420000000000002, 21, 'u', 'g', 'i', 'bb', 10, 't', 't', 13, 'f', 'g', 0, 6700, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (237, 'b', 26.170000000000002, 0.25, 'u', 'g', 'i', 'bb', 0, 't', 'f', 0, 't', 'g', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (239, 'b', 42.829999999999998, 4.625, 'u', 'g', 'q', 'v', 4.5800000000000001, 't', 'f', 0, 'f', 's', 0, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (241, 'b', 20.5, 10, 'y', 'p', 'c', 'v', 2.5, 't', 'f', 0, 'f', 's', 40, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (243, 'b', 28.329999999999998, 5, 'u', 'g', 'w', 'v', 11, 't', 'f', 0, 't', 'g', 70, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (245, 'b', 18.5, 2, 'u', 'g', 'i', 'v', 1.5, 't', 't', 2, 'f', 'g', 120, 300, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (247, 'b', 45, 8.5, 'u', 'g', 'cc', 'h', 14, 't', 't', 1, 't', 'g', 88, 2000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (249, NULL, 24.5, 12.75, 'u', 'g', 'c', 'bb', 4.75, 't', 't', 2, 'f', 'g', 73, 444, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (251, 'b', 40.25, 21.5, 'u', 'g', 'e', 'z', 20, 't', 't', 11, 'f', 'g', 0, 1200, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (253, 'a', 17.829999999999998, 11, 'u', 'g', 'x', 'h', 1, 't', 't', 11, 'f', 'g', 0, 3000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (255, 'b', NULL, 0.625, 'u', 'g', 'k', 'v', 0.25, 'f', 'f', 0, 'f', 'g', 380, 2010, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (256, 'b', 18.170000000000002, 10.25, 'u', 'g', 'c', 'h', 1.085, 'f', 'f', 0, 'f', 'g', 320, 13, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (258, 'b', 20, 0, 'u', 'g', 'd', 'v', 0.5, 'f', 'f', 0, 'f', 'g', 144, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (260, 'a', 24.5, 1.75, 'y', 'p', 'c', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 132, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (262, 'a', 52.170000000000002, 0, 'y', 'p', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', 0, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (264, 'a', 20.420000000000002, 10.5, 'y', 'p', 'x', 'h', 0, 'f', 'f', 0, 't', 'g', 154, 32, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (266, 'b', 17.079999999999998, 0.085000000000000006, 'y', 'p', 'c', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 140, 722, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (268, 'a', 32, 6, 'u', 'g', 'd', 'v', 1.25, 'f', 'f', 0, 'f', 'g', 272, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (270, 'b', 18, 0.16500000000000001, 'u', 'g', 'q', 'n', 0.20999999999999999, 'f', 'f', 0, 'f', 'g', 200, 40, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (272, 'b', 32.329999999999998, 2.5, 'u', 'g', 'c', 'v', 1.25, 'f', 'f', 0, 't', 'g', 280, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (274, 'b', 38.25, 10.125, 'y', 'p', 'k', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 160, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (276, 'b', 18.579999999999998, 5.71, 'u', 'g', 'd', 'v', 0.54000000000000004, 'f', 'f', 0, 'f', 'g', 120, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (278, 'a', 18.170000000000002, 10, 'y', 'p', 'q', 'h', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 340, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (280, 'b', 16.25, 0.83499999999999996, 'u', 'g', 'm', 'v', 0.085000000000000006, 't', 'f', 0, 'f', 's', 200, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (282, 'b', 23.920000000000002, 0.58499999999999996, 'y', 'p', 'cc', 'h', 0.125, 'f', 'f', 0, 'f', 'g', 240, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (284, 'a', 16.5, 1.25, 'u', 'g', 'q', 'v', 0.25, 'f', 't', 1, 'f', 'g', 108, 98, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (286, 'b', 17.579999999999998, 10, 'u', 'g', 'w', 'h', 0.16500000000000001, 'f', 't', 1, 'f', 'g', 120, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (288, 'b', 29.5, 0.57999999999999996, 'u', 'g', 'w', 'v', 0.28999999999999998, 'f', 't', 1, 'f', 'g', 340, 2803, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (290, 'a', 21.75, 1.75, 'y', 'p', 'j', 'j', 0, 'f', 'f', 0, 'f', 'g', 160, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (292, 'a', 18.25, 10, 'u', 'g', 'w', 'v', 1, 'f', 't', 1, 'f', 'g', 120, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (294, 'b', 35.75, 2.415, 'u', 'g', 'w', 'v', 0.125, 'f', 't', 2, 'f', 'g', 220, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (296, 'a', 31.920000000000002, 3.125, 'u', 'g', 'ff', 'ff', 3.04, 'f', 't', 2, 't', 'g', 200, 4, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (298, 'b', 32.920000000000002, 2.5, 'u', 'g', 'aa', 'v', 1.75, 'f', 't', 2, 't', 'g', 720, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (300, 'b', 22.170000000000002, 12.125, 'u', 'g', 'c', 'v', 3.335, 'f', 't', 2, 't', 'g', 180, 173, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (302, 'b', 18.25, 0.16500000000000001, 'u', 'g', 'd', 'v', 0.25, 'f', 'f', 0, 't', 's', 280, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (304, 'a', 15.92, 2.875, 'u', 'g', 'q', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 120, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (306, 'b', 48.75, 26.335000000000001, 'y', 'p', 'ff', 'ff', 0, 't', 'f', 0, 't', 'g', 0, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (308, 'b', 18.579999999999998, 10.289999999999999, 'u', 'g', 'ff', 'ff', 0.41499999999999998, 'f', 'f', 0, 'f', 'g', 80, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (310, 'a', 31.75, 3, 'y', 'p', 'j', 'j', 0, 'f', 'f', 0, 'f', 'g', 160, 20, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (312, 'b', 19, 1.75, 'y', 'p', 'c', 'v', 2.335, 'f', 'f', 0, 't', 'g', 112, 6, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (314, 'a', 18.579999999999998, 10, 'u', 'g', 'd', 'v', 0.41499999999999998, 'f', 'f', 0, 'f', 'g', 80, 42, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (316, 'b', 23, 0.75, 'u', 'g', 'm', 'v', 0.5, 't', 'f', 0, 't', 's', 320, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (318, 'b', 17.5, 22, 'l', 'gg', 'ff', 'o', 0, 'f', 'f', 0, 't', 'p', 450, 100000, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (320, 'b', 36.75, 0.125, 'y', 'p', 'c', 'v', 1.5, 'f', 'f', 0, 't', 'g', 232, 113, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (322, 'a', 18.079999999999998, 0.375, 'l', 'gg', 'cc', 'ff', 10, 'f', 'f', 0, 't', 's', 300, 0, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (324, 'b', 48.579999999999998, 0.20499999999999999, 'y', 'p', 'k', 'v', 0.25, 't', 't', 11, 'f', 'g', 380, 2732, '+');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (326, 'a', 29.5, 1.085, 'y', 'p', 'x', 'v', 1, 'f', 'f', 0, 'f', 'g', 280, 13, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (328, NULL, 40.829999999999998, 3.5, 'u', 'g', 'i', 'bb', 0.5, 'f', 'f', 0, 'f', 's', 1160, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (330, 'b', NULL, 4, 'y', 'p', 'i', 'v', 0.085000000000000006, 'f', 'f', 0, 't', 'g', 411, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (332, 'a', 33.25, 2.5, 'y', 'p', 'c', 'v', 2.5, 'f', 'f', 0, 't', 'g', 0, 2, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (334, 'a', 25.25, 12.5, 'u', 'g', 'd', 'v', 1, 'f', 'f', 0, 't', 'g', 180, 1062, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (336, 'b', 27.670000000000002, 0.75, 'u', 'g', 'q', 'h', 0.16500000000000001, 'f', 'f', 0, 't', 'g', 220, 251, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (338, 'a', 34.829999999999998, 1.25, 'y', 'p', 'i', 'h', 0.5, 'f', 'f', 0, 't', 'g', 160, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (340, 'b', 28, 3, 'u', 'g', 'w', 'v', 0.75, 'f', 'f', 0, 't', 'g', 300, 67, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (342, 'b', 42.75, 4.085, 'u', 'g', 'aa', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 108, 100, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (344, 'b', 33.75, 2.75, 'u', 'g', 'i', 'bb', 0, 'f', 'f', 0, 'f', 'g', 180, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (346, 'b', 62.75, 7, 'u', 'g', 'e', 'z', 0, 'f', 'f', 0, 'f', 'g', 0, 12, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (348, 'b', 26.75, 4.5, 'y', 'p', 'c', 'bb', 2.5, 'f', 'f', 0, 'f', 'g', 200, 1210, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (350, 'b', 27.829999999999998, 1.5, 'u', 'g', 'w', 'v', 2.25, 'f', 't', 1, 't', 'g', 100, 3, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (352, 'b', 22.170000000000002, 0.58499999999999996, 'y', 'p', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', 100, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (354, 'b', 30.75, 1.585, 'u', 'g', 'd', 'v', 0.58499999999999996, 'f', 'f', 0, 't', 's', 0, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (356, 'a', 16, 0.16500000000000001, 'u', 'g', 'aa', 'v', 1, 'f', 't', 2, 't', 'g', 320, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (358, 'a', 19.5, 0.16500000000000001, 'u', 'g', 'q', 'v', 0.040000000000000001, 'f', 'f', 0, 't', 'g', 380, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (360, 'a', 36.75, 4.71, 'u', 'g', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', 160, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (362, 'b', 23.079999999999998, 2.5, 'u', 'g', 'ff', 'ff', 0.085000000000000006, 'f', 'f', 0, 't', 'g', 100, 4208, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (364, 'b', 16.920000000000002, 0.33500000000000002, 'y', 'p', 'k', 'v', 0.28999999999999998, 'f', 'f', 0, 'f', 's', 200, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (366, 'b', 42.829999999999998, 1.25, 'u', 'g', 'm', 'v', 13.875, 'f', 't', 1, 't', 'g', 352, 112, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (368, 'b', 39.420000000000002, 1.71, 'y', 'p', 'm', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 's', 400, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (370, 'b', 21.420000000000002, 0.75, 'y', 'p', 'r', 'n', 0.75, 'f', 'f', 0, 't', 'g', 132, 2, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (372, 'b', 26.329999999999998, 13, 'u', 'g', 'e', 'dd', 0, 'f', 'f', 0, 't', 'g', 140, 1110, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (374, 'b', 26.25, 1.54, 'u', 'g', 'w', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 100, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (376, 'a', 20.829999999999998, 0.5, 'y', 'p', 'e', 'dd', 1, 'f', 'f', 0, 'f', 'g', 260, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (378, 'b', 20.670000000000002, 0.83499999999999996, 'y', 'p', 'c', 'v', 2, 'f', 'f', 0, 't', 's', 240, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (380, 'b', 33.579999999999998, 0.25, 'u', 'g', 'i', 'bb', 4, 'f', 'f', 0, 't', 's', 420, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (382, 'a', 22.670000000000002, 7, 'u', 'g', 'c', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 160, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (384, 'a', 56.829999999999998, 4.25, 'y', 'p', 'ff', 'ff', 5, 'f', 'f', 0, 't', 'g', 0, 4, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (386, 'b', 34, 5.5, 'y', 'p', 'c', 'v', 1.5, 'f', 'f', 0, 't', 'g', 60, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (388, 'b', 21.170000000000002, 0, 'u', 'g', 'c', 'v', 0.5, 'f', 'f', 0, 't', 's', 0, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (390, 'b', 22.920000000000002, 0.17000000000000001, 'u', 'g', 'm', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 's', 0, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (392, 'b', 39.920000000000002, 5, 'u', 'g', 'i', 'bb', 0.20999999999999999, 'f', 'f', 0, 'f', 'g', 550, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (394, 'b', 24.75, 0.54000000000000004, 'u', 'g', 'm', 'v', 1, 'f', 'f', 0, 't', 'g', 120, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (396, 'a', 33.079999999999998, 1.625, 'u', 'g', 'd', 'v', 0.54000000000000004, 'f', 'f', 0, 't', 'g', 0, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (398, 'a', 23.579999999999998, 0.58499999999999996, 'y', 'p', 'ff', 'ff', 0.125, 'f', 'f', 0, 'f', 'g', 120, 87, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (400, 'b', 31, 2.085, 'u', 'g', 'c', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 300, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (402, 'b', 28.920000000000002, 0.375, 'u', 'g', 'c', 'v', 0.28999999999999998, 'f', 'f', 0, 'f', 'g', 220, 140, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (404, 'a', 22.670000000000002, 0.33500000000000002, 'u', 'g', 'q', 'v', 0.75, 'f', 'f', 0, 'f', 's', 160, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (406, 'a', 69.5, 6, 'u', 'g', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 's', 0, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (408, 'a', 19.579999999999998, 0.66500000000000004, 'y', 'p', 'c', 'v', 1, 'f', 't', 1, 'f', 'g', 2000, 2, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (410, 'b', 17.079999999999998, 0.25, 'u', 'g', 'q', 'v', 0.33500000000000002, 'f', 't', 4, 'f', 'g', 160, 8, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (412, 'b', 25.170000000000002, 3, 'u', 'g', 'c', 'v', 1.25, 'f', 't', 1, 'f', 'g', 0, 22, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (414, 'b', 40.579999999999998, 1.5, 'u', 'g', 'i', 'bb', 0, 'f', 'f', 0, 'f', 's', 300, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (416, 'a', 22.25, 1.25, 'y', 'p', 'ff', 'ff', 3.25, 'f', 'f', 0, 'f', 'g', 280, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (418, 'b', 23.579999999999998, 1.79, 'u', 'g', 'c', 'v', 0.54000000000000004, 'f', 'f', 0, 't', 'g', 136, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (420, 'a', 26.579999999999998, 2.54, 'y', 'p', 'ff', 'ff', 0, 'f', 'f', 0, 't', 'g', 180, 60, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (422, 'b', 20.420000000000002, 1.085, 'u', 'g', 'q', 'v', 1.5, 'f', 'f', 0, 'f', 'g', 108, 7, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (424, 'b', 26.170000000000002, 0.83499999999999996, 'u', 'g', 'cc', 'v', 1.165, 'f', 'f', 0, 'f', 'g', 100, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (426, 'b', 24.579999999999998, 1.25, 'u', 'g', 'c', 'v', 0.25, 'f', 'f', 0, 'f', 'g', 110, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (428, 'b', 37.5, 0.83499999999999996, 'u', 'g', 'e', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 120, 5, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (430, 'b', 33.579999999999998, 0.33500000000000002, 'y', 'p', 'cc', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 180, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (432, 'b', 22.920000000000002, 3.165, 'y', 'p', 'c', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 160, 1058, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (434, 'b', 25.25, 1, 'u', 'g', 'aa', 'v', 0.5, 'f', 'f', 0, 'f', 'g', 200, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (436, 'b', 19, 0, 'y', 'p', 'ff', 'ff', 0, 'f', 't', 4, 'f', 'g', 45, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (438, 'a', 53.329999999999998, 0.16500000000000001, 'u', 'g', 'ff', 'ff', 0, 'f', 'f', 0, 't', 's', 62, 27, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (440, 'b', 25.920000000000002, 0.875, 'u', 'g', 'k', 'v', 0.375, 'f', 't', 2, 't', 'g', 174, 3, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (442, 'b', 39.579999999999998, 5, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 2, 'f', 'g', 17, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (444, 'b', 17.25, 3, 'u', 'g', 'k', 'v', 0.040000000000000001, 'f', 'f', 0, 't', 'g', 160, 40, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (446, 'a', NULL, 11.25, 'u', 'g', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', NULL, 5200, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (448, 'a', 27.329999999999998, 1.665, 'u', 'g', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', 340, 1, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (450, 'b', 20, 7, 'u', 'g', 'c', 'v', 0.5, 'f', 'f', 0, 'f', 'g', 0, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (452, 'b', 39.5, 1.625, 'u', 'g', 'c', 'v', 1.5, 'f', 'f', 0, 'f', 'g', 0, 316, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (454, NULL, 29.75, 0.66500000000000004, 'u', 'g', 'w', 'v', 0.25, 'f', 'f', 0, 't', 'g', 300, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (456, 'b', 36.170000000000002, 18.125, 'u', 'g', 'w', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 320, 3552, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (458, 'b', 29.670000000000002, 0.75, 'y', 'p', 'c', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 240, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (460, 'b', 25.670000000000002, 0.28999999999999998, 'y', 'p', 'c', 'v', 1.5, 'f', 'f', 0, 't', 'g', 160, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (462, 'b', 24.079999999999998, 0.875, 'u', 'g', 'm', 'v', 0.085000000000000006, 'f', 't', 4, 'f', 'g', 254, 1950, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (464, 'a', 36.579999999999998, 0.28999999999999998, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 10, 'f', 'g', 200, 18, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (466, 'a', 27.579999999999998, 3, 'u', 'g', 'm', 'v', 2.79, 'f', 't', 1, 't', 'g', 280, 10, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (468, 'a', 30.420000000000002, 1.375, 'u', 'g', 'w', 'h', 0.040000000000000001, 'f', 't', 3, 'f', 'g', 0, 33, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (470, 'b', 16.329999999999998, 4.085, 'u', 'g', 'i', 'h', 0.41499999999999998, 'f', 'f', 0, 't', 'g', 120, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (472, 'b', 21.079999999999998, 4.125, 'y', 'p', 'i', 'h', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 140, 100, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (474, 'b', 19.170000000000002, 4, 'y', 'p', 'i', 'v', 1, 'f', 'f', 0, 't', 'g', 360, 1000, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (476, 'b', 26.75, 2, 'u', 'g', 'd', 'v', 0.75, 'f', 'f', 0, 't', 'g', 80, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (478, 'b', 39.170000000000002, 2.5, 'y', 'p', 'i', 'h', 10, 'f', 'f', 0, 't', 's', 200, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (480, NULL, 26.5, 2.71, 'y', 'p', NULL, NULL, 0.085000000000000006, 'f', 'f', 0, 'f', 's', 80, 0, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (482, 'b', 23.5, 3.165, 'y', 'p', 'k', 'v', 0.41499999999999998, 'f', 't', 1, 't', 'g', 280, 80, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (484, 'b', 23.75, 0.41499999999999998, 'y', 'p', 'c', 'v', 0.040000000000000001, 'f', 't', 2, 'f', 'g', 128, 6, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (486, 'b', 74.829999999999998, 19, 'y', 'p', 'ff', 'ff', 0.040000000000000001, 'f', 't', 2, 'f', 'g', 0, 351, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (488, 'b', 24.5, 13.335000000000001, 'y', 'p', 'aa', 'v', 0.040000000000000001, 'f', 'f', 0, 't', 'g', 120, 475, '-');
-INSERT INTO MADLIB_SCHEMA.crx_dt_test VALUES (490, NULL, 45.329999999999998, 1, 'u', 'g', 'q', 'v', 0.125, 'f', 'f', 0, 't', 'g', 263, 0, '-');
+INSERT INTO crx_dt_test VALUES (2, 'a', 58.670000000000002, 4.46, 'u', 'g', 'q', 'h', 3.04, 't', 't', 6, 'f', 'g', 43, 560, '+');
+INSERT INTO crx_dt_test VALUES (4, 'b', 27.829999999999998, 1.54, 'u', 'g', 'w', 'v', 3.75, 't', 't', 5, 't', 'g', 100, 3, '+');
+INSERT INTO crx_dt_test VALUES (6, 'b', 32.079999999999998, 4, 'u', 'g', 'm', 'v', 2.5, 't', 'f', 0, 't', 'g', 360, 0, '+');
+INSERT INTO crx_dt_test VALUES (8, 'a', 22.920000000000002, 11.585000000000001, 'u', 'g', 'cc', 'v', 0.040000000000000001, 't', 'f', 0, 'f', 'g', 80, 1349, '+');
+INSERT INTO crx_dt_test VALUES (10, 'b', 42.5, 4.915, 'y', 'p', 'w', 'v', 3.165, 't', 'f', 0, 't', 'g', 52, 1442, '+');
+INSERT INTO crx_dt_test VALUES (12, 'b', 29.920000000000002, 1.835, 'u', 'g', 'c', 'h', 4.335, 't', 'f', 0, 'f', 'g', 260, 200, '+');
+INSERT INTO crx_dt_test VALUES (14, 'b', 48.079999999999998, 6.04, 'u', 'g', 'k', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 0, 2690, '+');
+INSERT INTO crx_dt_test VALUES (16, 'b', 36.670000000000002, 4.415, 'y', 'p', 'k', 'v', 0.25, 't', 't', 10, 't', 'g', 320, 0, '+');
+INSERT INTO crx_dt_test VALUES (18, 'a', 23.25, 5.875, 'u', 'g', 'q', 'v', 3.1699999999999999, 't', 't', 10, 'f', 'g', 120, 245, '+');
+INSERT INTO crx_dt_test VALUES (20, 'a', 19.170000000000002, 8.5850000000000009, 'u', 'g', 'cc', 'h', 0.75, 't', 't', 7, 'f', 'g', 96, 0, '+');
+INSERT INTO crx_dt_test VALUES (22, 'b', 23.25, 1, 'u', 'g', 'c', 'v', 0.83499999999999996, 't', 'f', 0, 'f', 's', 300, 0, '+');
+INSERT INTO crx_dt_test VALUES (24, 'a', 27.420000000000002, 14.5, 'u', 'g', 'x', 'h', 3.085, 't', 't', 1, 'f', 'g', 120, 11, '+');
+INSERT INTO crx_dt_test VALUES (26, 'a', 15.83, 0.58499999999999996, 'u', 'g', 'c', 'h', 1.5, 't', 't', 2, 'f', 'g', 100, 0, '+');
+INSERT INTO crx_dt_test VALUES (28, 'b', 56.579999999999998, 18.5, 'u', 'g', 'd', 'bb', 15, 't', 't', 17, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (30, 'b', 42.079999999999998, 1.04, 'u', 'g', 'w', 'v', 5, 't', 't', 6, 't', 'g', 500, 10000, '+');
+INSERT INTO crx_dt_test VALUES (32, 'b', 42, 9.7899999999999991, 'u', 'g', 'x', 'h', 7.96, 't', 't', 8, 'f', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (34, 'a', 36.75, 5.125, 'u', 'g', 'e', 'v', 5, 't', 'f', 0, 't', 'g', 0, 4000, '+');
+INSERT INTO crx_dt_test VALUES (36, 'b', 27.829999999999998, 1.5, 'u', 'g', 'w', 'v', 2, 't', 't', 11, 't', 'g', 434, 35, '+');
+INSERT INTO crx_dt_test VALUES (38, 'a', 23, 11.75, 'u', 'g', 'x', 'h', 0.5, 't', 't', 2, 't', 'g', 300, 551, '+');
+INSERT INTO crx_dt_test VALUES (40, 'b', 54.579999999999998, 9.4149999999999991, 'u', 'g', 'ff', 'ff', 14.414999999999999, 't', 't', 11, 't', 'g', 30, 300, '+');
+INSERT INTO crx_dt_test VALUES (42, 'b', 28.920000000000002, 15, 'u', 'g', 'c', 'h', 5.335, 't', 't', 11, 'f', 'g', 0, 2283, '+');
+INSERT INTO crx_dt_test VALUES (44, 'b', 39.579999999999998, 13.914999999999999, 'u', 'g', 'w', 'v', 8.625, 't', 't', 6, 't', 'g', 70, 0, '+');
+INSERT INTO crx_dt_test VALUES (46, 'b', 54.329999999999998, 6.75, 'u', 'g', 'c', 'h', 2.625, 't', 't', 11, 't', 'g', 0, 284, '+');
+INSERT INTO crx_dt_test VALUES (48, 'b', 31.920000000000002, 4.46, 'u', 'g', 'cc', 'h', 6.04, 't', 't', 3, 'f', 'g', 311, 300, '+');
+INSERT INTO crx_dt_test VALUES (50, 'b', 23.920000000000002, 0.66500000000000004, 'u', 'g', 'c', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 100, 0, '+');
+INSERT INTO crx_dt_test VALUES (52, 'b', 26, 1, 'u', 'g', 'q', 'v', 1.75, 't', 'f', 0, 't', 'g', 280, 0, '+');
+INSERT INTO crx_dt_test VALUES (54, 'b', 34.920000000000002, 2.5, 'u', 'g', 'w', 'v', 0, 't', 'f', 0, 't', 'g', 239, 200, '+');
+INSERT INTO crx_dt_test VALUES (56, 'b', 23.329999999999998, 11.625, 'y', 'p', 'w', 'v', 0.83499999999999996, 't', 'f', 0, 't', 'g', 160, 300, '+');
+INSERT INTO crx_dt_test VALUES (58, 'b', 44.329999999999998, 0.5, 'u', 'g', 'i', 'h', 5, 't', 'f', 0, 't', 'g', 320, 0, '+');
+INSERT INTO crx_dt_test VALUES (60, 'b', 43.25, 3, 'u', 'g', 'q', 'h', 6, 't', 't', 11, 'f', 'g', 80, 0, '+');
+INSERT INTO crx_dt_test VALUES (62, 'b', 31.670000000000002, 16.164999999999999, 'u', 'g', 'd', 'v', 3, 't', 't', 9, 'f', 'g', 250, 730, '+');
+INSERT INTO crx_dt_test VALUES (64, 'a', 20.420000000000002, 0.83499999999999996, 'u', 'g', 'q', 'v', 1.585, 't', 't', 1, 'f', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (66, 'b', 34.170000000000002, 1.54, 'u', 'g', 'cc', 'v', 1.54, 't', 't', 1, 't', 'g', 520, 50000, '+');
+INSERT INTO crx_dt_test VALUES (68, 'b', 25.5, 0.375, 'u', 'g', 'm', 'v', 0.25, 't', 't', 3, 'f', 'g', 260, 15108, '+');
+INSERT INTO crx_dt_test VALUES (70, 'b', 35.170000000000002, 25.125, 'u', 'g', 'x', 'h', 1.625, 't', 't', 1, 't', 'g', 515, 500, '+');
+INSERT INTO crx_dt_test VALUES (72, 'b', 34.829999999999998, 4, 'u', 'g', 'd', 'bb', 12.5, 't', 'f', 0, 't', 'g', NULL, 0, '-');
+INSERT INTO crx_dt_test VALUES (74, 'b', 44.25, 0.5, 'u', 'g', 'm', 'v', 10.75, 't', 'f', 0, 'f', 's', 400, 0, '-');
+INSERT INTO crx_dt_test VALUES (76, 'b', 20.670000000000002, 5.29, 'u', 'g', 'q', 'v', 0.375, 't', 't', 1, 'f', 'g', 160, 0, '-');
+INSERT INTO crx_dt_test VALUES (78, 'a', 19.170000000000002, 0.58499999999999996, 'y', 'p', 'aa', 'v', 0.58499999999999996, 't', 'f', 0, 't', 'g', 160, 0, '-');
+INSERT INTO crx_dt_test VALUES (80, 'b', 21.5, 9.75, 'u', 'g', 'c', 'v', 0.25, 't', 'f', 0, 'f', 'g', 140, 0, '-');
+INSERT INTO crx_dt_test VALUES (82, 'a', 27.670000000000002, 1.5, 'u', 'g', 'm', 'v', 2, 't', 'f', 0, 'f', 's', 368, 0, '-');
+INSERT INTO crx_dt_test VALUES (84, 'a', NULL, 3.5, 'u', 'g', 'd', 'v', 3, 't', 'f', 0, 't', 'g', 300, 0, '-');
+INSERT INTO crx_dt_test VALUES (86, 'b', 37.170000000000002, 4, 'u', 'g', 'c', 'bb', 5, 't', 'f', 0, 't', 's', 280, 0, '-');
+INSERT INTO crx_dt_test VALUES (88, 'b', 25.670000000000002, 2.21, 'y', 'p', 'aa', 'v', 4, 't', 'f', 0, 'f', 'g', 188, 0, '-');
+INSERT INTO crx_dt_test VALUES (90, 'a', 49, 1.5, 'u', 'g', 'j', 'j', 0, 't', 'f', 0, 't', 'g', 100, 27, '-');
+INSERT INTO crx_dt_test VALUES (92, 'b', 31.420000000000002, 15.5, 'u', 'g', 'c', 'v', 0.5, 't', 'f', 0, 'f', 'g', 120, 0, '-');
+INSERT INTO crx_dt_test VALUES (94, 'b', 52.329999999999998, 1.375, 'y', 'p', 'c', 'h', 9.4600000000000009, 't', 'f', 0, 't', 'g', 200, 100, '-');
+INSERT INTO crx_dt_test VALUES (96, 'a', 28.579999999999998, 3.54, 'u', 'g', 'i', 'bb', 0.5, 't', 'f', 0, 't', 'g', 171, 0, '-');
+INSERT INTO crx_dt_test VALUES (98, 'b', NULL, 0.5, 'u', 'g', 'c', 'bb', 0.83499999999999996, 't', 'f', 0, 't', 's', 320, 0, '-');
+INSERT INTO crx_dt_test VALUES (100, 'a', 28.5, 1, 'u', 'g', 'q', 'v', 1, 't', 't', 2, 't', 'g', 167, 500, '-');
+INSERT INTO crx_dt_test VALUES (102, 'b', 35.25, 16.5, 'y', 'p', 'c', 'v', 4, 't', 'f', 0, 'f', 'g', 80, 0, '-');
+INSERT INTO crx_dt_test VALUES (104, 'b', 25, 12, 'u', 'g', 'k', 'v', 2.25, 't', 't', 2, 't', 'g', 120, 5, '-');
+INSERT INTO crx_dt_test VALUES (106, 'b', 54.829999999999998, 15.5, 'u', 'g', 'e', 'z', 0, 't', 't', 20, 'f', 'g', 152, 130, '-');
+INSERT INTO crx_dt_test VALUES (108, 'a', 25, 11, 'y', 'p', 'aa', 'v', 4.5, 't', 'f', 0, 'f', 'g', 120, 0, '-');
+INSERT INTO crx_dt_test VALUES (110, 'a', 19.75, 0.75, 'u', 'g', 'c', 'v', 0.79500000000000004, 't', 't', 5, 't', 'g', 140, 5, '-');
+INSERT INTO crx_dt_test VALUES (112, 'a', 24.5, 1.04, 'y', 'p', 'ff', 'ff', 0.5, 't', 't', 3, 'f', 'g', 180, 147, '-');
+INSERT INTO crx_dt_test VALUES (114, 'a', 33.75, 0.75, 'u', 'g', 'k', 'bb', 1, 't', 't', 3, 't', 'g', 212, 0, '-');
+INSERT INTO crx_dt_test VALUES (116, 'a', 25.420000000000002, 1.125, 'u', 'g', 'q', 'v', 1.29, 't', 't', 2, 'f', 'g', 200, 0, '-');
+INSERT INTO crx_dt_test VALUES (118, 'b', 52.5, 6.5, 'u', 'g', 'k', 'v', 6.29, 't', 't', 15, 'f', 'g', 0, 11202, '+');
+INSERT INTO crx_dt_test VALUES (120, 'a', 20.75, 10.335000000000001, 'u', 'g', 'cc', 'h', 0.33500000000000002, 't', 't', 1, 't', 'g', 80, 50, '+');
+INSERT INTO crx_dt_test VALUES (122, 'b', 25.670000000000002, 12.5, 'u', 'g', 'cc', 'v', 1.21, 't', 't', 67, 't', 'g', 140, 258, '+');
+INSERT INTO crx_dt_test VALUES (124, 'a', 44.170000000000002, 6.665, 'u', 'g', 'q', 'v', 7.375, 't', 't', 3, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (126, 'b', 34.920000000000002, 5, 'u', 'g', 'x', 'h', 7.5, 't', 't', 6, 't', 'g', 0, 1000, '+');
+INSERT INTO crx_dt_test VALUES (128, 'b', 22.75, 11, 'u', 'g', 'q', 'v', 2.5, 't', 't', 7, 't', 'g', 100, 809, '+');
+INSERT INTO crx_dt_test VALUES (130, 'a', 28.420000000000002, 3.5, 'u', 'g', 'w', 'v', 0.83499999999999996, 't', 'f', 0, 'f', 's', 280, 0, '+');
+INSERT INTO crx_dt_test VALUES (132, 'b', 20.420000000000002, 1.835, 'u', 'g', 'c', 'v', 2.25, 't', 't', 1, 'f', 'g', 100, 150, '+');
+INSERT INTO crx_dt_test VALUES (134, 'b', 36.25, 5, 'u', 'g', 'c', 'bb', 2.5, 't', 't', 6, 'f', 'g', 0, 367, '+');
+INSERT INTO crx_dt_test VALUES (136, 'b', 48.579999999999998, 6.5, 'u', 'g', 'q', 'h', 6, 't', 'f', 0, 't', 'g', 350, 0, '+');
+INSERT INTO crx_dt_test VALUES (138, 'b', 33.579999999999998, 2.75, 'u', 'g', 'm', 'v', 4.25, 't', 't', 6, 'f', 'g', 204, 0, '+');
+INSERT INTO crx_dt_test VALUES (140, 'a', 26.920000000000002, 13.5, 'u', 'g', 'q', 'h', 5, 't', 't', 2, 'f', 'g', 0, 5000, '+');
+INSERT INTO crx_dt_test VALUES (142, 'a', 56.5, 16, 'u', 'g', 'j', 'ff', 0, 't', 't', 15, 'f', 'g', 0, 247, '+');
+INSERT INTO crx_dt_test VALUES (144, 'b', 22.329999999999998, 11, 'u', 'g', 'w', 'v', 2, 't', 't', 1, 'f', 'g', 80, 278, '+');
+INSERT INTO crx_dt_test VALUES (146, 'b', 32.829999999999998, 2.5, 'u', 'g', 'cc', 'h', 2.75, 't', 't', 6, 'f', 'g', 160, 2072, '+');
+INSERT INTO crx_dt_test VALUES (148, 'a', 40.329999999999998, 7.54, 'y', 'p', 'q', 'h', 8, 't', 't', 14, 'f', 'g', 0, 2300, '+');
+INSERT INTO crx_dt_test VALUES (150, 'a', 52.829999999999998, 15, 'u', 'g', 'c', 'v', 5.5, 't', 't', 14, 'f', 'g', 0, 2200, '+');
+INSERT INTO crx_dt_test VALUES (152, 'a', 58.329999999999998, 10, 'u', 'g', 'q', 'v', 4, 't', 't', 14, 'f', 'g', 0, 1602, '+');
+INSERT INTO crx_dt_test VALUES (154, 'b', 23.079999999999998, 2.5, 'u', 'g', 'c', 'v', 1.085, 't', 't', 11, 't', 'g', 60, 2184, '+');
+INSERT INTO crx_dt_test VALUES (156, 'a', 21.670000000000002, 11.5, 'y', 'p', 'j', 'j', 0, 't', 't', 11, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (158, 'a', 68.670000000000002, 15, 'u', 'g', 'e', 'z', 0, 't', 't', 14, 'f', 'g', 0, 3376, '+');
+INSERT INTO crx_dt_test VALUES (160, 'b', 34.079999999999998, 0.080000000000000002, 'y', 'p', 'm', 'bb', 0.040000000000000001, 't', 't', 1, 't', 'g', 280, 2000, '+');
+INSERT INTO crx_dt_test VALUES (162, 'b', 44, 2, 'u', 'g', 'm', 'v', 1.75, 't', 't', 2, 't', 'g', 0, 15, '+');
+INSERT INTO crx_dt_test VALUES (164, 'b', 32, 1.75, 'y', 'p', 'e', 'h', 0.040000000000000001, 't', 'f', 0, 't', 'g', 393, 0, '+');
+INSERT INTO crx_dt_test VALUES (166, 'a', 40.829999999999998, 10, 'u', 'g', 'q', 'h', 1.75, 't', 'f', 0, 'f', 'g', 29, 837, '+');
+INSERT INTO crx_dt_test VALUES (168, 'a', 32.329999999999998, 0.54000000000000004, 'u', 'g', 'cc', 'v', 0.040000000000000001, 't', 'f', 0, 'f', 'g', 440, 11177, '+');
+INSERT INTO crx_dt_test VALUES (170, 'b', 37.5, 1.125, 'y', 'p', 'd', 'v', 1.5, 'f', 'f', 0, 't', 'g', 431, 0, '+');
+INSERT INTO crx_dt_test VALUES (172, 'b', 41.329999999999998, 0, 'u', 'g', 'c', 'bb', 15, 't', 'f', 0, 'f', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (174, 'a', 49.829999999999998, 13.585000000000001, 'u', 'g', 'k', 'h', 8.5, 't', 'f', 0, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (176, 'b', 27, 1.5, 'y', 'p', 'w', 'v', 0.375, 't', 'f', 0, 't', 'g', 260, 1065, '+');
+INSERT INTO crx_dt_test VALUES (178, 'a', 26.079999999999998, 8.6649999999999991, 'u', 'g', 'aa', 'v', 1.415, 't', 'f', 0, 'f', 'g', 160, 150, '+');
+INSERT INTO crx_dt_test VALUES (180, 'b', 20.170000000000002, 8.1699999999999999, 'u', 'g', 'aa', 'v', 1.96, 't', 't', 14, 'f', 'g', 60, 158, '+');
+INSERT INTO crx_dt_test VALUES (182, 'a', 21.25, 2.335, 'u', 'g', 'i', 'bb', 0.5, 't', 't', 4, 'f', 's', 80, 0, '+');
+INSERT INTO crx_dt_test VALUES (184, 'a', 57.079999999999998, 19.5, 'u', 'g', 'c', 'v', 5.5, 't', 't', 7, 'f', 'g', 0, 3000, '+');
+INSERT INTO crx_dt_test VALUES (186, 'b', 48.75, 8.5, 'u', 'g', 'c', 'h', 12.5, 't', 't', 9, 'f', 'g', 181, 1655, '+');
+INSERT INTO crx_dt_test VALUES (188, 'b', 40.579999999999998, 5, 'u', 'g', 'c', 'v', 5, 't', 't', 7, 'f', 'g', 0, 3065, '+');
+INSERT INTO crx_dt_test VALUES (190, 'a', 33.079999999999998, 4.625, 'u', 'g', 'q', 'h', 1.625, 't', 't', 2, 'f', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (192, 'b', 42, 0.20499999999999999, 'u', 'g', 'i', 'h', 5.125, 't', 'f', 0, 'f', 'g', 400, 0, '+');
+INSERT INTO crx_dt_test VALUES (194, 'b', 22.670000000000002, 1.585, 'y', 'p', 'w', 'v', 3.085, 't', 't', 6, 'f', 'g', 80, 0, '+');
+INSERT INTO crx_dt_test VALUES (196, 'b', 28.25, 5.04, 'y', 'p', 'c', 'bb', 1.5, 't', 't', 8, 't', 'g', 144, 7, '+');
+INSERT INTO crx_dt_test VALUES (198, 'b', 48.170000000000002, 7.625, 'u', 'g', 'w', 'h', 15.5, 't', 't', 12, 'f', 'g', 0, 790, '+');
+INSERT INTO crx_dt_test VALUES (200, 'b', 22.579999999999998, 10.039999999999999, 'u', 'g', 'x', 'v', 0.040000000000000001, 't', 't', 9, 'f', 'g', 60, 396, '+');
+INSERT INTO crx_dt_test VALUES (202, 'a', 41.329999999999998, 1, 'u', 'g', 'i', 'bb', 2.25, 't', 'f', 0, 't', 'g', 0, 300, '+');
+INSERT INTO crx_dt_test VALUES (204, 'a', 20.75, 10.25, 'u', 'g', 'q', 'v', 0.70999999999999996, 't', 't', 2, 't', 'g', 49, 0, '+');
+INSERT INTO crx_dt_test VALUES (206, 'a', 35.420000000000002, 12, 'u', 'g', 'q', 'h', 14, 't', 't', 8, 'f', 'g', 0, 6590, '+');
+INSERT INTO crx_dt_test VALUES (208, 'b', 28.670000000000002, 9.3350000000000009, 'u', 'g', 'q', 'h', 5.665, 't', 't', 6, 'f', 'g', 381, 168, '+');
+INSERT INTO crx_dt_test VALUES (210, 'b', 39.5, 4.25, 'u', 'g', 'c', 'bb', 6.5, 't', 't', 16, 'f', 'g', 117, 1210, '+');
+INSERT INTO crx_dt_test VALUES (212, 'b', 24.329999999999998, 6.625, 'y', 'p', 'd', 'v', 5.5, 't', 'f', 0, 't', 's', 100, 0, '+');
+INSERT INTO crx_dt_test VALUES (214, 'b', 23.079999999999998, 11.5, 'u', 'g', 'i', 'v', 3.5, 't', 't', 9, 'f', 'g', 56, 742, '+');
+INSERT INTO crx_dt_test VALUES (216, 'b', 48.170000000000002, 3.5, 'u', 'g', 'aa', 'v', 3.5, 't', 'f', 0, 'f', 's', 230, 0, '+');
+INSERT INTO crx_dt_test VALUES (218, 'b', 55.920000000000002, 11.5, 'u', 'g', 'ff', 'ff', 5, 't', 't', 5, 'f', 'g', 0, 8851, '+');
+INSERT INTO crx_dt_test VALUES (220, 'a', 18.920000000000002, 9.25, 'y', 'p', 'c', 'v', 1, 't', 't', 4, 't', 'g', 80, 500, '+');
+INSERT INTO crx_dt_test VALUES (222, 'b', 65.420000000000002, 11, 'u', 'g', 'e', 'z', 20, 't', 't', 7, 't', 'g', 22, 0, '+');
+INSERT INTO crx_dt_test VALUES (224, 'a', 18.829999999999998, 9.5399999999999991, 'u', 'g', 'aa', 'v', 0.085000000000000006, 't', 'f', 0, 'f', 'g', 100, 0, '+');
+INSERT INTO crx_dt_test VALUES (226, 'b', 23.25, 4, 'u', 'g', 'c', 'bb', 0.25, 't', 'f', 0, 't', 'g', 160, 0, '+');
+INSERT INTO crx_dt_test VALUES (228, 'a', 22.5, 8.4600000000000009, 'y', 'p', 'x', 'v', 2.46, 'f', 'f', 0, 'f', 'g', 164, 0, '+');
+INSERT INTO crx_dt_test VALUES (230, 'b', 22.079999999999998, 11, 'u', 'g', 'cc', 'v', 0.66500000000000004, 't', 'f', 0, 'f', 'g', 100, 0, '+');
+INSERT INTO crx_dt_test VALUES (232, 'a', 47.420000000000002, 3, 'u', 'g', 'x', 'v', 13.875, 't', 't', 2, 't', 'g', 519, 1704, '+');
+INSERT INTO crx_dt_test VALUES (234, 'b', 27.670000000000002, 13.75, 'u', 'g', 'w', 'v', 5.75, 't', 'f', 0, 't', 'g', 487, 500, '+');
+INSERT INTO crx_dt_test VALUES (236, 'a', 20.670000000000002, 1.835, 'u', 'g', 'q', 'v', 2.085, 't', 't', 5, 'f', 'g', 220, 2503, '+');
+INSERT INTO crx_dt_test VALUES (238, 'b', 21.329999999999998, 7.5, 'u', 'g', 'aa', 'v', 1.415, 't', 't', 1, 'f', 'g', 80, 9800, '+');
+INSERT INTO crx_dt_test VALUES (240, 'b', 38.170000000000002, 10.125, 'u', 'g', 'x', 'v', 2.5, 't', 't', 6, 'f', 'g', 520, 196, '+');
+INSERT INTO crx_dt_test VALUES (242, 'b', 48.25, 25.085000000000001, 'u', 'g', 'w', 'v', 1.75, 't', 't', 3, 'f', 'g', 120, 14, '+');
+INSERT INTO crx_dt_test VALUES (244, 'a', 18.75, 7.5, 'u', 'g', 'q', 'v', 2.71, 't', 't', 5, 'f', 'g', NULL, 26726, '+');
+INSERT INTO crx_dt_test VALUES (246, 'b', 33.170000000000002, 3.04, 'y', 'p', 'c', 'h', 2.04, 't', 't', 1, 't', 'g', 180, 18027, '+');
+INSERT INTO crx_dt_test VALUES (248, 'a', 19.670000000000002, 0.20999999999999999, 'u', 'g', 'q', 'h', 0.28999999999999998, 't', 't', 11, 'f', 'g', 80, 99, '+');
+INSERT INTO crx_dt_test VALUES (250, 'b', 21.829999999999998, 11, 'u', 'g', 'x', 'v', 0.28999999999999998, 't', 't', 6, 'f', 'g', 121, 0, '+');
+INSERT INTO crx_dt_test VALUES (252, 'b', 41.420000000000002, 5, 'u', 'g', 'q', 'h', 5, 't', 't', 6, 't', 'g', 470, 0, '+');
+INSERT INTO crx_dt_test VALUES (254, 'b', 23.170000000000002, 11.125, 'u', 'g', 'x', 'h', 0.46000000000000002, 't', 't', 1, 'f', 'g', 100, 0, '+');
+INSERT INTO crx_dt_test VALUES (257, 'b', 20, 11.045, 'u', 'g', 'c', 'v', 2, 'f', 'f', 0, 't', 'g', 136, 0, '-');
+INSERT INTO crx_dt_test VALUES (259, 'a', 20.75, 9.5399999999999991, 'u', 'g', 'i', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 200, 1000, '-');
+INSERT INTO crx_dt_test VALUES (261, 'b', 32.75, 2.335, 'u', 'g', 'd', 'h', 5.75, 'f', 'f', 0, 't', 'g', 292, 0, '-');
+INSERT INTO crx_dt_test VALUES (263, 'a', 48.170000000000002, 1.335, 'u', 'g', 'i', 'o', 0.33500000000000002, 'f', 'f', 0, 'f', 'g', 0, 120, '-');
+INSERT INTO crx_dt_test VALUES (265, 'b', 50.75, 0.58499999999999996, 'u', 'g', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', 145, 0, '-');
+INSERT INTO crx_dt_test VALUES (267, 'b', 18.329999999999998, 1.21, 'y', 'p', 'e', 'dd', 0, 'f', 'f', 0, 'f', 'g', 100, 0, '-');
+INSERT INTO crx_dt_test VALUES (269, 'b', 59.670000000000002, 1.54, 'u', 'g', 'q', 'v', 0.125, 't', 'f', 0, 't', 'g', 260, 0, '+');
+INSERT INTO crx_dt_test VALUES (271, 'b', 37.579999999999998, 0, NULL, NULL, NULL, NULL, 0, 'f', 'f', 0, 'f', 'p', NULL, 0, '+');
+INSERT INTO crx_dt_test VALUES (273, 'b', 18.079999999999998, 6.75, 'y', 'p', 'm', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 140, 0, '-');
+INSERT INTO crx_dt_test VALUES (275, 'b', 30.670000000000002, 2.5, 'u', 'g', 'cc', 'h', 2.25, 'f', 'f', 0, 't', 's', 340, 0, '-');
+INSERT INTO crx_dt_test VALUES (277, 'a', 19.170000000000002, 5.415, 'u', 'g', 'i', 'h', 0.28999999999999998, 'f', 'f', 0, 'f', 'g', 80, 484, '-');
+INSERT INTO crx_dt_test VALUES (279, 'b', 24.579999999999998, 13.5, 'y', 'p', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', NULL, 0, '-');
+INSERT INTO crx_dt_test VALUES (281, 'b', 21.170000000000002, 0.875, 'y', 'p', 'c', 'h', 0.25, 'f', 'f', 0, 'f', 'g', 280, 204, '-');
+INSERT INTO crx_dt_test VALUES (283, 'b', 17.670000000000002, 4.46, 'u', 'g', 'c', 'v', 0.25, 'f', 'f', 0, 'f', 's', 80, 0, '-');
+INSERT INTO crx_dt_test VALUES (285, 'b', 23.25, 12.625, 'u', 'g', 'c', 'v', 0.125, 'f', 't', 2, 'f', 'g', 0, 5552, '-');
+INSERT INTO crx_dt_test VALUES (287, 'a', NULL, 1.5, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 2, 't', 'g', 200, 105, '-');
+INSERT INTO crx_dt_test VALUES (289, 'b', 18.829999999999998, 0.41499999999999998, 'y', 'p', 'c', 'v', 0.16500000000000001, 'f', 't', 1, 'f', 'g', 200, 1, '-');
+INSERT INTO crx_dt_test VALUES (291, 'b', 23, 0.75, 'u', 'g', 'm', 'v', 0.5, 'f', 'f', 0, 't', 's', 320, 0, '-');
+INSERT INTO crx_dt_test VALUES (293, 'b', 25.420000000000002, 0.54000000000000004, 'u', 'g', 'w', 'v', 0.16500000000000001, 'f', 't', 1, 'f', 'g', 272, 444, '-');
+INSERT INTO crx_dt_test VALUES (295, 'a', 16.079999999999998, 0.33500000000000002, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 1, 'f', 'g', 160, 126, '-');
+INSERT INTO crx_dt_test VALUES (297, 'b', 69.170000000000002, 9, 'u', 'g', 'ff', 'ff', 4, 'f', 't', 1, 'f', 'g', 70, 6, '-');
+INSERT INTO crx_dt_test VALUES (299, 'b', 16.329999999999998, 2.75, 'u', 'g', 'aa', 'v', 0.66500000000000004, 'f', 't', 1, 'f', 'g', 80, 21, '-');
+INSERT INTO crx_dt_test VALUES (301, 'a', 57.579999999999998, 2, 'u', 'g', 'ff', 'ff', 6.5, 'f', 't', 1, 'f', 'g', 0, 10, '-');
+INSERT INTO crx_dt_test VALUES (303, 'b', 23.420000000000002, 1, 'u', 'g', 'c', 'v', 0.5, 'f', 'f', 0, 't', 's', 280, 0, '-');
+INSERT INTO crx_dt_test VALUES (305, 'a', 24.75, 13.664999999999999, 'u', 'g', 'q', 'h', 1.5, 'f', 'f', 0, 'f', 'g', 280, 1, '-');
+INSERT INTO crx_dt_test VALUES (307, 'b', 23.5, 2.75, 'u', 'g', 'ff', 'ff', 4.5, 'f', 'f', 0, 'f', 'g', 160, 25, '-');
+INSERT INTO crx_dt_test VALUES (309, 'b', 27.75, 1.29, 'u', 'g', 'k', 'h', 0.25, 'f', 'f', 0, 't', 's', 140, 0, '-');
+INSERT INTO crx_dt_test VALUES (311, 'a', 24.829999999999998, 4.5, 'u', 'g', 'w', 'v', 1, 'f', 'f', 0, 't', 'g', 360, 6, '-');
+INSERT INTO crx_dt_test VALUES (313, 'a', 16.329999999999998, 0.20999999999999999, 'u', 'g', 'aa', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 200, 1, '-');
+INSERT INTO crx_dt_test VALUES (315, 'b', 16.25, 0, 'y', 'p', 'aa', 'v', 0.25, 'f', 'f', 0, 'f', 'g', 60, 0, '-');
+INSERT INTO crx_dt_test VALUES (317, 'b', 21.170000000000002, 0.25, 'y', 'p', 'c', 'h', 0.25, 'f', 'f', 0, 'f', 'g', 280, 204, '-');
+INSERT INTO crx_dt_test VALUES (319, 'b', 19.170000000000002, 0, 'y', 'p', 'm', 'bb', 0, 'f', 'f', 0, 't', 's', 500, 1, '+');
+INSERT INTO crx_dt_test VALUES (321, 'b', 21.25, 1.5, 'u', 'g', 'w', 'v', 1.5, 'f', 'f', 0, 'f', 'g', 150, 8, '+');
+INSERT INTO crx_dt_test VALUES (323, 'a', 33.670000000000002, 0.375, 'u', 'g', 'cc', 'v', 0.375, 'f', 'f', 0, 'f', 'g', 300, 44, '+');
+INSERT INTO crx_dt_test VALUES (325, 'b', 33.670000000000002, 1.25, 'u', 'g', 'w', 'v', 1.165, 'f', 'f', 0, 'f', 'g', 120, 0, '-');
+INSERT INTO crx_dt_test VALUES (327, 'b', 30.170000000000002, 1.085, 'y', 'p', 'c', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 170, 179, '-');
+INSERT INTO crx_dt_test VALUES (329, 'b', 34.829999999999998, 2.5, 'y', 'p', 'w', 'v', 3, 'f', 'f', 0, 'f', 's', 200, 0, '-');
+INSERT INTO crx_dt_test VALUES (331, 'b', 20.420000000000002, 0, NULL, NULL, NULL, NULL, 0, 'f', 'f', 0, 'f', 'p', NULL, 0, '-');
+INSERT INTO crx_dt_test VALUES (333, 'b', 34.079999999999998, 2.5, 'u', 'g', 'c', 'v', 1, 'f', 'f', 0, 'f', 'g', 460, 16, '-');
+INSERT INTO crx_dt_test VALUES (335, 'b', 34.75, 2.5, 'u', 'g', 'cc', 'bb', 0.5, 'f', 'f', 0, 'f', 'g', 348, 0, '-');
+INSERT INTO crx_dt_test VALUES (337, 'b', 47.329999999999998, 6.5, 'u', 'g', 'c', 'v', 1, 'f', 'f', 0, 't', 'g', 0, 228, '-');
+INSERT INTO crx_dt_test VALUES (339, 'a', 33.25, 3, 'y', 'p', 'aa', 'v', 2, 'f', 'f', 0, 'f', 'g', 180, 0, '-');
+INSERT INTO crx_dt_test VALUES (341, 'a', 39.079999999999998, 4, 'u', 'g', 'c', 'v', 3, 'f', 'f', 0, 'f', 'g', 480, 0, '-');
+INSERT INTO crx_dt_test VALUES (343, 'b', 26.920000000000002, 2.25, 'u', 'g', 'i', 'bb', 0.5, 'f', 'f', 0, 't', 'g', 640, 4000, '-');
+INSERT INTO crx_dt_test VALUES (345, 'b', 38.920000000000002, 1.75, 'u', 'g', 'k', 'v', 0.5, 'f', 'f', 0, 't', 'g', 300, 2, '-');
+INSERT INTO crx_dt_test VALUES (347, NULL, 32.25, 1.5, 'u', 'g', 'c', 'v', 0.25, 'f', 'f', 0, 't', 'g', 372, 122, '-');
+INSERT INTO crx_dt_test VALUES (349, 'b', 63.329999999999998, 0.54000000000000004, 'u', 'g', 'c', 'v', 0.58499999999999996, 't', 't', 3, 't', 'g', 180, 0, '-');
+INSERT INTO crx_dt_test VALUES (351, 'a', 26.170000000000002, 2, 'u', 'g', 'j', 'j', 0, 'f', 'f', 0, 't', 'g', 276, 1, '-');
+INSERT INTO crx_dt_test VALUES (353, 'b', 22.5, 11.5, 'y', 'p', 'm', 'v', 1.5, 'f', 'f', 0, 't', 'g', 0, 4000, '-');
+INSERT INTO crx_dt_test VALUES (355, 'b', 36.670000000000002, 2, 'u', 'g', 'i', 'v', 0.25, 'f', 'f', 0, 't', 'g', 221, 0, '-');
+INSERT INTO crx_dt_test VALUES (357, 'b', 41.170000000000002, 1.335, 'u', 'g', 'd', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 168, 0, '-');
+INSERT INTO crx_dt_test VALUES (359, 'b', 32.420000000000002, 3, 'u', 'g', 'd', 'v', 0.16500000000000001, 'f', 'f', 0, 't', 'g', 120, 0, '-');
+INSERT INTO crx_dt_test VALUES (361, 'a', 30.25, 5.5, 'u', 'g', 'k', 'v', 5.5, 'f', 'f', 0, 't', 's', 100, 0, '-');
+INSERT INTO crx_dt_test VALUES (363, 'b', 26.829999999999998, 0.54000000000000004, 'u', 'g', 'k', 'ff', 0, 'f', 'f', 0, 'f', 'g', 100, 0, '-');
+INSERT INTO crx_dt_test VALUES (365, 'b', 24.420000000000002, 2, 'u', 'g', 'e', 'dd', 0.16500000000000001, 'f', 't', 2, 'f', 'g', 320, 1300, '-');
+INSERT INTO crx_dt_test VALUES (367, 'a', 22.75, 6.165, 'u', 'g', 'aa', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 220, 1000, '-');
+INSERT INTO crx_dt_test VALUES (369, 'a', 23.579999999999998, 11.5, 'y', 'p', 'k', 'h', 3, 'f', 'f', 0, 't', 'g', 20, 16, '-');
+INSERT INTO crx_dt_test VALUES (371, 'b', 33, 2.5, 'y', 'p', 'w', 'v', 7, 'f', 'f', 0, 't', 'g', 280, 0, '-');
+INSERT INTO crx_dt_test VALUES (373, 'a', 45, 4.585, 'u', 'g', 'k', 'h', 1, 'f', 'f', 0, 't', 's', 240, 0, '-');
+INSERT INTO crx_dt_test VALUES (1, 'b', 30.829999999999998, 0, 'u', 'g', 'w', 'v', 1.25, 't', 't', 1, 'f', 'g', 202, 0, '+');
+INSERT INTO crx_dt_test VALUES (3, 'a', 24.5, 0.5, 'u', 'g', 'q', 'h', 1.5, 't', 'f', 0, 'f', 'g', 280, 824, '+');
+INSERT INTO crx_dt_test VALUES (5, 'b', 20.170000000000002, 5.625, 'u', 'g', 'w', 'v', 1.71, 't', 'f', 0, 'f', 's', 120, 0, '+');
+INSERT INTO crx_dt_test VALUES (7, 'b', 33.170000000000002, 1.04, 'u', 'g', 'r', 'h', 6.5, 't', 'f', 0, 't', 'g', 164, 31285, '+');
+INSERT INTO crx_dt_test VALUES (9, 'b', 54.420000000000002, 0.5, 'y', 'p', 'k', 'h', 3.96, 't', 'f', 0, 'f', 'g', 180, 314, '+');
+INSERT INTO crx_dt_test VALUES (11, 'b', 22.079999999999998, 0.82999999999999996, 'u', 'g', 'c', 'h', 2.165, 'f', 'f', 0, 't', 'g', 128, 0, '+');
+INSERT INTO crx_dt_test VALUES (13, 'a', 38.25, 6, 'u', 'g', 'k', 'v', 1, 't', 'f', 0, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (15, 'a', 45.829999999999998, 10.5, 'u', 'g', 'q', 'v', 5, 't', 't', 7, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (17, 'b', 28.25, 0.875, 'u', 'g', 'm', 'v', 0.95999999999999996, 't', 't', 3, 't', 'g', 396, 0, '+');
+INSERT INTO crx_dt_test VALUES (19, 'b', 21.829999999999998, 0.25, 'u', 'g', 'd', 'h', 0.66500000000000004, 't', 'f', 0, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (21, 'b', 25, 11.25, 'u', 'g', 'c', 'v', 2.5, 't', 't', 17, 'f', 'g', 200, 1208, '+');
+INSERT INTO crx_dt_test VALUES (23, 'a', 47.75, 8, 'u', 'g', 'c', 'v', 7.875, 't', 't', 6, 't', 'g', 0, 1260, '+');
+INSERT INTO crx_dt_test VALUES (25, 'a', 41.170000000000002, 6.5, 'u', 'g', 'q', 'v', 0.5, 't', 't', 3, 't', 'g', 145, 0, '+');
+INSERT INTO crx_dt_test VALUES (27, 'a', 47, 13, 'u', 'g', 'i', 'bb', 5.165, 't', 't', 9, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (29, 'b', 57.420000000000002, 8.5, 'u', 'g', 'e', 'h', 7, 't', 't', 3, 'f', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (31, 'b', 29.25, 14.789999999999999, 'u', 'g', 'aa', 'v', 5.04, 't', 't', 5, 't', 'g', 168, 0, '+');
+INSERT INTO crx_dt_test VALUES (33, 'b', 49.5, 7.585, 'u', 'g', 'i', 'bb', 7.585, 't', 't', 15, 't', 'g', 0, 5000, '+');
+INSERT INTO crx_dt_test VALUES (35, 'a', 22.579999999999998, 10.75, 'u', 'g', 'q', 'v', 0.41499999999999998, 't', 't', 5, 't', 'g', 0, 560, '+');
+INSERT INTO crx_dt_test VALUES (37, 'b', 27.25, 1.585, 'u', 'g', 'cc', 'h', 1.835, 't', 't', 12, 't', 'g', 583, 713, '+');
+INSERT INTO crx_dt_test VALUES (39, 'b', 27.75, 0.58499999999999996, 'y', 'p', 'cc', 'v', 0.25, 't', 't', 2, 'f', 'g', 260, 500, '+');
+INSERT INTO crx_dt_test VALUES (41, 'b', 34.170000000000002, 9.1699999999999999, 'u', 'g', 'c', 'v', 4.5, 't', 't', 12, 't', 'g', 0, 221, '+');
+INSERT INTO crx_dt_test VALUES (43, 'b', 29.670000000000002, 1.415, 'u', 'g', 'w', 'h', 0.75, 't', 't', 1, 'f', 'g', 240, 100, '+');
+INSERT INTO crx_dt_test VALUES (45, 'b', 56.420000000000002, 28, 'y', 'p', 'c', 'v', 28.5, 't', 't', 40, 'f', 'g', 0, 15, '+');
+INSERT INTO crx_dt_test VALUES (47, 'a', 41, 2.04, 'y', 'p', 'q', 'h', 0.125, 't', 't', 23, 't', 'g', 455, 1236, '+');
+INSERT INTO crx_dt_test VALUES (49, 'b', 41.5, 1.54, 'u', 'g', 'i', 'bb', 3.5, 'f', 'f', 0, 'f', 'g', 216, 0, '+');
+INSERT INTO crx_dt_test VALUES (51, 'a', 25.75, 0.5, 'u', 'g', 'c', 'h', 0.875, 't', 'f', 0, 't', 'g', 491, 0, '+');
+INSERT INTO crx_dt_test VALUES (53, 'b', 37.420000000000002, 2.04, 'u', 'g', 'w', 'v', 0.040000000000000001, 't', 'f', 0, 't', 'g', 400, 5800, '+');
+INSERT INTO crx_dt_test VALUES (55, 'b', 34.25, 3, 'u', 'g', 'cc', 'h', 7.415, 't', 'f', 0, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (57, 'b', 23.170000000000002, 0, 'u', 'g', 'cc', 'v', 0.085000000000000006, 't', 'f', 0, 'f', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (59, 'b', 35.170000000000002, 4.5, 'u', 'g', 'x', 'h', 5.75, 'f', 'f', 0, 't', 's', 711, 0, '+');
+INSERT INTO crx_dt_test VALUES (61, 'b', 56.75, 12.25, 'u', 'g', 'm', 'v', 1.25, 't', 't', 4, 't', 'g', 200, 0, '+');
+INSERT INTO crx_dt_test VALUES (63, 'a', 23.420000000000002, 0.79000000000000004, 'y', 'p', 'q', 'v', 1.5, 't', 't', 2, 't', 'g', 80, 400, '+');
+INSERT INTO crx_dt_test VALUES (65, 'b', 26.670000000000002, 4.25, 'u', 'g', 'cc', 'v', 4.29, 't', 't', 1, 't', 'g', 120, 0, '+');
+INSERT INTO crx_dt_test VALUES (67, 'a', 36, 1, 'u', 'g', 'c', 'v', 2, 't', 't', 11, 'f', 'g', 0, 456, '+');
+INSERT INTO crx_dt_test VALUES (69, 'b', 19.420000000000002, 6.5, 'u', 'g', 'w', 'h', 1.46, 't', 't', 7, 'f', 'g', 80, 2954, '+');
+INSERT INTO crx_dt_test VALUES (71, 'b', 32.329999999999998, 7.5, 'u', 'g', 'e', 'bb', 1.585, 't', 'f', 0, 't', 's', 420, 0, '-');
+INSERT INTO crx_dt_test VALUES (73, 'a', 38.579999999999998, 5, 'u', 'g', 'cc', 'v', 13.5, 't', 'f', 0, 't', 'g', 980, 0, '-');
+INSERT INTO crx_dt_test VALUES (75, 'b', 44.829999999999998, 7, 'y', 'p', 'c', 'v', 1.625, 'f', 'f', 0, 'f', 'g', 160, 2, '-');
+INSERT INTO crx_dt_test VALUES (77, 'b', 34.079999999999998, 6.5, 'u', 'g', 'aa', 'v', 0.125, 't', 'f', 0, 't', 'g', 443, 0, '-');
+INSERT INTO crx_dt_test VALUES (79, 'b', 21.670000000000002, 1.165, 'y', 'p', 'k', 'v', 2.5, 't', 't', 1, 'f', 'g', 180, 20, '-');
+INSERT INTO crx_dt_test VALUES (81, 'b', 49.579999999999998, 19, 'u', 'g', 'ff', 'ff', 0, 't', 't', 1, 'f', 'g', 94, 0, '-');
+INSERT INTO crx_dt_test VALUES (83, 'b', 39.829999999999998, 0.5, 'u', 'g', 'm', 'v', 0.25, 't', 'f', 0, 'f', 's', 288, 0, '-');
+INSERT INTO crx_dt_test VALUES (85, 'b', 27.25, 0.625, 'u', 'g', 'aa', 'v', 0.45500000000000002, 't', 'f', 0, 't', 'g', 200, 0, '-');
+INSERT INTO crx_dt_test VALUES (87, 'b', NULL, 0.375, 'u', 'g', 'd', 'v', 0.875, 't', 'f', 0, 't', 's', 928, 0, '-');
+INSERT INTO crx_dt_test VALUES (89, 'b', 34, 4.5, 'u', 'g', 'aa', 'v', 1, 't', 'f', 0, 't', 'g', 240, 0, '-');
+INSERT INTO crx_dt_test VALUES (91, 'b', 62.5, 12.75, 'y', 'p', 'c', 'h', 5, 't', 'f', 0, 'f', 'g', 112, 0, '-');
+INSERT INTO crx_dt_test VALUES (93, 'b', NULL, 5, 'y', 'p', 'aa', 'v', 8.5, 't', 'f', 0, 'f', 'g', 0, 0, '-');
+INSERT INTO crx_dt_test VALUES (95, 'b', 28.75, 1.5, 'y', 'p', 'c', 'v', 1.5, 't', 'f', 0, 't', 'g', 0, 225, '-');
+INSERT INTO crx_dt_test VALUES (97, 'b', 23, 0.625, 'y', 'p', 'aa', 'v', 0.125, 't', 'f', 0, 'f', 'g', 180, 1, '-');
+INSERT INTO crx_dt_test VALUES (99, 'a', 22.5, 11, 'y', 'p', 'q', 'v', 3, 't', 'f', 0, 't', 'g', 268, 0, '-');
+INSERT INTO crx_dt_test VALUES (101, 'b', 37.5, 1.75, 'y', 'p', 'c', 'bb', 0.25, 't', 'f', 0, 't', 'g', 164, 400, '-');
+INSERT INTO crx_dt_test VALUES (103, 'b', 18.670000000000002, 5, 'u', 'g', 'q', 'v', 0.375, 't', 't', 2, 'f', 'g', 0, 38, '-');
+INSERT INTO crx_dt_test VALUES (105, 'b', 27.829999999999998, 4, 'y', 'p', 'i', 'h', 5.75, 't', 't', 2, 't', 'g', 75, 0, '-');
+INSERT INTO crx_dt_test VALUES (107, 'b', 28.75, 1.165, 'u', 'g', 'k', 'v', 0.5, 't', 'f', 0, 'f', 's', 280, 0, '-');
+INSERT INTO crx_dt_test VALUES (109, 'b', 40.920000000000002, 2.25, 'y', 'p', 'x', 'h', 10, 't', 'f', 0, 't', 'g', 176, 0, '-');
+INSERT INTO crx_dt_test VALUES (111, 'b', 29.170000000000002, 3.5, 'u', 'g', 'w', 'v', 3.5, 't', 't', 3, 't', 'g', 329, 0, '-');
+INSERT INTO crx_dt_test VALUES (113, 'b', 24.579999999999998, 12.5, 'u', 'g', 'w', 'v', 0.875, 't', 'f', 0, 't', 'g', 260, 0, '-');
+INSERT INTO crx_dt_test VALUES (115, 'b', 20.670000000000002, 1.25, 'y', 'p', 'c', 'h', 1.375, 't', 't', 3, 't', 'g', 140, 210, '-');
+INSERT INTO crx_dt_test VALUES (117, 'b', 37.75, 7, 'u', 'g', 'q', 'h', 11.5, 't', 't', 7, 't', 'g', 300, 5, '-');
+INSERT INTO crx_dt_test VALUES (119, 'b', 57.829999999999998, 7.04, 'u', 'g', 'm', 'v', 14, 't', 't', 6, 't', 'g', 360, 1332, '+');
+INSERT INTO crx_dt_test VALUES (121, 'b', 39.920000000000002, 6.21, 'u', 'g', 'q', 'v', 0.040000000000000001, 't', 't', 1, 'f', 'g', 200, 300, '+');
+INSERT INTO crx_dt_test VALUES (123, 'a', 24.75, 12.5, 'u', 'g', 'aa', 'v', 1.5, 't', 't', 12, 't', 'g', 120, 567, '+');
+INSERT INTO crx_dt_test VALUES (125, 'a', 23.5, 9, 'u', 'g', 'q', 'v', 8.5, 't', 't', 5, 't', 'g', 120, 0, '+');
+INSERT INTO crx_dt_test VALUES (127, 'b', 47.670000000000002, 2.5, 'u', 'g', 'm', 'bb', 2.5, 't', 't', 12, 't', 'g', 410, 2510, '+');
+INSERT INTO crx_dt_test VALUES (129, 'b', 34.420000000000002, 4.25, 'u', 'g', 'i', 'bb', 3.25, 't', 't', 2, 'f', 'g', 274, 610, '+');
+INSERT INTO crx_dt_test VALUES (131, 'b', 67.75, 5.5, 'u', 'g', 'e', 'z', 13, 't', 't', 1, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (133, 'a', 47.420000000000002, 8, 'u', 'g', 'e', 'bb', 6.5, 't', 't', 6, 'f', 'g', 375, 51100, '+');
+INSERT INTO crx_dt_test VALUES (135, 'b', 32.670000000000002, 5.5, 'u', 'g', 'q', 'h', 5.5, 't', 't', 12, 't', 'g', 408, 1000, '+');
+INSERT INTO crx_dt_test VALUES (137, 'b', 39.920000000000002, 0.54000000000000004, 'y', 'p', 'aa', 'v', 0.5, 't', 't', 3, 'f', 'g', 200, 1000, '+');
+INSERT INTO crx_dt_test VALUES (139, 'a', 18.829999999999998, 9.5, 'u', 'g', 'w', 'v', 1.625, 't', 't', 6, 't', 'g', 40, 600, '+');
+INSERT INTO crx_dt_test VALUES (141, 'a', 31.25, 3.75, 'u', 'g', 'cc', 'h', 0.625, 't', 't', 9, 't', 'g', 181, 0, '+');
+INSERT INTO crx_dt_test VALUES (143, 'b', 43, 0.28999999999999998, 'y', 'p', 'cc', 'h', 1.75, 't', 't', 8, 'f', 'g', 100, 375, '+');
+INSERT INTO crx_dt_test VALUES (145, 'b', 27.25, 1.665, 'u', 'g', 'cc', 'h', 5.085, 't', 't', 9, 'f', 'g', 399, 827, '+');
+INSERT INTO crx_dt_test VALUES (147, 'b', 23.25, 1.5, 'u', 'g', 'q', 'v', 2.375, 't', 't', 3, 't', 'g', 0, 582, '+');
+INSERT INTO crx_dt_test VALUES (149, 'a', 30.5, 6.5, 'u', 'g', 'c', 'bb', 4, 't', 't', 7, 't', 'g', 0, 3065, '+');
+INSERT INTO crx_dt_test VALUES (151, 'a', 46.670000000000002, 0.46000000000000002, 'u', 'g', 'cc', 'h', 0.41499999999999998, 't', 't', 11, 't', 'g', 440, 6, '+');
+INSERT INTO crx_dt_test VALUES (153, 'b', 37.329999999999998, 6.5, 'u', 'g', 'm', 'h', 4.25, 't', 't', 12, 't', 'g', 93, 0, '+');
+INSERT INTO crx_dt_test VALUES (155, 'b', 32.75, 1.5, 'u', 'g', 'cc', 'h', 5.5, 't', 't', 3, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (157, 'a', 28.5, 3.04, 'y', 'p', 'x', 'h', 2.54, 't', 't', 1, 'f', 'g', 70, 0, '+');
+INSERT INTO crx_dt_test VALUES (159, 'b', 28, 2, 'u', 'g', 'k', 'h', 4.165, 't', 't', 2, 't', 'g', 181, 0, '+');
+INSERT INTO crx_dt_test VALUES (161, 'b', 27.670000000000002, 2, 'u', 'g', 'x', 'h', 1, 't', 't', 4, 'f', 'g', 140, 7544, '+');
+INSERT INTO crx_dt_test VALUES (163, 'b', 25.079999999999998, 1.71, 'u', 'g', 'x', 'v', 1.665, 't', 't', 1, 't', 'g', 395, 20, '+');
+INSERT INTO crx_dt_test VALUES (165, 'a', 60.579999999999998, 16.5, 'u', 'g', 'q', 'v', 11, 't', 'f', 0, 't', 'g', 21, 10561, '+');
+INSERT INTO crx_dt_test VALUES (167, 'b', 19.329999999999998, 9.5, 'u', 'g', 'q', 'v', 1, 't', 'f', 0, 't', 'g', 60, 400, '+');
+INSERT INTO crx_dt_test VALUES (169, 'b', 36.670000000000002, 3.25, 'u', 'g', 'q', 'h', 9, 't', 'f', 0, 't', 'g', 102, 639, '+');
+INSERT INTO crx_dt_test VALUES (171, 'a', 25.079999999999998, 2.54, 'y', 'p', 'aa', 'v', 0.25, 't', 'f', 0, 't', 'g', 370, 0, '+');
+INSERT INTO crx_dt_test VALUES (173, 'b', 56, 12.5, 'u', 'g', 'k', 'h', 8, 't', 'f', 0, 't', 'g', 24, 2028, '+');
+INSERT INTO crx_dt_test VALUES (175, 'b', 22.670000000000002, 10.5, 'u', 'g', 'q', 'h', 1.335, 't', 'f', 0, 'f', 'g', 100, 0, '+');
+INSERT INTO crx_dt_test VALUES (177, 'b', 25, 12.5, 'u', 'g', 'aa', 'v', 3, 't', 'f', 0, 't', 's', 20, 0, '+');
+INSERT INTO crx_dt_test VALUES (179, 'a', 18.420000000000002, 9.25, 'u', 'g', 'q', 'v', 1.21, 't', 't', 4, 'f', 'g', 60, 540, '+');
+INSERT INTO crx_dt_test VALUES (181, 'b', 47.670000000000002, 0.28999999999999998, 'u', 'g', 'c', 'bb', 15, 't', 't', 20, 'f', 'g', 0, 15000, '+');
+INSERT INTO crx_dt_test VALUES (183, 'a', 20.670000000000002, 3, 'u', 'g', 'q', 'v', 0.16500000000000001, 't', 't', 3, 'f', 'g', 100, 6, '+');
+INSERT INTO crx_dt_test VALUES (185, 'a', 22.420000000000002, 5.665, 'u', 'g', 'q', 'v', 2.585, 't', 't', 7, 'f', 'g', 129, 3257, '+');
+INSERT INTO crx_dt_test VALUES (375, NULL, 28.170000000000002, 0.58499999999999996, 'u', 'g', 'aa', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 260, 1004, '-');
+INSERT INTO crx_dt_test VALUES (377, 'b', 28.670000000000002, 14.5, 'u', 'g', 'd', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 0, 286, '-');
+INSERT INTO crx_dt_test VALUES (379, 'b', 34.420000000000002, 1.335, 'u', 'g', 'i', 'bb', 0.125, 'f', 'f', 0, 't', 'g', 440, 4500, '-');
+INSERT INTO crx_dt_test VALUES (381, 'b', 43.170000000000002, 5, 'u', 'g', 'i', 'bb', 2.25, 'f', 'f', 0, 't', 'g', 141, 0, '-');
+INSERT INTO crx_dt_test VALUES (383, 'a', 24.329999999999998, 2.5, 'y', 'p', 'i', 'bb', 4.5, 'f', 'f', 0, 'f', 'g', 200, 456, '-');
+INSERT INTO crx_dt_test VALUES (385, 'b', 22.079999999999998, 11.460000000000001, 'u', 'g', 'k', 'v', 1.585, 'f', 'f', 0, 't', 'g', 100, 1212, '-');
+INSERT INTO crx_dt_test VALUES (387, 'b', 22.579999999999998, 1.5, 'y', 'p', 'aa', 'v', 0.54000000000000004, 'f', 'f', 0, 't', 'g', 120, 67, '-');
+INSERT INTO crx_dt_test VALUES (389, 'b', 26.670000000000002, 14.585000000000001, 'u', 'g', 'i', 'bb', 0, 'f', 'f', 0, 't', 'g', 178, 0, '-');
+INSERT INTO crx_dt_test VALUES (391, 'b', 15.17, 7, 'u', 'g', 'e', 'v', 1, 'f', 'f', 0, 'f', 'g', 600, 0, '-');
+INSERT INTO crx_dt_test VALUES (393, 'b', 27.420000000000002, 12.5, 'u', 'g', 'aa', 'bb', 0.25, 'f', 'f', 0, 't', 'g', 720, 0, '-');
+INSERT INTO crx_dt_test VALUES (395, 'b', 41.170000000000002, 1.25, 'y', 'p', 'w', 'v', 0.25, 'f', 'f', 0, 'f', 'g', 0, 195, '-');
+INSERT INTO crx_dt_test VALUES (397, 'b', 29.829999999999998, 2.04, 'y', 'p', 'x', 'h', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 128, 1, '-');
+INSERT INTO crx_dt_test VALUES (399, 'b', 26.170000000000002, 12.5, 'y', 'p', 'k', 'h', 1.25, 'f', 'f', 0, 't', 'g', 0, 17, '-');
+INSERT INTO crx_dt_test VALUES (401, 'b', 20.75, 5.085, 'y', 'p', 'j', 'v', 0.28999999999999998, 'f', 'f', 0, 'f', 'g', 140, 184, '-');
+INSERT INTO crx_dt_test VALUES (403, 'a', 51.920000000000002, 6.5, 'u', 'g', 'i', 'bb', 3.085, 'f', 'f', 0, 't', 'g', 73, 0, '-');
+INSERT INTO crx_dt_test VALUES (405, 'b', 34, 5.085, 'y', 'p', 'i', 'bb', 1.085, 'f', 'f', 0, 't', 'g', 480, 0, '-');
+INSERT INTO crx_dt_test VALUES (407, 'a', 40.329999999999998, 8.125, 'y', 'p', 'k', 'v', 0.16500000000000001, 'f', 't', 2, 'f', 'g', NULL, 18, '-');
+INSERT INTO crx_dt_test VALUES (409, 'b', 16, 3.125, 'u', 'g', 'w', 'v', 0.085000000000000006, 'f', 't', 1, 'f', 'g', 0, 6, '-');
+INSERT INTO crx_dt_test VALUES (411, 'b', 31.25, 2.835, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 5, 'f', 'g', 176, 146, '-');
+INSERT INTO crx_dt_test VALUES (413, 'a', 22.670000000000002, 0.79000000000000004, 'u', 'g', 'i', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 144, 0, '-');
+INSERT INTO crx_dt_test VALUES (415, 'b', 22.25, 0.46000000000000002, 'u', 'g', 'k', 'v', 0.125, 'f', 'f', 0, 't', 'g', 280, 55, '-');
+INSERT INTO crx_dt_test VALUES (417, 'b', 22.5, 0.125, 'y', 'p', 'k', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 200, 70, '-');
+INSERT INTO crx_dt_test VALUES (419, 'b', 38.420000000000002, 0.70499999999999996, 'u', 'g', 'c', 'v', 0.375, 'f', 't', 2, 'f', 'g', 225, 500, '-');
+INSERT INTO crx_dt_test VALUES (421, 'b', 35, 2.5, 'u', 'g', 'i', 'v', 1, 'f', 'f', 0, 't', 'g', 210, 0, '-');
+INSERT INTO crx_dt_test VALUES (423, 'b', 29.420000000000002, 1.25, 'u', 'g', 'w', 'v', 1.75, 'f', 'f', 0, 'f', 'g', 200, 0, '-');
+INSERT INTO crx_dt_test VALUES (425, 'b', 33.670000000000002, 2.165, 'u', 'g', 'c', 'v', 1.5, 'f', 'f', 0, 'f', 'p', 120, 0, '-');
+INSERT INTO crx_dt_test VALUES (427, 'a', 27.670000000000002, 2.04, 'u', 'g', 'w', 'v', 0.25, 'f', 'f', 0, 't', 'g', 180, 50, '-');
+INSERT INTO crx_dt_test VALUES (429, 'b', 49.170000000000002, 2.29, 'u', 'g', 'ff', 'ff', 0.28999999999999998, 'f', 'f', 0, 'f', 'g', 200, 3, '-');
+INSERT INTO crx_dt_test VALUES (431, 'b', 51.829999999999998, 3, 'y', 'p', 'ff', 'ff', 1.5, 'f', 'f', 0, 'f', 'g', 180, 4, '-');
+INSERT INTO crx_dt_test VALUES (433, 'b', 21.829999999999998, 1.54, 'u', 'g', 'k', 'v', 0.085000000000000006, 'f', 'f', 0, 't', 'g', 356, 0, '-');
+INSERT INTO crx_dt_test VALUES (435, 'b', 58.579999999999998, 2.71, 'u', 'g', 'c', 'v', 2.415, 'f', 'f', 0, 't', 'g', 320, 0, '-');
+INSERT INTO crx_dt_test VALUES (437, 'b', 19.579999999999998, 0.58499999999999996, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 3, 'f', 'g', 350, 769, '-');
+INSERT INTO crx_dt_test VALUES (439, 'a', 27.170000000000002, 1.25, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 1, 'f', 'g', 92, 300, '-');
+INSERT INTO crx_dt_test VALUES (441, 'b', 23.079999999999998, 0, 'u', 'g', 'k', 'v', 1, 'f', 't', 11, 'f', 's', 0, 0, '-');
+INSERT INTO crx_dt_test VALUES (443, 'b', 30.579999999999998, 2.71, 'y', 'p', 'm', 'v', 0.125, 'f', 'f', 0, 't', 's', 80, 0, '-');
+INSERT INTO crx_dt_test VALUES (445, 'a', 17.670000000000002, 0, 'y', 'p', 'j', 'ff', 0, 'f', 'f', 0, 'f', 'g', 86, 0, '-');
+INSERT INTO crx_dt_test VALUES (447, 'b', 16.5, 0.125, 'u', 'g', 'c', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 132, 0, '-');
+INSERT INTO crx_dt_test VALUES (449, 'b', 31.25, 1.125, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 1, 'f', 'g', 96, 19, '-');
+INSERT INTO crx_dt_test VALUES (451, 'b', NULL, 3, 'y', 'p', 'i', 'bb', 7, 'f', 'f', 0, 'f', 'g', 0, 1, '-');
+INSERT INTO crx_dt_test VALUES (453, 'b', 36.5, 4.25, 'u', 'g', 'q', 'v', 3.5, 'f', 'f', 0, 'f', 'g', 454, 50, '-');
+INSERT INTO crx_dt_test VALUES (455, 'b', 52.420000000000002, 1.5, 'u', 'g', 'd', 'v', 3.75, 'f', 'f', 0, 't', 'g', 0, 350, '-');
+INSERT INTO crx_dt_test VALUES (457, 'b', 34.579999999999998, 0, NULL, NULL, NULL, NULL, 0, 'f', 'f', 0, 'f', 'p', NULL, 0, '-');
+INSERT INTO crx_dt_test VALUES (459, 'b', 36.170000000000002, 5.5, 'u', 'g', 'i', 'bb', 5, 'f', 'f', 0, 'f', 'g', 210, 687, '-');
+INSERT INTO crx_dt_test VALUES (461, 'a', 24.5, 2.415, 'y', 'p', 'c', 'v', 0, 'f', 'f', 0, 'f', 'g', 120, 0, '-');
+INSERT INTO crx_dt_test VALUES (463, 'b', 21.920000000000002, 0.5, 'u', 'g', 'c', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 360, 0, '-');
+INSERT INTO crx_dt_test VALUES (465, 'a', 23, 1.835, 'u', 'g', 'j', 'j', 0, 'f', 't', 1, 'f', 'g', 200, 53, '-');
+INSERT INTO crx_dt_test VALUES (467, 'b', 31.079999999999998, 3.085, 'u', 'g', 'c', 'v', 2.5, 'f', 't', 2, 't', 'g', 160, 41, '-');
+INSERT INTO crx_dt_test VALUES (469, 'b', 22.079999999999998, 2.335, 'u', 'g', 'k', 'v', 0.75, 'f', 'f', 0, 'f', 'g', 180, 0, '-');
+INSERT INTO crx_dt_test VALUES (471, 'a', 21.920000000000002, 11.664999999999999, 'u', 'g', 'k', 'h', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 320, 5, '-');
+INSERT INTO crx_dt_test VALUES (473, 'b', 17.420000000000002, 6.5, 'u', 'g', 'i', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 60, 100, '-');
+INSERT INTO crx_dt_test VALUES (475, 'b', 20.670000000000002, 0.41499999999999998, 'u', 'g', 'c', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 0, 44, '-');
+INSERT INTO crx_dt_test VALUES (477, 'b', 23.579999999999998, 0.83499999999999996, 'u', 'g', 'i', 'h', 0.085000000000000006, 'f', 'f', 0, 't', 'g', 220, 5, '-');
+INSERT INTO crx_dt_test VALUES (479, 'b', 22.75, 11.5, 'u', 'g', 'i', 'v', 0.41499999999999998, 'f', 'f', 0, 'f', 'g', 0, 0, '-');
+INSERT INTO crx_dt_test VALUES (481, 'a', 16.920000000000002, 0.5, 'u', 'g', 'i', 'v', 0.16500000000000001, 'f', 't', 6, 't', 'g', 240, 35, '-');
+INSERT INTO crx_dt_test VALUES (483, 'a', 17.329999999999998, 9.5, 'u', 'g', 'aa', 'v', 1.75, 'f', 't', 10, 't', 'g', 0, 10, '-');
+INSERT INTO crx_dt_test VALUES (485, 'b', 34.670000000000002, 1.0800000000000001, 'u', 'g', 'm', 'v', 1.165, 'f', 'f', 0, 'f', 's', 28, 0, '-');
+INSERT INTO crx_dt_test VALUES (487, 'b', 28.170000000000002, 0.125, 'y', 'p', 'k', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 216, 2100, '-');
+INSERT INTO crx_dt_test VALUES (489, 'b', 18.829999999999998, 3.54, 'y', 'p', 'ff', 'ff', 0, 'f', 'f', 0, 't', 'g', 180, 1, '-');
+INSERT INTO crx_dt_test VALUES (187, 'b', 40, 6.5, 'u', 'g', 'aa', 'bb', 3.5, 't', 't', 1, 'f', 'g', 0, 500, '+');
+INSERT INTO crx_dt_test VALUES (189, 'a', 28.670000000000002, 1.04, 'u', 'g', 'c', 'v', 2.5, 't', 't', 5, 't', 'g', 300, 1430, '+');
+INSERT INTO crx_dt_test VALUES (191, 'b', 21.329999999999998, 10.5, 'u', 'g', 'c', 'v', 3, 't', 'f', 0, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (193, 'b', 41.75, 0.95999999999999996, 'u', 'g', 'x', 'v', 2.5, 't', 'f', 0, 'f', 'g', 510, 600, '+');
+INSERT INTO crx_dt_test VALUES (195, 'b', 34.5, 4.04, 'y', 'p', 'i', 'bb', 8.5, 't', 't', 7, 't', 'g', 195, 0, '+');
+INSERT INTO crx_dt_test VALUES (197, 'b', 33.170000000000002, 3.165, 'y', 'p', 'x', 'v', 3.165, 't', 't', 3, 't', 'g', 380, 0, '+');
+INSERT INTO crx_dt_test VALUES (199, 'b', 27.579999999999998, 2.04, 'y', 'p', 'aa', 'v', 2, 't', 't', 3, 't', 'g', 370, 560, '+');
+INSERT INTO crx_dt_test VALUES (201, 'a', 24.079999999999998, 0.5, 'u', 'g', 'q', 'h', 1.25, 't', 't', 1, 'f', 'g', 0, 678, '+');
+INSERT INTO crx_dt_test VALUES (203, 'b', 24.829999999999998, 2.75, 'u', 'g', 'c', 'v', 2.25, 't', 't', 6, 'f', 'g', NULL, 600, '+');
+INSERT INTO crx_dt_test VALUES (205, 'b', 36.329999999999998, 2.125, 'y', 'p', 'w', 'v', 0.085000000000000006, 't', 't', 1, 'f', 'g', 50, 1187, '+');
+INSERT INTO crx_dt_test VALUES (207, 'a', 71.579999999999998, 0, NULL, NULL, NULL, NULL, 0, 'f', 'f', 0, 'f', 'p', NULL, 0, '+');
+INSERT INTO crx_dt_test VALUES (209, 'b', 35.170000000000002, 2.5, 'u', 'g', 'k', 'v', 4.5, 't', 't', 7, 'f', 'g', 150, 1270, '+');
+INSERT INTO crx_dt_test VALUES (211, 'b', 39.329999999999998, 5.875, 'u', 'g', 'cc', 'h', 10, 't', 't', 14, 't', 'g', 399, 0, '+');
+INSERT INTO crx_dt_test VALUES (213, 'b', 60.079999999999998, 14.5, 'u', 'g', 'ff', 'ff', 18, 't', 't', 15, 't', 'g', 0, 1000, '+');
+INSERT INTO crx_dt_test VALUES (215, 'b', 26.670000000000002, 2.71, 'y', 'p', 'cc', 'v', 5.25, 't', 't', 1, 'f', 'g', 211, 0, '+');
+INSERT INTO crx_dt_test VALUES (217, 'b', 41.170000000000002, 4.04, 'u', 'g', 'cc', 'h', 7, 't', 't', 8, 'f', 'g', 320, 0, '+');
+INSERT INTO crx_dt_test VALUES (219, 'b', 53.920000000000002, 9.625, 'u', 'g', 'e', 'v', 8.6649999999999991, 't', 't', 5, 'f', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (221, 'a', 50.079999999999998, 12.539999999999999, 'u', 'g', 'aa', 'v', 2.29, 't', 't', 3, 't', 'g', 156, 0, '+');
+INSERT INTO crx_dt_test VALUES (223, 'a', 17.579999999999998, 9, 'u', 'g', 'aa', 'v', 1.375, 't', 'f', 0, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (225, 'a', 37.75, 5.5, 'u', 'g', 'q', 'v', 0.125, 't', 'f', 0, 't', 'g', 228, 0, '+');
+INSERT INTO crx_dt_test VALUES (227, 'b', 18.079999999999998, 5.5, 'u', 'g', 'k', 'v', 0.5, 't', 'f', 0, 'f', 'g', 80, 0, '+');
+INSERT INTO crx_dt_test VALUES (229, 'b', 19.670000000000002, 0.375, 'u', 'g', 'q', 'v', 2, 't', 't', 2, 't', 'g', 80, 0, '+');
+INSERT INTO crx_dt_test VALUES (231, 'b', 25.170000000000002, 3.5, 'u', 'g', 'cc', 'v', 0.625, 't', 't', 7, 'f', 'g', 0, 7059, '+');
+INSERT INTO crx_dt_test VALUES (233, 'b', 33.5, 1.75, 'u', 'g', 'x', 'h', 4.5, 't', 't', 4, 't', 'g', 253, 857, '+');
+INSERT INTO crx_dt_test VALUES (235, 'a', 58.420000000000002, 21, 'u', 'g', 'i', 'bb', 10, 't', 't', 13, 'f', 'g', 0, 6700, '+');
+INSERT INTO crx_dt_test VALUES (237, 'b', 26.170000000000002, 0.25, 'u', 'g', 'i', 'bb', 0, 't', 'f', 0, 't', 'g', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (239, 'b', 42.829999999999998, 4.625, 'u', 'g', 'q', 'v', 4.5800000000000001, 't', 'f', 0, 'f', 's', 0, 0, '+');
+INSERT INTO crx_dt_test VALUES (241, 'b', 20.5, 10, 'y', 'p', 'c', 'v', 2.5, 't', 'f', 0, 'f', 's', 40, 0, '+');
+INSERT INTO crx_dt_test VALUES (243, 'b', 28.329999999999998, 5, 'u', 'g', 'w', 'v', 11, 't', 'f', 0, 't', 'g', 70, 0, '+');
+INSERT INTO crx_dt_test VALUES (245, 'b', 18.5, 2, 'u', 'g', 'i', 'v', 1.5, 't', 't', 2, 'f', 'g', 120, 300, '+');
+INSERT INTO crx_dt_test VALUES (247, 'b', 45, 8.5, 'u', 'g', 'cc', 'h', 14, 't', 't', 1, 't', 'g', 88, 2000, '+');
+INSERT INTO crx_dt_test VALUES (249, NULL, 24.5, 12.75, 'u', 'g', 'c', 'bb', 4.75, 't', 't', 2, 'f', 'g', 73, 444, '+');
+INSERT INTO crx_dt_test VALUES (251, 'b', 40.25, 21.5, 'u', 'g', 'e', 'z', 20, 't', 't', 11, 'f', 'g', 0, 1200, '+');
+INSERT INTO crx_dt_test VALUES (253, 'a', 17.829999999999998, 11, 'u', 'g', 'x', 'h', 1, 't', 't', 11, 'f', 'g', 0, 3000, '+');
+INSERT INTO crx_dt_test VALUES (255, 'b', NULL, 0.625, 'u', 'g', 'k', 'v', 0.25, 'f', 'f', 0, 'f', 'g', 380, 2010, '-');
+INSERT INTO crx_dt_test VALUES (256, 'b', 18.170000000000002, 10.25, 'u', 'g', 'c', 'h', 1.085, 'f', 'f', 0, 'f', 'g', 320, 13, '-');
+INSERT INTO crx_dt_test VALUES (258, 'b', 20, 0, 'u', 'g', 'd', 'v', 0.5, 'f', 'f', 0, 'f', 'g', 144, 0, '-');
+INSERT INTO crx_dt_test VALUES (260, 'a', 24.5, 1.75, 'y', 'p', 'c', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 132, 0, '-');
+INSERT INTO crx_dt_test VALUES (262, 'a', 52.170000000000002, 0, 'y', 'p', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', 0, 0, '-');
+INSERT INTO crx_dt_test VALUES (264, 'a', 20.420000000000002, 10.5, 'y', 'p', 'x', 'h', 0, 'f', 'f', 0, 't', 'g', 154, 32, '-');
+INSERT INTO crx_dt_test VALUES (266, 'b', 17.079999999999998, 0.085000000000000006, 'y', 'p', 'c', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 140, 722, '-');
+INSERT INTO crx_dt_test VALUES (268, 'a', 32, 6, 'u', 'g', 'd', 'v', 1.25, 'f', 'f', 0, 'f', 'g', 272, 0, '-');
+INSERT INTO crx_dt_test VALUES (270, 'b', 18, 0.16500000000000001, 'u', 'g', 'q', 'n', 0.20999999999999999, 'f', 'f', 0, 'f', 'g', 200, 40, '+');
+INSERT INTO crx_dt_test VALUES (272, 'b', 32.329999999999998, 2.5, 'u', 'g', 'c', 'v', 1.25, 'f', 'f', 0, 't', 'g', 280, 0, '-');
+INSERT INTO crx_dt_test VALUES (274, 'b', 38.25, 10.125, 'y', 'p', 'k', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 160, 0, '-');
+INSERT INTO crx_dt_test VALUES (276, 'b', 18.579999999999998, 5.71, 'u', 'g', 'd', 'v', 0.54000000000000004, 'f', 'f', 0, 'f', 'g', 120, 0, '-');
+INSERT INTO crx_dt_test VALUES (278, 'a', 18.170000000000002, 10, 'y', 'p', 'q', 'h', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 340, 0, '-');
+INSERT INTO crx_dt_test VALUES (280, 'b', 16.25, 0.83499999999999996, 'u', 'g', 'm', 'v', 0.085000000000000006, 't', 'f', 0, 'f', 's', 200, 0, '-');
+INSERT INTO crx_dt_test VALUES (282, 'b', 23.920000000000002, 0.58499999999999996, 'y', 'p', 'cc', 'h', 0.125, 'f', 'f', 0, 'f', 'g', 240, 1, '-');
+INSERT INTO crx_dt_test VALUES (284, 'a', 16.5, 1.25, 'u', 'g', 'q', 'v', 0.25, 'f', 't', 1, 'f', 'g', 108, 98, '-');
+INSERT INTO crx_dt_test VALUES (286, 'b', 17.579999999999998, 10, 'u', 'g', 'w', 'h', 0.16500000000000001, 'f', 't', 1, 'f', 'g', 120, 1, '-');
+INSERT INTO crx_dt_test VALUES (288, 'b', 29.5, 0.57999999999999996, 'u', 'g', 'w', 'v', 0.28999999999999998, 'f', 't', 1, 'f', 'g', 340, 2803, '-');
+INSERT INTO crx_dt_test VALUES (290, 'a', 21.75, 1.75, 'y', 'p', 'j', 'j', 0, 'f', 'f', 0, 'f', 'g', 160, 0, '-');
+INSERT INTO crx_dt_test VALUES (292, 'a', 18.25, 10, 'u', 'g', 'w', 'v', 1, 'f', 't', 1, 'f', 'g', 120, 1, '-');
+INSERT INTO crx_dt_test VALUES (294, 'b', 35.75, 2.415, 'u', 'g', 'w', 'v', 0.125, 'f', 't', 2, 'f', 'g', 220, 1, '-');
+INSERT INTO crx_dt_test VALUES (296, 'a', 31.920000000000002, 3.125, 'u', 'g', 'ff', 'ff', 3.04, 'f', 't', 2, 't', 'g', 200, 4, '-');
+INSERT INTO crx_dt_test VALUES (298, 'b', 32.920000000000002, 2.5, 'u', 'g', 'aa', 'v', 1.75, 'f', 't', 2, 't', 'g', 720, 0, '-');
+INSERT INTO crx_dt_test VALUES (300, 'b', 22.170000000000002, 12.125, 'u', 'g', 'c', 'v', 3.335, 'f', 't', 2, 't', 'g', 180, 173, '-');
+INSERT INTO crx_dt_test VALUES (302, 'b', 18.25, 0.16500000000000001, 'u', 'g', 'd', 'v', 0.25, 'f', 'f', 0, 't', 's', 280, 0, '-');
+INSERT INTO crx_dt_test VALUES (304, 'a', 15.92, 2.875, 'u', 'g', 'q', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 120, 0, '-');
+INSERT INTO crx_dt_test VALUES (306, 'b', 48.75, 26.335000000000001, 'y', 'p', 'ff', 'ff', 0, 't', 'f', 0, 't', 'g', 0, 0, '-');
+INSERT INTO crx_dt_test VALUES (308, 'b', 18.579999999999998, 10.289999999999999, 'u', 'g', 'ff', 'ff', 0.41499999999999998, 'f', 'f', 0, 'f', 'g', 80, 0, '-');
+INSERT INTO crx_dt_test VALUES (310, 'a', 31.75, 3, 'y', 'p', 'j', 'j', 0, 'f', 'f', 0, 'f', 'g', 160, 20, '-');
+INSERT INTO crx_dt_test VALUES (312, 'b', 19, 1.75, 'y', 'p', 'c', 'v', 2.335, 'f', 'f', 0, 't', 'g', 112, 6, '-');
+INSERT INTO crx_dt_test VALUES (314, 'a', 18.579999999999998, 10, 'u', 'g', 'd', 'v', 0.41499999999999998, 'f', 'f', 0, 'f', 'g', 80, 42, '-');
+INSERT INTO crx_dt_test VALUES (316, 'b', 23, 0.75, 'u', 'g', 'm', 'v', 0.5, 't', 'f', 0, 't', 's', 320, 0, '-');
+INSERT INTO crx_dt_test VALUES (318, 'b', 17.5, 22, 'l', 'gg', 'ff', 'o', 0, 'f', 'f', 0, 't', 'p', 450, 100000, '+');
+INSERT INTO crx_dt_test VALUES (320, 'b', 36.75, 0.125, 'y', 'p', 'c', 'v', 1.5, 'f', 'f', 0, 't', 'g', 232, 113, '+');
+INSERT INTO crx_dt_test VALUES (322, 'a', 18.079999999999998, 0.375, 'l', 'gg', 'cc', 'ff', 10, 'f', 'f', 0, 't', 's', 300, 0, '+');
+INSERT INTO crx_dt_test VALUES (324, 'b', 48.579999999999998, 0.20499999999999999, 'y', 'p', 'k', 'v', 0.25, 't', 't', 11, 'f', 'g', 380, 2732, '+');
+INSERT INTO crx_dt_test VALUES (326, 'a', 29.5, 1.085, 'y', 'p', 'x', 'v', 1, 'f', 'f', 0, 'f', 'g', 280, 13, '-');
+INSERT INTO crx_dt_test VALUES (328, NULL, 40.829999999999998, 3.5, 'u', 'g', 'i', 'bb', 0.5, 'f', 'f', 0, 'f', 's', 1160, 0, '-');
+INSERT INTO crx_dt_test VALUES (330, 'b', NULL, 4, 'y', 'p', 'i', 'v', 0.085000000000000006, 'f', 'f', 0, 't', 'g', 411, 0, '-');
+INSERT INTO crx_dt_test VALUES (332, 'a', 33.25, 2.5, 'y', 'p', 'c', 'v', 2.5, 'f', 'f', 0, 't', 'g', 0, 2, '-');
+INSERT INTO crx_dt_test VALUES (334, 'a', 25.25, 12.5, 'u', 'g', 'd', 'v', 1, 'f', 'f', 0, 't', 'g', 180, 1062, '-');
+INSERT INTO crx_dt_test VALUES (336, 'b', 27.670000000000002, 0.75, 'u', 'g', 'q', 'h', 0.16500000000000001, 'f', 'f', 0, 't', 'g', 220, 251, '-');
+INSERT INTO crx_dt_test VALUES (338, 'a', 34.829999999999998, 1.25, 'y', 'p', 'i', 'h', 0.5, 'f', 'f', 0, 't', 'g', 160, 0, '-');
+INSERT INTO crx_dt_test VALUES (340, 'b', 28, 3, 'u', 'g', 'w', 'v', 0.75, 'f', 'f', 0, 't', 'g', 300, 67, '-');
+INSERT INTO crx_dt_test VALUES (342, 'b', 42.75, 4.085, 'u', 'g', 'aa', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 108, 100, '-');
+INSERT INTO crx_dt_test VALUES (344, 'b', 33.75, 2.75, 'u', 'g', 'i', 'bb', 0, 'f', 'f', 0, 'f', 'g', 180, 0, '-');
+INSERT INTO crx_dt_test VALUES (346, 'b', 62.75, 7, 'u', 'g', 'e', 'z', 0, 'f', 'f', 0, 'f', 'g', 0, 12, '-');
+INSERT INTO crx_dt_test VALUES (348, 'b', 26.75, 4.5, 'y', 'p', 'c', 'bb', 2.5, 'f', 'f', 0, 'f', 'g', 200, 1210, '-');
+INSERT INTO crx_dt_test VALUES (350, 'b', 27.829999999999998, 1.5, 'u', 'g', 'w', 'v', 2.25, 'f', 't', 1, 't', 'g', 100, 3, '-');
+INSERT INTO crx_dt_test VALUES (352, 'b', 22.170000000000002, 0.58499999999999996, 'y', 'p', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', 100, 0, '-');
+INSERT INTO crx_dt_test VALUES (354, 'b', 30.75, 1.585, 'u', 'g', 'd', 'v', 0.58499999999999996, 'f', 'f', 0, 't', 's', 0, 0, '-');
+INSERT INTO crx_dt_test VALUES (356, 'a', 16, 0.16500000000000001, 'u', 'g', 'aa', 'v', 1, 'f', 't', 2, 't', 'g', 320, 1, '-');
+INSERT INTO crx_dt_test VALUES (358, 'a', 19.5, 0.16500000000000001, 'u', 'g', 'q', 'v', 0.040000000000000001, 'f', 'f', 0, 't', 'g', 380, 0, '-');
+INSERT INTO crx_dt_test VALUES (360, 'a', 36.75, 4.71, 'u', 'g', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', 160, 0, '-');
+INSERT INTO crx_dt_test VALUES (362, 'b', 23.079999999999998, 2.5, 'u', 'g', 'ff', 'ff', 0.085000000000000006, 'f', 'f', 0, 't', 'g', 100, 4208, '-');
+INSERT INTO crx_dt_test VALUES (364, 'b', 16.920000000000002, 0.33500000000000002, 'y', 'p', 'k', 'v', 0.28999999999999998, 'f', 'f', 0, 'f', 's', 200, 0, '-');
+INSERT INTO crx_dt_test VALUES (366, 'b', 42.829999999999998, 1.25, 'u', 'g', 'm', 'v', 13.875, 'f', 't', 1, 't', 'g', 352, 112, '-');
+INSERT INTO crx_dt_test VALUES (368, 'b', 39.420000000000002, 1.71, 'y', 'p', 'm', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 's', 400, 0, '-');
+INSERT INTO crx_dt_test VALUES (370, 'b', 21.420000000000002, 0.75, 'y', 'p', 'r', 'n', 0.75, 'f', 'f', 0, 't', 'g', 132, 2, '-');
+INSERT INTO crx_dt_test VALUES (372, 'b', 26.329999999999998, 13, 'u', 'g', 'e', 'dd', 0, 'f', 'f', 0, 't', 'g', 140, 1110, '-');
+INSERT INTO crx_dt_test VALUES (374, 'b', 26.25, 1.54, 'u', 'g', 'w', 'v', 0.125, 'f', 'f', 0, 'f', 'g', 100, 0, '-');
+INSERT INTO crx_dt_test VALUES (376, 'a', 20.829999999999998, 0.5, 'y', 'p', 'e', 'dd', 1, 'f', 'f', 0, 'f', 'g', 260, 0, '-');
+INSERT INTO crx_dt_test VALUES (378, 'b', 20.670000000000002, 0.83499999999999996, 'y', 'p', 'c', 'v', 2, 'f', 'f', 0, 't', 's', 240, 0, '-');
+INSERT INTO crx_dt_test VALUES (380, 'b', 33.579999999999998, 0.25, 'u', 'g', 'i', 'bb', 4, 'f', 'f', 0, 't', 's', 420, 0, '-');
+INSERT INTO crx_dt_test VALUES (382, 'a', 22.670000000000002, 7, 'u', 'g', 'c', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 160, 0, '-');
+INSERT INTO crx_dt_test VALUES (384, 'a', 56.829999999999998, 4.25, 'y', 'p', 'ff', 'ff', 5, 'f', 'f', 0, 't', 'g', 0, 4, '-');
+INSERT INTO crx_dt_test VALUES (386, 'b', 34, 5.5, 'y', 'p', 'c', 'v', 1.5, 'f', 'f', 0, 't', 'g', 60, 0, '-');
+INSERT INTO crx_dt_test VALUES (388, 'b', 21.170000000000002, 0, 'u', 'g', 'c', 'v', 0.5, 'f', 'f', 0, 't', 's', 0, 0, '-');
+INSERT INTO crx_dt_test VALUES (390, 'b', 22.920000000000002, 0.17000000000000001, 'u', 'g', 'm', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 's', 0, 0, '-');
+INSERT INTO crx_dt_test VALUES (392, 'b', 39.920000000000002, 5, 'u', 'g', 'i', 'bb', 0.20999999999999999, 'f', 'f', 0, 'f', 'g', 550, 0, '-');
+INSERT INTO crx_dt_test VALUES (394, 'b', 24.75, 0.54000000000000004, 'u', 'g', 'm', 'v', 1, 'f', 'f', 0, 't', 'g', 120, 1, '-');
+INSERT INTO crx_dt_test VALUES (396, 'a', 33.079999999999998, 1.625, 'u', 'g', 'd', 'v', 0.54000000000000004, 'f', 'f', 0, 't', 'g', 0, 0, '-');
+INSERT INTO crx_dt_test VALUES (398, 'a', 23.579999999999998, 0.58499999999999996, 'y', 'p', 'ff', 'ff', 0.125, 'f', 'f', 0, 'f', 'g', 120, 87, '-');
+INSERT INTO crx_dt_test VALUES (400, 'b', 31, 2.085, 'u', 'g', 'c', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 300, 0, '-');
+INSERT INTO crx_dt_test VALUES (402, 'b', 28.920000000000002, 0.375, 'u', 'g', 'c', 'v', 0.28999999999999998, 'f', 'f', 0, 'f', 'g', 220, 140, '-');
+INSERT INTO crx_dt_test VALUES (404, 'a', 22.670000000000002, 0.33500000000000002, 'u', 'g', 'q', 'v', 0.75, 'f', 'f', 0, 'f', 's', 160, 0, '-');
+INSERT INTO crx_dt_test VALUES (406, 'a', 69.5, 6, 'u', 'g', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 's', 0, 0, '-');
+INSERT INTO crx_dt_test VALUES (408, 'a', 19.579999999999998, 0.66500000000000004, 'y', 'p', 'c', 'v', 1, 'f', 't', 1, 'f', 'g', 2000, 2, '-');
+INSERT INTO crx_dt_test VALUES (410, 'b', 17.079999999999998, 0.25, 'u', 'g', 'q', 'v', 0.33500000000000002, 'f', 't', 4, 'f', 'g', 160, 8, '-');
+INSERT INTO crx_dt_test VALUES (412, 'b', 25.170000000000002, 3, 'u', 'g', 'c', 'v', 1.25, 'f', 't', 1, 'f', 'g', 0, 22, '-');
+INSERT INTO crx_dt_test VALUES (414, 'b', 40.579999999999998, 1.5, 'u', 'g', 'i', 'bb', 0, 'f', 'f', 0, 'f', 's', 300, 0, '-');
+INSERT INTO crx_dt_test VALUES (416, 'a', 22.25, 1.25, 'y', 'p', 'ff', 'ff', 3.25, 'f', 'f', 0, 'f', 'g', 280, 0, '-');
+INSERT INTO crx_dt_test VALUES (418, 'b', 23.579999999999998, 1.79, 'u', 'g', 'c', 'v', 0.54000000000000004, 'f', 'f', 0, 't', 'g', 136, 1, '-');
+INSERT INTO crx_dt_test VALUES (420, 'a', 26.579999999999998, 2.54, 'y', 'p', 'ff', 'ff', 0, 'f', 'f', 0, 't', 'g', 180, 60, '-');
+INSERT INTO crx_dt_test VALUES (422, 'b', 20.420000000000002, 1.085, 'u', 'g', 'q', 'v', 1.5, 'f', 'f', 0, 'f', 'g', 108, 7, '-');
+INSERT INTO crx_dt_test VALUES (424, 'b', 26.170000000000002, 0.83499999999999996, 'u', 'g', 'cc', 'v', 1.165, 'f', 'f', 0, 'f', 'g', 100, 0, '-');
+INSERT INTO crx_dt_test VALUES (426, 'b', 24.579999999999998, 1.25, 'u', 'g', 'c', 'v', 0.25, 'f', 'f', 0, 'f', 'g', 110, 0, '-');
+INSERT INTO crx_dt_test VALUES (428, 'b', 37.5, 0.83499999999999996, 'u', 'g', 'e', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 120, 5, '-');
+INSERT INTO crx_dt_test VALUES (430, 'b', 33.579999999999998, 0.33500000000000002, 'y', 'p', 'cc', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 180, 0, '-');
+INSERT INTO crx_dt_test VALUES (432, 'b', 22.920000000000002, 3.165, 'y', 'p', 'c', 'v', 0.16500000000000001, 'f', 'f', 0, 'f', 'g', 160, 1058, '-');
+INSERT INTO crx_dt_test VALUES (434, 'b', 25.25, 1, 'u', 'g', 'aa', 'v', 0.5, 'f', 'f', 0, 'f', 'g', 200, 0, '-');
+INSERT INTO crx_dt_test VALUES (436, 'b', 19, 0, 'y', 'p', 'ff', 'ff', 0, 'f', 't', 4, 'f', 'g', 45, 1, '-');
+INSERT INTO crx_dt_test VALUES (438, 'a', 53.329999999999998, 0.16500000000000001, 'u', 'g', 'ff', 'ff', 0, 'f', 'f', 0, 't', 's', 62, 27, '-');
+INSERT INTO crx_dt_test VALUES (440, 'b', 25.920000000000002, 0.875, 'u', 'g', 'k', 'v', 0.375, 'f', 't', 2, 't', 'g', 174, 3, '-');
+INSERT INTO crx_dt_test VALUES (442, 'b', 39.579999999999998, 5, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 2, 'f', 'g', 17, 1, '-');
+INSERT INTO crx_dt_test VALUES (444, 'b', 17.25, 3, 'u', 'g', 'k', 'v', 0.040000000000000001, 'f', 'f', 0, 't', 'g', 160, 40, '-');
+INSERT INTO crx_dt_test VALUES (446, 'a', NULL, 11.25, 'u', 'g', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', NULL, 5200, '-');
+INSERT INTO crx_dt_test VALUES (448, 'a', 27.329999999999998, 1.665, 'u', 'g', 'ff', 'ff', 0, 'f', 'f', 0, 'f', 'g', 340, 1, '-');
+INSERT INTO crx_dt_test VALUES (450, 'b', 20, 7, 'u', 'g', 'c', 'v', 0.5, 'f', 'f', 0, 'f', 'g', 0, 0, '-');
+INSERT INTO crx_dt_test VALUES (452, 'b', 39.5, 1.625, 'u', 'g', 'c', 'v', 1.5, 'f', 'f', 0, 'f', 'g', 0, 316, '-');
+INSERT INTO crx_dt_test VALUES (454, NULL, 29.75, 0.66500000000000004, 'u', 'g', 'w', 'v', 0.25, 'f', 'f', 0, 't', 'g', 300, 0, '-');
+INSERT INTO crx_dt_test VALUES (456, 'b', 36.170000000000002, 18.125, 'u', 'g', 'w', 'v', 0.085000000000000006, 'f', 'f', 0, 'f', 'g', 320, 3552, '-');
+INSERT INTO crx_dt_test VALUES (458, 'b', 29.670000000000002, 0.75, 'y', 'p', 'c', 'v', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 240, 0, '-');
+INSERT INTO crx_dt_test VALUES (460, 'b', 25.670000000000002, 0.28999999999999998, 'y', 'p', 'c', 'v', 1.5, 'f', 'f', 0, 't', 'g', 160, 0, '-');
+INSERT INTO crx_dt_test VALUES (462, 'b', 24.079999999999998, 0.875, 'u', 'g', 'm', 'v', 0.085000000000000006, 'f', 't', 4, 'f', 'g', 254, 1950, '-');
+INSERT INTO crx_dt_test VALUES (464, 'a', 36.579999999999998, 0.28999999999999998, 'u', 'g', 'ff', 'ff', 0, 'f', 't', 10, 'f', 'g', 200, 18, '-');
+INSERT INTO crx_dt_test VALUES (466, 'a', 27.579999999999998, 3, 'u', 'g', 'm', 'v', 2.79, 'f', 't', 1, 't', 'g', 280, 10, '-');
+INSERT INTO crx_dt_test VALUES (468, 'a', 30.420000000000002, 1.375, 'u', 'g', 'w', 'h', 0.040000000000000001, 'f', 't', 3, 'f', 'g', 0, 33, '-');
+INSERT INTO crx_dt_test VALUES (470, 'b', 16.329999999999998, 4.085, 'u', 'g', 'i', 'h', 0.41499999999999998, 'f', 'f', 0, 't', 'g', 120, 0, '-');
+INSERT INTO crx_dt_test VALUES (472, 'b', 21.079999999999998, 4.125, 'y', 'p', 'i', 'h', 0.040000000000000001, 'f', 'f', 0, 'f', 'g', 140, 100, '-');
+INSERT INTO crx_dt_test VALUES (474, 'b', 19.170000000000002, 4, 'y', 'p', 'i', 'v', 1, 'f', 'f', 0, 't', 'g', 360, 1000, '-');
+INSERT INTO crx_dt_test VALUES (476, 'b', 26.75, 2, 'u', 'g', 'd', 'v', 0.75, 'f', 'f', 0, 't', 'g', 80, 0, '-');
+INSERT INTO crx_dt_test VALUES (478, 'b', 39.170000000000002, 2.5, 'y', 'p', 'i', 'h', 10, 'f', 'f', 0, 't', 's', 200, 0, '-');
+INSERT INTO crx_dt_test VALUES (480, NULL, 26.5, 2.71, 'y', 'p', NULL, NULL, 0.085000000000000006, 'f', 'f', 0, 'f', 's', 80, 0, '-');
+INSERT INTO crx_dt_test VALUES (482, 'b', 23.5, 3.165, 'y', 'p', 'k', 'v', 0.41499999999999998, 'f', 't', 1, 't', 'g', 280, 80, '-');
+INSERT INTO crx_dt_test VALUES (484, 'b', 23.75, 0.41499999999999998, 'y', 'p', 'c', 'v', 0.040000000000000001, 'f', 't', 2, 'f', 'g', 128, 6, '-');
+INSERT INTO crx_dt_test VALUES (486, 'b', 74.829999999999998, 19, 'y', 'p', 'ff', 'ff', 0.040000000000000001, 'f', 't', 2, 'f', 'g', 0, 351, '-');
+INSERT INTO crx_dt_test VALUES (488, 'b', 24.5, 13.335000000000001, 'y', 'p', 'aa', 'v', 0.040000000000000001, 'f', 'f', 0, 't', 'g', 120, 475, '-');
+INSERT INTO crx_dt_test VALUES (490, NULL, 45.329999999999998, 1, 'u', 'g', 'q', 'v', 0.125, 'f', 'f', 0, 't', 'g', 263, 0, '-');
 
-drop function if exists MADLIB_SCHEMA.rf_test( TEXT, TEXT, TEXT, TEXT,TEXT, INT,TEXT,INT);
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.rf_test
+drop function if exists rf_test( TEXT, TEXT, TEXT, TEXT,TEXT, INT,TEXT,INT);
+CREATE OR REPLACE FUNCTION rf_test
     (
     training_set        TEXT,
     method              TEXT,
@@ -553,22 +551,22 @@ RETURNS TEXT AS $$
 DECLARE
     result              TEXT;
     score_accuracy      FLOAT8;
-    train_result        MADLIB_SCHEMA.rf_train_result;
-    tree_name           TEXT := 'MADLIB_SCHEMA.trained_rf';
-    classify_result     TEXT := 'MADLIB_SCHEMA.classify_result';
-    classify_result2    TEXT := 'MADLIB_SCHEMA.classify_result2';
+    train_result        rf_train_result;
+    tree_name           TEXT := 'trained_rf';
+    classify_result     TEXT := 'classify_result';
+    classify_result2    TEXT := 'classify_result2';
     size                INT;
     size_consistent     INT;
     pass                BOOL;
-BEGIN 
+BEGIN
     result='PASS';
     train_result = MADLIB_SCHEMA.rf_train(method,training_set,tree_name,
-        num_of_tree,null,1,cont_features,null,'id',class_column, 
+        num_of_tree,null,1,cont_features,null,'id',class_column,
         missing_operation,tree_dep,0,0,0);
 
     -- ensure we didn't change the variable names of the returned type
     EXECUTE 'SELECT COUNT(*) = 7 FROM pg_attribute
-             WHERE attrelid = ''MADLIB_SCHEMA.rf_train_result''::regclass and
+             WHERE attrelid = ''rf_train_result''::regclass and
                    attname IN (''training_time'', ''num_of_samples'',
                                 ''num_trees'', ''features_per_node'',
                                 ''num_tree_nodes'', ''max_tree_depth'',
@@ -583,21 +581,21 @@ BEGIN
 
     -- parallel classify should work.
     PERFORM MADLIB_SCHEMA.rf_classify(tree_name,score_set,classify_result,'f',0);
-    
+
     -- serial classify should work.
     PERFORM MADLIB_SCHEMA.rf_classify(tree_name,score_set,classify_result2,'t',0);
-    
+
     -- Check the classification result is OK
     IF ( MADLIB_SCHEMA.__table_exists(classify_result)
             AND MADLIB_SCHEMA.__table_exists(classify_result2) ) THEN
         EXECUTE 'SELECT COUNT(*) FROM '||classify_result||';' INTO size;
-        
+
         EXECUTE 'SELECT COUNT(*) FROM '||classify_result||' t1,'||classify_result2||
             ' t2 WHERE t1.id=t2.id AND t1.class=t2.class;' INTO size_consistent;
 
         EXECUTE 'DROP TABLE '||classify_result;
         EXECUTE 'DROP TABLE '||classify_result2;
-        
+
         -- The results from the two classification method should be consistent.
         IF (size <> size_consistent) THEN
             result = 'FAIL';
@@ -607,22 +605,22 @@ BEGIN
         result = 'FAIL';
         RAISE EXCEPTION 'Install check failed.';
     END IF;
-    
-    PERFORM MADLIB_SCHEMA.rf_clean(tree_name);  
+
+    PERFORM MADLIB_SCHEMA.rf_clean(tree_name);
 
     -- Since random forest use sampling, the trained model varies each time.
     -- As a result, we cannot check the display result as the test for c4.5.
     -- But for the chosen data set, we should not get an accuracy lower than 0.8.
-    IF (score_accuracy<0.8) THEN 
+    IF (score_accuracy<0.8) THEN
         result = 'FAIL';
         RAISE EXCEPTION 'Install check failed.';
     END IF;
     RETURN result;
 END
-$$ language plpgsql;  
+$$ language plpgsql;
 
-DROP FUNCTION IF EXISTS MADLIB_SCHEMA.c45_test(TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,INT,TEXT,TEXT);
-CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.c45_test
+DROP FUNCTION IF EXISTS c45_test(TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,INT,TEXT,TEXT);
+CREATE OR REPLACE FUNCTION c45_test
     (
     training_set        TEXT,
     method              TEXT,
@@ -633,25 +631,25 @@ CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.c45_test
     tree_dep            INT,
     missing_operation   TEXT,
     exp_display_result  TEXT
-    ) 
+    )
 RETURNS TEXT AS $$
 declare
 	result              TEXT := 'PASS';
 	display_result      TEXT;
 	exp_display_result  TEXT;
     score_accuracy      FLOAT8;
-    train_result        MADLIB_SCHEMA.c45_train_result;
-    tree_name           TEXT := 'MADLIB_SCHEMA.trained_tree';
-    classify_result     TEXT := 'MADLIB_SCHEMA.classify_result';
+    train_result        c45_train_result;
+    tree_name           TEXT := 'trained_tree';
+    classify_result     TEXT := 'classify_result';
     pass                BOOL;
-begin 
+begin
 
 	train_result = MADLIB_SCHEMA.c45_train(method,training_set,tree_name,
         validation_set,cont_features,null,'id',class_column, 100,
         missing_operation,tree_dep,0,0,0);
     -- ensure we didn't change the variable names of the returned type
     EXECUTE 'SELECT COUNT(*) = 5 FROM pg_attribute
-             WHERE attrelid = ''MADLIB_SCHEMA.c45_train_result''::regclass and
+             WHERE attrelid = ''c45_train_result''::regclass and
                    attname IN (''training_set_size'', ''tree_nodes'',
                                 ''tree_depth'', ''training_time'',
                                 ''split_criterion'')'
@@ -660,9 +658,9 @@ begin
         result = 'FAIL';
         RAISE EXCEPTION 'Install check failed.';
     END IF;
-    
+
 	score_accuracy =  MADLIB_SCHEMA.c45_score(tree_name,score_set,0);
-	
+
     -- classify should work.
     PERFORM MADLIB_SCHEMA.c45_classify(tree_name,score_set,classify_result,0);
     -- Check the classification result is OK
@@ -674,16 +672,16 @@ begin
     END IF;
 
     -- For those two datasets, we should not get an accuracy lower than 0.9
-    IF (score_accuracy<0.9) THEN 
+    IF (score_accuracy<0.9) THEN
         result = 'FAIL';
         RAISE EXCEPTION 'Install check failed.';
     END IF;
-    
+
     -- remove space and some control character
     exp_display_result = replace(exp_display_result,' ','');
     exp_display_result = replace(exp_display_result,E'\n','');
 
-    SELECT * FROM MADLIB_SCHEMA.c45_display(tree_name) LIMIT 1 
+    SELECT * FROM MADLIB_SCHEMA.c45_display(tree_name) LIMIT 1
         INTO display_result;
     -- remove space and some control character
     display_result = replace(display_result,' ','');
@@ -696,15 +694,15 @@ begin
         RAISE EXCEPTION 'Install check failed.';
     END IF;
 
-    PERFORM MADLIB_SCHEMA.c45_clean(tree_name);    
+    PERFORM MADLIB_SCHEMA.c45_clean(tree_name);
     RETURN result;
 end
-$$ language plpgsql;	
+$$ language plpgsql;
 
 -- Golf dataset is very small. Since random forest uses sampling, we think this dataset
 -- is not appropriate for random forest test. We only test c4.5 based on golf.
-SELECT MADLIB_SCHEMA.c45_test('MADLIB_SCHEMA.golf_dt_test','infogain','temperature,humidity',
-    'class','MADLIB_SCHEMA.golf_dt_test','MADLIB_SCHEMA.golf_dt_test',10,'explicit',
+SELECT c45_test('golf_dt_test','infogain','temperature,humidity',
+    'class','golf_dt_test','golf_dt_test',10,'explicit',
     'Tree 1
     Root Node  : class( Play)   num_elements(14)  predict_prob(0.642857142857143)
          outlook:  = overcast  : class( Play)   num_elements(4)  predict_prob(1)
@@ -716,8 +714,8 @@ SELECT MADLIB_SCHEMA.c45_test('MADLIB_SCHEMA.golf_dt_test','infogain','temperatu
              humidity:  > 70  : class( Do not Play)   num_elements(3)  predict_prob(1)');
 
 
-SELECT MADLIB_SCHEMA.c45_test('MADLIB_SCHEMA.golf_dt_test','gini','temperature,humidity',
-    'class','MADLIB_SCHEMA.golf_dt_test','MADLIB_SCHEMA.golf_dt_test',10,'explicit',
+SELECT c45_test('golf_dt_test','gini','temperature,humidity',
+    'class','golf_dt_test','golf_dt_test',10,'explicit',
     'Tree 1
     Root Node  : class( Play)   num_elements(14)  predict_prob(0.642857142857143)
          outlook:  = overcast  : class( Play)   num_elements(4)  predict_prob(1)
@@ -729,430 +727,425 @@ SELECT MADLIB_SCHEMA.c45_test('MADLIB_SCHEMA.golf_dt_test','gini','temperature,h
              humidity:  > 70  : class( Do not Play)   num_elements(3)  predict_prob(1)');
 
 -- Verify temporary table can be used as training table.
-DROP TABLE IF EXISTS golf_tmp;
-CREATE TEMP TABLE golf_tmp AS SELECT * from MADLIB_SCHEMA.golf_dt_test;
-SELECT MADLIB_SCHEMA.c45_test('golf_tmp','gainratio','temperature,humidity',
-    'class','MADLIB_SCHEMA.golf_dt_test','MADLIB_SCHEMA.golf_dt_test',10,'explicit',
+CREATE TABLE golf_tmp AS SELECT * from golf_dt_test;
+SELECT c45_test('golf_tmp','gainratio','temperature,humidity',
+    'class','golf_dt_test','golf_dt_test',10,'explicit',
     'Tree 1
-    Root Node  : class( Play)   num_elements(14)  predict_prob(0.642857142857143)                                          
-         temperature:  <= 83  : class( Play)   num_elements(13)  predict_prob(0.692307692307692)                            
-             temperature:  <= 80  : class( Play)   num_elements(11)  predict_prob(0.636363636363636)                        
-                 temperature:  <= 75  : class( Play)   num_elements(10)  predict_prob(0.7)                                  
-                     temperature:  <= 72  : class( Play)   num_elements(8)  predict_prob(0.625)                             
-                         humidity:  <= 95  : class( Play)   num_elements(7)  predict_prob(0.571428571428571)                
-                             humidity:  <= 90  : class( Play)   num_elements(6)  predict_prob(0.666666666666667)            
-                                 outlook:  = overcast  : class( Play)   num_elements(2)  predict_prob(1)                    
-                                 outlook:  = rain  : class( Do not Play)   num_elements(3)  predict_prob(0.666666666666667) 
-                                     windy:  =  false  : class( Play)   num_elements(1)  predict_prob(1)                    
-                                     windy:  =  true  : class( Do not Play)   num_elements(2)  predict_prob(1)              
-                                 outlook:  = sunny  : class( Play)   num_elements(1)  predict_prob(1)                       
-                             humidity:  > 90  : class( Do not Play)   num_elements(1)  predict_prob(1)                      
-                         humidity:  > 95  : class( Play)   num_elements(1)  predict_prob(1)                                 
-                     temperature:  > 72  : class( Play)   num_elements(2)  predict_prob(1)                                  
-                 temperature:  > 75  : class( Do not Play)   num_elements(1)  predict_prob(1)                               
-             temperature:  > 80  : class( Play)   num_elements(2)  predict_prob(1)                                          
+    Root Node  : class( Play)   num_elements(14)  predict_prob(0.642857142857143)
+         temperature:  <= 83  : class( Play)   num_elements(13)  predict_prob(0.692307692307692)
+             temperature:  <= 80  : class( Play)   num_elements(11)  predict_prob(0.636363636363636)
+                 temperature:  <= 75  : class( Play)   num_elements(10)  predict_prob(0.7)
+                     temperature:  <= 72  : class( Play)   num_elements(8)  predict_prob(0.625)
+                         humidity:  <= 95  : class( Play)   num_elements(7)  predict_prob(0.571428571428571)
+                             humidity:  <= 90  : class( Play)   num_elements(6)  predict_prob(0.666666666666667)
+                                 outlook:  = overcast  : class( Play)   num_elements(2)  predict_prob(1)
+                                 outlook:  = rain  : class( Do not Play)   num_elements(3)  predict_prob(0.666666666666667)
+                                     windy:  =  false  : class( Play)   num_elements(1)  predict_prob(1)
+                                     windy:  =  true  : class( Do not Play)   num_elements(2)  predict_prob(1)
+                                 outlook:  = sunny  : class( Play)   num_elements(1)  predict_prob(1)
+                             humidity:  > 90  : class( Do not Play)   num_elements(1)  predict_prob(1)
+                         humidity:  > 95  : class( Play)   num_elements(1)  predict_prob(1)
+                     temperature:  > 72  : class( Play)   num_elements(2)  predict_prob(1)
+                 temperature:  > 75  : class( Do not Play)   num_elements(1)  predict_prob(1)
+             temperature:  > 80  : class( Play)   num_elements(2)  predict_prob(1)
          temperature:  > 83  : class( Do not Play)   num_elements(1)  predict_prob(1)');
 
-DROP TABLE IF EXISTS golf_tmp;
-DROP TABLE IF EXISTS MADLIB_SCHEMA.golf_dt_test;
+SELECT rf_test('crx_dt_test','gini','A2,A3,A8,A11,A14,A15',
+    'a16','crx_dt_test',10,'ignore',5);
 
-SELECT MADLIB_SCHEMA.rf_test('MADLIB_SCHEMA.crx_dt_test','gini','A2,A3,A8,A11,A14,A15',
-    'a16','MADLIB_SCHEMA.crx_dt_test',10,'ignore',5);
-
-SELECT MADLIB_SCHEMA.c45_test('MADLIB_SCHEMA.crx_dt_test','gini','A2,A3,A8,A11,A14,A15',
-    'a16','MADLIB_SCHEMA.crx_dt_test','MADLIB_SCHEMA.crx_dt_test',10,'ignore',
+SELECT c45_test('crx_dt_test','gini','A2,A3,A8,A11,A14,A15',
+    'a16','crx_dt_test','crx_dt_test',10,'ignore',
     'Tree 1
-    Root Node  : class(-)   num_elements(490)  predict_prob(0.557142857142857)                           
-         a9:  = f  : class(-)   num_elements(235)  predict_prob(0.940425531914894)                        
-             a5:  = g  : class(-)   num_elements(159)  predict_prob(0.949685534591195)                    
-                 a6:  = aa  : class(-)   num_elements(10)  predict_prob(1)                                
-                 a6:  = c  : class(-)   num_elements(29)  predict_prob(0.931034482758621)                 
-                     a7:  = h  : class(-)   num_elements(2)  predict_prob(0.5)                            
-                         a12:  = f  : class(-)   num_elements(1)  predict_prob(1)                         
-                         a12:  = t  : class(+)   num_elements(1)  predict_prob(1)                         
-                     a7:  = v  : class(-)   num_elements(27)  predict_prob(0.962962962962963)             
-                         a3:  <= 0.665  : class(-)   num_elements(6)  predict_prob(0.833333333333333)     
-                             a3:  <= 0.5  : class(-)   num_elements(5)  predict_prob(1)                   
-                             a3:  > 0.5  : class(+)   num_elements(1)  predict_prob(1)                    
-                         a3:  > 0.665  : class(-)   num_elements(21)  predict_prob(1)                     
-                 a6:  = cc  : class(-)   num_elements(4)  predict_prob(0.75)                              
-                     a1:  = a  : class(+)   num_elements(1)  predict_prob(1)                              
-                     a1:  = b  : class(-)   num_elements(3)  predict_prob(1)                              
-                 a6:  = d  : class(-)   num_elements(14)  predict_prob(1)                                 
-                 a6:  = e  : class(-)   num_elements(5)  predict_prob(1)                                  
-                 a6:  = ff  : class(-)   num_elements(21)  predict_prob(1)                                
-                 a6:  = i  : class(-)   num_elements(23)  predict_prob(0.956521739130435)                 
-                     a8:  <= 3.085  : class(-)   num_elements(20)  predict_prob(1)                        
-                     a8:  > 3.085  : class(-)   num_elements(3)  predict_prob(0.666666666666667)          
-                         a8:  <= 3.5  : class(+)   num_elements(1)  predict_prob(1)                       
-                         a8:  > 3.5  : class(-)   num_elements(2)  predict_prob(1)                        
-                 a6:  = j  : class(-)   num_elements(2)  predict_prob(1)                                  
-                 a6:  = k  : class(-)   num_elements(15)  predict_prob(0.933333333333333)                 
-                     a15:  <= 2010  : class(-)   num_elements(14)  predict_prob(1)                        
-                     a15:  > 2010  : class(+)   num_elements(1)  predict_prob(1)                          
-                 a6:  = m  : class(-)   num_elements(7)  predict_prob(1)                                  
-                 a6:  = q  : class(-)   num_elements(11)  predict_prob(0.909090909090909)                 
-                     a7:  = h  : class(-)   num_elements(2)  predict_prob(1)                              
-                     a7:  = n  : class(+)   num_elements(1)  predict_prob(1)                              
-                     a7:  = v  : class(-)   num_elements(8)  predict_prob(1)                              
-                 a6:  = w  : class(-)   num_elements(17)  predict_prob(0.941176470588235)                 
-                     a8:  <= 1.165  : class(-)   num_elements(14)  predict_prob(1)                        
-                     a8:  > 1.165  : class(-)   num_elements(3)  predict_prob(0.666666666666667)          
-                         a15:  <= 3  : class(-)   num_elements(2)  predict_prob(1)                        
-                         a15:  > 3  : class(+)   num_elements(1)  predict_prob(1)                         
-                 a6:  = x  : class(+)   num_elements(1)  predict_prob(1)                                  
-             a5:  = gg  : class(+)   num_elements(2)  predict_prob(1)                                     
-             a5:  = p  : class(-)   num_elements(73)  predict_prob(0.945205479452055)                     
-                 a6:  = aa  : class(-)   num_elements(4)  predict_prob(1)                                 
-                 a6:  = c  : class(-)   num_elements(19)  predict_prob(0.947368421052632)                 
-                     a3:  <= 0.125  : class(-)   num_elements(2)  predict_prob(0.5)                       
-                         a12:  = f  : class(-)   num_elements(1)  predict_prob(1)                         
-                         a12:  = t  : class(+)   num_elements(1)  predict_prob(1)                         
-                     a3:  > 0.125  : class(-)   num_elements(17)  predict_prob(1)                         
-                 a6:  = cc  : class(-)   num_elements(2)  predict_prob(1)                                 
-                 a6:  = d  : class(+)   num_elements(1)  predict_prob(1)                                  
-                 a6:  = e  : class(-)   num_elements(2)  predict_prob(1)                                  
-                 a6:  = ff  : class(-)   num_elements(11)  predict_prob(1)                                
-                 a6:  = i  : class(-)   num_elements(8)  predict_prob(1)                                  
-                 a6:  = j  : class(-)   num_elements(4)  predict_prob(1)                                  
-                 a6:  = k  : class(-)   num_elements(8)  predict_prob(1)                                  
-                 a6:  = m  : class(-)   num_elements(5)  predict_prob(0.8)                                
-                     a7:  = bb  : class(+)   num_elements(1)  predict_prob(1)                             
-                     a7:  = v  : class(-)   num_elements(4)  predict_prob(1)                              
-                 a6:  = q  : class(-)   num_elements(1)  predict_prob(1)                                  
-                 a6:  = r  : class(-)   num_elements(1)  predict_prob(1)                                  
-                 a6:  = w  : class(-)   num_elements(3)  predict_prob(1)                                  
-                 a6:  = x  : class(-)   num_elements(4)  predict_prob(0.75)                               
-                     a15:  <= 0  : class(+)   num_elements(1)  predict_prob(1)                            
-                     a15:  > 0  : class(-)   num_elements(3)  predict_prob(1)                             
-         a9:  = t  : class(+)   num_elements(251)  predict_prob(0.800796812749004)                        
-             a15:  <= 225  : class(+)   num_elements(145)  predict_prob(0.668965517241379)                
-                 a6:  = aa  : class(+)   num_elements(17)  predict_prob(0.529411764705882)                
-                     a3:  <= 6.5  : class(-)   num_elements(9)  predict_prob(0.777777777777778)           
-                         a13:  = g  : class(-)   num_elements(8)  predict_prob(0.875)                     
-                             a1:  = a  : class(-)   num_elements(2)  predict_prob(0.5)                    
-                                 a14:  <= 160  : class(-)   num_elements(1)  predict_prob(1)              
-                                 a14:  > 160  : class(+)   num_elements(1)  predict_prob(1)               
-                             a1:  = b  : class(-)   num_elements(6)  predict_prob(1)                      
-                         a13:  = s  : class(+)   num_elements(1)  predict_prob(1)                         
-                     a3:  > 6.5  : class(+)   num_elements(8)  predict_prob(0.875)                        
-                         a5:  = g  : class(+)   num_elements(7)  predict_prob(1)                          
-                         a5:  = p  : class(-)   num_elements(1)  predict_prob(1)                          
-                 a6:  = c  : class(+)   num_elements(23)  predict_prob(0.521739130434783)                 
-                     a14:  <= 100  : class(+)   num_elements(9)  predict_prob(0.777777777777778)          
-                         a15:  <= 221  : class(+)   num_elements(8)  predict_prob(0.875)                  
-                             a3:  <= 10.5  : class(+)   num_elements(6)  predict_prob(1)                  
-                             a3:  > 10.5  : class(-)   num_elements(2)  predict_prob(0.5)                 
-                                 a10:  = f  : class(-)   num_elements(1)  predict_prob(1)                 
-                                 a10:  = t  : class(+)   num_elements(1)  predict_prob(1)                 
-                         a15:  > 221  : class(-)   num_elements(1)  predict_prob(1)                       
-                     a14:  > 100  : class(-)   num_elements(13)  predict_prob(0.615384615384615)          
-                         a2:  <= 29.92  : class(+)   num_elements(8)  predict_prob(0.625)                 
-                             a2:  <= 21.5  : class(-)   num_elements(4)  predict_prob(1)                  
-                             a2:  > 21.5  : class(+)   num_elements(5)  predict_prob(1)                   
-                         a2:  > 29.92  : class(-)   num_elements(5)  predict_prob(1)                      
-                 a6:  = cc  : class(+)   num_elements(13)  predict_prob(0.923076923076923)                
-                     a14:  <= 440  : class(+)   num_elements(12)  predict_prob(1)                         
-                     a14:  > 440  : class(-)   num_elements(1)  predict_prob(1)                           
-                 a6:  = d  : class(+)   num_elements(5)  predict_prob(0.6)                                
-                     a14:  <= 100  : class(+)   num_elements(4)  predict_prob(0.75)                       
-                         a7:  = bb  : class(-)   num_elements(2)  predict_prob(0.5)                       
-                             a10:  = f  : class(-)   num_elements(1)  predict_prob(1)                     
-                             a10:  = t  : class(+)   num_elements(1)  predict_prob(1)                     
-                         a7:  = h  : class(+)   num_elements(1)  predict_prob(1)                          
-                         a7:  = v  : class(+)   num_elements(1)  predict_prob(1)                          
-                     a14:  > 100  : class(-)   num_elements(2)  predict_prob(1)                           
-                 a6:  = e  : class(+)   num_elements(7)  predict_prob(0.714285714285714)                  
-                     a7:  = bb  : class(-)   num_elements(1)  predict_prob(1)                             
-                     a7:  = h  : class(+)   num_elements(2)  predict_prob(1)                              
-                     a7:  = v  : class(+)   num_elements(1)  predict_prob(1)                              
-                     a7:  = z  : class(+)   num_elements(3)  predict_prob(0.666666666666667)              
-                         a12:  = f  : class(-)   num_elements(1)  predict_prob(1)                         
-                         a12:  = t  : class(+)   num_elements(2)  predict_prob(1)                         
-                 a6:  = ff  : class(-)   num_elements(3)  predict_prob(1)                                 
-                 a6:  = i  : class(+)   num_elements(8)  predict_prob(0.75)                               
-                     a3:  <= 2.335  : class(+)   num_elements(4)  predict_prob(1)                         
-                     a3:  > 2.335  : class(-)   num_elements(4)  predict_prob(0.5)                        
-                         a11:  <= 2  : class(-)   num_elements(2)  predict_prob(1)                        
-                         a11:  > 2  : class(+)   num_elements(2)  predict_prob(1)                         
-                 a6:  = j  : class(-)   num_elements(2)  predict_prob(0.5)                                
-                     a10:  = f  : class(-)   num_elements(1)  predict_prob(1)                             
-                     a10:  = t  : class(+)   num_elements(1)  predict_prob(1)                             
-                 a6:  = k  : class(+)   num_elements(9)  predict_prob(0.555555555555556)                  
-                     a3:  <= 1.165  : class(-)   num_elements(3)  predict_prob(1)                         
-                     a3:  > 1.165  : class(+)   num_elements(6)  predict_prob(0.833333333333333)          
-                         a15:  <= 0  : class(+)   num_elements(5)  predict_prob(1)                        
-                         a15:  > 0  : class(-)   num_elements(1)  predict_prob(1)                         
-                 a6:  = m  : class(+)   num_elements(11)  predict_prob(0.545454545454545)                 
-                     a13:  = g  : class(+)   num_elements(6)  predict_prob(1)                             
-                     a13:  = s  : class(-)   num_elements(5)  predict_prob(1)                             
-                 a6:  = q  : class(+)   num_elements(24)  predict_prob(0.791666666666667)                 
-                     a5:  = g  : class(+)   num_elements(23)  predict_prob(0.826086956521739)             
-                         a8:  <= 8.5  : class(+)   num_elements(22)  predict_prob(0.863636363636364)      
-                             a2:  <= 18.67  : class(-)   num_elements(1)  predict_prob(1)                 
-                             a2:  > 18.67  : class(+)   num_elements(21)  predict_prob(0.904761904761905) 
-                                 a14:  <= 145  : class(+)   num_elements(13)  predict_prob(1)             
-                                 a14:  > 145  : class(+)   num_elements(8)  predict_prob(0.75)            
-                                     a14:  <= 200  : class(-)   num_elements(2)  predict_prob(1)          
-                                     a14:  > 200  : class(+)   num_elements(6)  predict_prob(1)           
-                         a8:  > 8.5  : class(-)   num_elements(1)  predict_prob(1)                        
-                     a5:  = p  : class(-)   num_elements(1)  predict_prob(1)                              
-                 a6:  = w  : class(+)   num_elements(13)  predict_prob(0.846153846153846)                 
-                     a14:  <= 240  : class(+)   num_elements(9)  predict_prob(1)                          
-                     a14:  > 240  : class(-)   num_elements(4)  predict_prob(0.5)                         
-                         a13:  = g  : class(-)   num_elements(3)  predict_prob(0.666666666666667)         
-                             a15:  <= 0  : class(-)   num_elements(2)  predict_prob(1)                    
-                             a15:  > 0  : class(+)   num_elements(1)  predict_prob(1)                     
-                         a13:  = s  : class(+)   num_elements(1)  predict_prob(1)                         
-                 a6:  = x  : class(+)   num_elements(9)  predict_prob(0.888888888888889)                  
-                     a10:  = f  : class(-)   num_elements(1)  predict_prob(1)                             
-                     a10:  = t  : class(+)   num_elements(8)  predict_prob(1)                             
-             a15:  > 225  : class(+)   num_elements(106)  predict_prob(0.981132075471698)                 
-                 a8:  <= 1  : class(+)   num_elements(25)  predict_prob(0.92)                             
-                     a6:  = aa  : class(+)   num_elements(1)  predict_prob(1)                             
-                     a6:  = c  : class(-)   num_elements(2)  predict_prob(0.5)                            
-                         a10:  = f  : class(-)   num_elements(1)  predict_prob(1)                         
-                         a10:  = t  : class(+)   num_elements(1)  predict_prob(1)                         
-                     a6:  = cc  : class(+)   num_elements(4)  predict_prob(1)                             
-                     a6:  = e  : class(+)   num_elements(1)  predict_prob(1)                              
-                     a6:  = j  : class(+)   num_elements(1)  predict_prob(1)                              
-                     a6:  = k  : class(+)   num_elements(1)  predict_prob(1)                              
-                     a6:  = m  : class(+)   num_elements(2)  predict_prob(1)                              
-                     a6:  = q  : class(+)   num_elements(5)  predict_prob(0.8)                            
-                         a3:  <= 1  : class(-)   num_elements(1)  predict_prob(1)                         
-                         a3:  > 1  : class(+)   num_elements(4)  predict_prob(1)                          
-                     a6:  = w  : class(+)   num_elements(4)  predict_prob(1)                              
-                     a6:  = x  : class(+)   num_elements(4)  predict_prob(1)                              
+    Root Node  : class(-)   num_elements(490)  predict_prob(0.557142857142857)
+         a9:  = f  : class(-)   num_elements(235)  predict_prob(0.940425531914894)
+             a5:  = g  : class(-)   num_elements(159)  predict_prob(0.949685534591195)
+                 a6:  = aa  : class(-)   num_elements(10)  predict_prob(1)
+                 a6:  = c  : class(-)   num_elements(29)  predict_prob(0.931034482758621)
+                     a7:  = h  : class(-)   num_elements(2)  predict_prob(0.5)
+                         a12:  = f  : class(-)   num_elements(1)  predict_prob(1)
+                         a12:  = t  : class(+)   num_elements(1)  predict_prob(1)
+                     a7:  = v  : class(-)   num_elements(27)  predict_prob(0.962962962962963)
+                         a3:  <= 0.665  : class(-)   num_elements(6)  predict_prob(0.833333333333333)
+                             a3:  <= 0.5  : class(-)   num_elements(5)  predict_prob(1)
+                             a3:  > 0.5  : class(+)   num_elements(1)  predict_prob(1)
+                         a3:  > 0.665  : class(-)   num_elements(21)  predict_prob(1)
+                 a6:  = cc  : class(-)   num_elements(4)  predict_prob(0.75)
+                     a1:  = a  : class(+)   num_elements(1)  predict_prob(1)
+                     a1:  = b  : class(-)   num_elements(3)  predict_prob(1)
+                 a6:  = d  : class(-)   num_elements(14)  predict_prob(1)
+                 a6:  = e  : class(-)   num_elements(5)  predict_prob(1)
+                 a6:  = ff  : class(-)   num_elements(21)  predict_prob(1)
+                 a6:  = i  : class(-)   num_elements(23)  predict_prob(0.956521739130435)
+                     a8:  <= 3.085  : class(-)   num_elements(20)  predict_prob(1)
+                     a8:  > 3.085  : class(-)   num_elements(3)  predict_prob(0.666666666666667)
+                         a8:  <= 3.5  : class(+)   num_elements(1)  predict_prob(1)
+                         a8:  > 3.5  : class(-)   num_elements(2)  predict_prob(1)
+                 a6:  = j  : class(-)   num_elements(2)  predict_prob(1)
+                 a6:  = k  : class(-)   num_elements(15)  predict_prob(0.933333333333333)
+                     a15:  <= 2010  : class(-)   num_elements(14)  predict_prob(1)
+                     a15:  > 2010  : class(+)   num_elements(1)  predict_prob(1)
+                 a6:  = m  : class(-)   num_elements(7)  predict_prob(1)
+                 a6:  = q  : class(-)   num_elements(11)  predict_prob(0.909090909090909)
+                     a7:  = h  : class(-)   num_elements(2)  predict_prob(1)
+                     a7:  = n  : class(+)   num_elements(1)  predict_prob(1)
+                     a7:  = v  : class(-)   num_elements(8)  predict_prob(1)
+                 a6:  = w  : class(-)   num_elements(17)  predict_prob(0.941176470588235)
+                     a8:  <= 1.165  : class(-)   num_elements(14)  predict_prob(1)
+                     a8:  > 1.165  : class(-)   num_elements(3)  predict_prob(0.666666666666667)
+                         a15:  <= 3  : class(-)   num_elements(2)  predict_prob(1)
+                         a15:  > 3  : class(+)   num_elements(1)  predict_prob(1)
+                 a6:  = x  : class(+)   num_elements(1)  predict_prob(1)
+             a5:  = gg  : class(+)   num_elements(2)  predict_prob(1)
+             a5:  = p  : class(-)   num_elements(73)  predict_prob(0.945205479452055)
+                 a6:  = aa  : class(-)   num_elements(4)  predict_prob(1)
+                 a6:  = c  : class(-)   num_elements(19)  predict_prob(0.947368421052632)
+                     a3:  <= 0.125  : class(-)   num_elements(2)  predict_prob(0.5)
+                         a12:  = f  : class(-)   num_elements(1)  predict_prob(1)
+                         a12:  = t  : class(+)   num_elements(1)  predict_prob(1)
+                     a3:  > 0.125  : class(-)   num_elements(17)  predict_prob(1)
+                 a6:  = cc  : class(-)   num_elements(2)  predict_prob(1)
+                 a6:  = d  : class(+)   num_elements(1)  predict_prob(1)
+                 a6:  = e  : class(-)   num_elements(2)  predict_prob(1)
+                 a6:  = ff  : class(-)   num_elements(11)  predict_prob(1)
+                 a6:  = i  : class(-)   num_elements(8)  predict_prob(1)
+                 a6:  = j  : class(-)   num_elements(4)  predict_prob(1)
+                 a6:  = k  : class(-)   num_elements(8)  predict_prob(1)
+                 a6:  = m  : class(-)   num_elements(5)  predict_prob(0.8)
+                     a7:  = bb  : class(+)   num_elements(1)  predict_prob(1)
+                     a7:  = v  : class(-)   num_elements(4)  predict_prob(1)
+                 a6:  = q  : class(-)   num_elements(1)  predict_prob(1)
+                 a6:  = r  : class(-)   num_elements(1)  predict_prob(1)
+                 a6:  = w  : class(-)   num_elements(3)  predict_prob(1)
+                 a6:  = x  : class(-)   num_elements(4)  predict_prob(0.75)
+                     a15:  <= 0  : class(+)   num_elements(1)  predict_prob(1)
+                     a15:  > 0  : class(-)   num_elements(3)  predict_prob(1)
+         a9:  = t  : class(+)   num_elements(251)  predict_prob(0.800796812749004)
+             a15:  <= 225  : class(+)   num_elements(145)  predict_prob(0.668965517241379)
+                 a6:  = aa  : class(+)   num_elements(17)  predict_prob(0.529411764705882)
+                     a3:  <= 6.5  : class(-)   num_elements(9)  predict_prob(0.777777777777778)
+                         a13:  = g  : class(-)   num_elements(8)  predict_prob(0.875)
+                             a1:  = a  : class(-)   num_elements(2)  predict_prob(0.5)
+                                 a14:  <= 160  : class(-)   num_elements(1)  predict_prob(1)
+                                 a14:  > 160  : class(+)   num_elements(1)  predict_prob(1)
+                             a1:  = b  : class(-)   num_elements(6)  predict_prob(1)
+                         a13:  = s  : class(+)   num_elements(1)  predict_prob(1)
+                     a3:  > 6.5  : class(+)   num_elements(8)  predict_prob(0.875)
+                         a5:  = g  : class(+)   num_elements(7)  predict_prob(1)
+                         a5:  = p  : class(-)   num_elements(1)  predict_prob(1)
+                 a6:  = c  : class(+)   num_elements(23)  predict_prob(0.521739130434783)
+                     a14:  <= 100  : class(+)   num_elements(9)  predict_prob(0.777777777777778)
+                         a15:  <= 221  : class(+)   num_elements(8)  predict_prob(0.875)
+                             a3:  <= 10.5  : class(+)   num_elements(6)  predict_prob(1)
+                             a3:  > 10.5  : class(-)   num_elements(2)  predict_prob(0.5)
+                                 a10:  = f  : class(-)   num_elements(1)  predict_prob(1)
+                                 a10:  = t  : class(+)   num_elements(1)  predict_prob(1)
+                         a15:  > 221  : class(-)   num_elements(1)  predict_prob(1)
+                     a14:  > 100  : class(-)   num_elements(13)  predict_prob(0.615384615384615)
+                         a2:  <= 29.92  : class(+)   num_elements(8)  predict_prob(0.625)
+                             a2:  <= 21.5  : class(-)   num_elements(4)  predict_prob(1)
+                             a2:  > 21.5  : class(+)   num_elements(5)  predict_prob(1)
+                         a2:  > 29.92  : class(-)   num_elements(5)  predict_prob(1)
+                 a6:  = cc  : class(+)   num_elements(13)  predict_prob(0.923076923076923)
+                     a14:  <= 440  : class(+)   num_elements(12)  predict_prob(1)
+                     a14:  > 440  : class(-)   num_elements(1)  predict_prob(1)
+                 a6:  = d  : class(+)   num_elements(5)  predict_prob(0.6)
+                     a14:  <= 100  : class(+)   num_elements(4)  predict_prob(0.75)
+                         a7:  = bb  : class(-)   num_elements(2)  predict_prob(0.5)
+                             a10:  = f  : class(-)   num_elements(1)  predict_prob(1)
+                             a10:  = t  : class(+)   num_elements(1)  predict_prob(1)
+                         a7:  = h  : class(+)   num_elements(1)  predict_prob(1)
+                         a7:  = v  : class(+)   num_elements(1)  predict_prob(1)
+                     a14:  > 100  : class(-)   num_elements(2)  predict_prob(1)
+                 a6:  = e  : class(+)   num_elements(7)  predict_prob(0.714285714285714)
+                     a7:  = bb  : class(-)   num_elements(1)  predict_prob(1)
+                     a7:  = h  : class(+)   num_elements(2)  predict_prob(1)
+                     a7:  = v  : class(+)   num_elements(1)  predict_prob(1)
+                     a7:  = z  : class(+)   num_elements(3)  predict_prob(0.666666666666667)
+                         a12:  = f  : class(-)   num_elements(1)  predict_prob(1)
+                         a12:  = t  : class(+)   num_elements(2)  predict_prob(1)
+                 a6:  = ff  : class(-)   num_elements(3)  predict_prob(1)
+                 a6:  = i  : class(+)   num_elements(8)  predict_prob(0.75)
+                     a3:  <= 2.335  : class(+)   num_elements(4)  predict_prob(1)
+                     a3:  > 2.335  : class(-)   num_elements(4)  predict_prob(0.5)
+                         a11:  <= 2  : class(-)   num_elements(2)  predict_prob(1)
+                         a11:  > 2  : class(+)   num_elements(2)  predict_prob(1)
+                 a6:  = j  : class(-)   num_elements(2)  predict_prob(0.5)
+                     a10:  = f  : class(-)   num_elements(1)  predict_prob(1)
+                     a10:  = t  : class(+)   num_elements(1)  predict_prob(1)
+                 a6:  = k  : class(+)   num_elements(9)  predict_prob(0.555555555555556)
+                     a3:  <= 1.165  : class(-)   num_elements(3)  predict_prob(1)
+                     a3:  > 1.165  : class(+)   num_elements(6)  predict_prob(0.833333333333333)
+                         a15:  <= 0  : class(+)   num_elements(5)  predict_prob(1)
+                         a15:  > 0  : class(-)   num_elements(1)  predict_prob(1)
+                 a6:  = m  : class(+)   num_elements(11)  predict_prob(0.545454545454545)
+                     a13:  = g  : class(+)   num_elements(6)  predict_prob(1)
+                     a13:  = s  : class(-)   num_elements(5)  predict_prob(1)
+                 a6:  = q  : class(+)   num_elements(24)  predict_prob(0.791666666666667)
+                     a5:  = g  : class(+)   num_elements(23)  predict_prob(0.826086956521739)
+                         a8:  <= 8.5  : class(+)   num_elements(22)  predict_prob(0.863636363636364)
+                             a2:  <= 18.67  : class(-)   num_elements(1)  predict_prob(1)
+                             a2:  > 18.67  : class(+)   num_elements(21)  predict_prob(0.904761904761905)
+                                 a14:  <= 145  : class(+)   num_elements(13)  predict_prob(1)
+                                 a14:  > 145  : class(+)   num_elements(8)  predict_prob(0.75)
+                                     a14:  <= 200  : class(-)   num_elements(2)  predict_prob(1)
+                                     a14:  > 200  : class(+)   num_elements(6)  predict_prob(1)
+                         a8:  > 8.5  : class(-)   num_elements(1)  predict_prob(1)
+                     a5:  = p  : class(-)   num_elements(1)  predict_prob(1)
+                 a6:  = w  : class(+)   num_elements(13)  predict_prob(0.846153846153846)
+                     a14:  <= 240  : class(+)   num_elements(9)  predict_prob(1)
+                     a14:  > 240  : class(-)   num_elements(4)  predict_prob(0.5)
+                         a13:  = g  : class(-)   num_elements(3)  predict_prob(0.666666666666667)
+                             a15:  <= 0  : class(-)   num_elements(2)  predict_prob(1)
+                             a15:  > 0  : class(+)   num_elements(1)  predict_prob(1)
+                         a13:  = s  : class(+)   num_elements(1)  predict_prob(1)
+                 a6:  = x  : class(+)   num_elements(9)  predict_prob(0.888888888888889)
+                     a10:  = f  : class(-)   num_elements(1)  predict_prob(1)
+                     a10:  = t  : class(+)   num_elements(8)  predict_prob(1)
+             a15:  > 225  : class(+)   num_elements(106)  predict_prob(0.981132075471698)
+                 a8:  <= 1  : class(+)   num_elements(25)  predict_prob(0.92)
+                     a6:  = aa  : class(+)   num_elements(1)  predict_prob(1)
+                     a6:  = c  : class(-)   num_elements(2)  predict_prob(0.5)
+                         a10:  = f  : class(-)   num_elements(1)  predict_prob(1)
+                         a10:  = t  : class(+)   num_elements(1)  predict_prob(1)
+                     a6:  = cc  : class(+)   num_elements(4)  predict_prob(1)
+                     a6:  = e  : class(+)   num_elements(1)  predict_prob(1)
+                     a6:  = j  : class(+)   num_elements(1)  predict_prob(1)
+                     a6:  = k  : class(+)   num_elements(1)  predict_prob(1)
+                     a6:  = m  : class(+)   num_elements(2)  predict_prob(1)
+                     a6:  = q  : class(+)   num_elements(5)  predict_prob(0.8)
+                         a3:  <= 1  : class(-)   num_elements(1)  predict_prob(1)
+                         a3:  > 1  : class(+)   num_elements(4)  predict_prob(1)
+                     a6:  = w  : class(+)   num_elements(4)  predict_prob(1)
+                     a6:  = x  : class(+)   num_elements(4)  predict_prob(1)
                  a8:  > 1  : class(+)   num_elements(81)  predict_prob(1)');
 
-SELECT MADLIB_SCHEMA.rf_test('MADLIB_SCHEMA.crx_dt_test','gainratio','A2,A3,A8,A11,A14,A15',
-    'a16','MADLIB_SCHEMA.crx_dt_test',10,'explicit',5);
-SELECT MADLIB_SCHEMA.c45_test('MADLIB_SCHEMA.crx_dt_test','gainratio','A2,A3,A8,A11,A14,A15',
-    'a16','MADLIB_SCHEMA.crx_dt_test','MADLIB_SCHEMA.crx_dt_test',10,'explicit',
+SELECT rf_test('crx_dt_test','gainratio','A2,A3,A8,A11,A14,A15',
+    'a16','crx_dt_test',10,'explicit',5);
+SELECT c45_test('crx_dt_test','gainratio','A2,A3,A8,A11,A14,A15',
+    'a16','crx_dt_test','crx_dt_test',10,'explicit',
     'Tree 1
-    Root Node  : class(-)   num_elements(490)  predict_prob(0.557142857142857)                                            
-         a9:  = f  : class(-)   num_elements(239)  predict_prob(0.933054393305439)                                         
-             a15:  <= 5552  : class(-)   num_elements(238)  predict_prob(0.936974789915966)                                
-                 a2:  <= 69.5  : class(-)   num_elements(236)  predict_prob(0.940677966101695)                             
-                     a8:  <= 7  : class(-)   num_elements(233)  predict_prob(0.944206008583691)                            
-                         a14:  <= 480  : class(-)   num_elements(224)  predict_prob(0.950892857142857)                     
-                             a2:  <= 36.67  : class(-)   num_elements(186)  predict_prob(0.967741935483871)                
-                                 a8:  <= 0.125  : class(-)   num_elements(70)  predict_prob(1)                             
-                                 a8:  > 0.125  : class(-)   num_elements(116)  predict_prob(0.948275862068966)             
-                                     a3:  <= 0.83  : class(-)   num_elements(29)  predict_prob(0.862068965517241)          
-                                         a3:  <= 0.75  : class(-)   num_elements(28)  predict_prob(0.892857142857143)      
-                                             a2:  <= 33.58  : class(-)   num_elements(27)  predict_prob(0.925925925925926) 
-                                             a2:  > 33.58  : class(+)   num_elements(1)  predict_prob(1)                   
-                                         a3:  > 0.75  : class(+)   num_elements(1)  predict_prob(1)                        
-                                     a3:  > 0.83  : class(-)   num_elements(87)  predict_prob(0.977011494252874)           
-                             a2:  > 36.67  : class(-)   num_elements(38)  predict_prob(0.868421052631579)                  
-                                 a15:  <= 500  : class(-)   num_elements(37)  predict_prob(0.891891891891892)              
-                                     a2:  <= 37.58  : class(+)   num_elements(5)  predict_prob(0.6)                        
-                                         a5:  = g  : class(-)   num_elements(2)  predict_prob(1)                           
-                                         a5:  = p  : class(+)   num_elements(2)  predict_prob(1)                           
-                                         a5:  = null  : class(+)   num_elements(1)  predict_prob(1)                        
-                                     a2:  > 37.58  : class(-)   num_elements(32)  predict_prob(0.96875)                    
-                                         a8:  <= 3.085  : class(-)   num_elements(27)  predict_prob(1)                     
-                                         a8:  > 3.085  : class(-)   num_elements(5)  predict_prob(0.8)                     
-                                             a15:  <= 0  : class(+)   num_elements(1)  predict_prob(1)                     
-                                             a15:  > 0  : class(-)   num_elements(4)  predict_prob(1)                      
-                                 a15:  > 500  : class(+)   num_elements(1)  predict_prob(1)                                
-                         a14:  > 480  : class(-)   num_elements(9)  predict_prob(0.777777777777778)                        
-                             a14:  <= 500  : class(+)   num_elements(1)  predict_prob(1)                                   
-                             a14:  > 500  : class(-)   num_elements(8)  predict_prob(0.875)                                
-                                 a8:  <= 1.75  : class(-)   num_elements(7)  predict_prob(1)                               
-                                 a8:  > 1.75  : class(+)   num_elements(1)  predict_prob(1)                                
-                     a8:  > 7  : class(-)   num_elements(3)  predict_prob(0.666666666666667)                               
-                         a1:  = a  : class(+)   num_elements(1)  predict_prob(1)                                           
-                         a1:  = b  : class(-)   num_elements(2)  predict_prob(1)                                           
-                 a2:  > 69.5  : class(-)   num_elements(2)  predict_prob(0.5)                                              
-                     a13:  = g  : class(-)   num_elements(1)  predict_prob(1)                                              
-                     a13:  = p  : class(+)   num_elements(1)  predict_prob(1)                                              
-             a15:  > 5552  : class(+)   num_elements(1)  predict_prob(1)                                                   
-         a9:  = t  : class(+)   num_elements(251)  predict_prob(0.800796812749004)                                         
-             a2:  <= 14.17  : class(-)   num_elements(4)  predict_prob(1)                                                  
-             a2:  > 14.17  : class(+)   num_elements(247)  predict_prob(0.813765182186235)                                 
-                 a14:  <= 583  : class(+)   num_elements(246)  predict_prob(0.817073170731707)                             
-                     a15:  <= 500  : class(+)   num_elements(166)  predict_prob(0.728915662650602)                         
-                         a14:  <= -1  : class(-)   num_elements(1)  predict_prob(1)                                        
-                         a14:  > -1  : class(+)   num_elements(165)  predict_prob(0.733333333333333)                       
-                             a14:  <= 100  : class(+)   num_elements(72)  predict_prob(0.902777777777778)                  
-                                 a3:  <= 18.5  : class(+)   num_elements(69)  predict_prob(0.927536231884058)              
-                                     a3:  <= 16  : class(+)   num_elements(67)  predict_prob(0.940298507462687)            
-                                         a3:  <= 5  : class(+)   num_elements(30)  predict_prob(0.866666666666667)         
-                                             a2:  <= 44  : class(+)   num_elements(29)  predict_prob(0.896551724137931)    
-                                             a2:  > 44  : class(-)   num_elements(1)  predict_prob(1)                      
-                                         a3:  > 5  : class(+)   num_elements(37)  predict_prob(1)                          
-                                     a3:  > 16  : class(-)   num_elements(2)  predict_prob(0.5)                            
-                                         a12:  = f  : class(-)   num_elements(1)  predict_prob(1)                          
-                                         a12:  = t  : class(+)   num_elements(1)  predict_prob(1)                          
-                                 a3:  > 18.5  : class(-)   num_elements(3)  predict_prob(0.666666666666667)                
-                                     a7:  = ff  : class(-)   num_elements(2)  predict_prob(1)                              
-                                     a7:  = v  : class(+)   num_elements(1)  predict_prob(1)                               
-                             a14:  > 100  : class(+)   num_elements(93)  predict_prob(0.602150537634409)                   
-                                 a8:  <= 10  : class(+)   num_elements(91)  predict_prob(0.615384615384615)                
-                                     a2:  <= 59.67  : class(+)   num_elements(89)  predict_prob(0.629213483146067)         
-                                         a2:  <= 16.25  : class(-)   num_elements(1)  predict_prob(1)                      
-                                         a2:  > 16.25  : class(+)   num_elements(88)  predict_prob(0.636363636363636)      
-                                             a2:  <= 23  : class(-)   num_elements(12)  predict_prob(0.75)                 
-                                             a2:  > 23  : class(+)   num_elements(76)  predict_prob(0.697368421052632)     
-                                     a2:  > 59.67  : class(-)   num_elements(2)  predict_prob(1)                           
-                                 a8:  > 10  : class(-)   num_elements(2)  predict_prob(1)                                  
-                     a15:  > 500  : class(+)   num_elements(80)  predict_prob(1)                                           
-                 a14:  > 583  : class(-)   num_elements(1)  predict_prob(1)');  
+    Root Node  : class(-)   num_elements(490)  predict_prob(0.557142857142857)
+         a9:  = f  : class(-)   num_elements(239)  predict_prob(0.933054393305439)
+             a15:  <= 5552  : class(-)   num_elements(238)  predict_prob(0.936974789915966)
+                 a2:  <= 69.5  : class(-)   num_elements(236)  predict_prob(0.940677966101695)
+                     a8:  <= 7  : class(-)   num_elements(233)  predict_prob(0.944206008583691)
+                         a14:  <= 480  : class(-)   num_elements(224)  predict_prob(0.950892857142857)
+                             a2:  <= 36.67  : class(-)   num_elements(186)  predict_prob(0.967741935483871)
+                                 a8:  <= 0.125  : class(-)   num_elements(70)  predict_prob(1)
+                                 a8:  > 0.125  : class(-)   num_elements(116)  predict_prob(0.948275862068966)
+                                     a3:  <= 0.83  : class(-)   num_elements(29)  predict_prob(0.862068965517241)
+                                         a3:  <= 0.75  : class(-)   num_elements(28)  predict_prob(0.892857142857143)
+                                             a2:  <= 33.58  : class(-)   num_elements(27)  predict_prob(0.925925925925926)
+                                             a2:  > 33.58  : class(+)   num_elements(1)  predict_prob(1)
+                                         a3:  > 0.75  : class(+)   num_elements(1)  predict_prob(1)
+                                     a3:  > 0.83  : class(-)   num_elements(87)  predict_prob(0.977011494252874)
+                             a2:  > 36.67  : class(-)   num_elements(38)  predict_prob(0.868421052631579)
+                                 a15:  <= 500  : class(-)   num_elements(37)  predict_prob(0.891891891891892)
+                                     a2:  <= 37.58  : class(+)   num_elements(5)  predict_prob(0.6)
+                                         a5:  = g  : class(-)   num_elements(2)  predict_prob(1)
+                                         a5:  = p  : class(+)   num_elements(2)  predict_prob(1)
+                                         a5:  = null  : class(+)   num_elements(1)  predict_prob(1)
+                                     a2:  > 37.58  : class(-)   num_elements(32)  predict_prob(0.96875)
+                                         a8:  <= 3.085  : class(-)   num_elements(27)  predict_prob(1)
+                                         a8:  > 3.085  : class(-)   num_elements(5)  predict_prob(0.8)
+                                             a15:  <= 0  : class(+)   num_elements(1)  predict_prob(1)
+                                             a15:  > 0  : class(-)   num_elements(4)  predict_prob(1)
+                                 a15:  > 500  : class(+)   num_elements(1)  predict_prob(1)
+                         a14:  > 480  : class(-)   num_elements(9)  predict_prob(0.777777777777778)
+                             a14:  <= 500  : class(+)   num_elements(1)  predict_prob(1)
+                             a14:  > 500  : class(-)   num_elements(8)  predict_prob(0.875)
+                                 a8:  <= 1.75  : class(-)   num_elements(7)  predict_prob(1)
+                                 a8:  > 1.75  : class(+)   num_elements(1)  predict_prob(1)
+                     a8:  > 7  : class(-)   num_elements(3)  predict_prob(0.666666666666667)
+                         a1:  = a  : class(+)   num_elements(1)  predict_prob(1)
+                         a1:  = b  : class(-)   num_elements(2)  predict_prob(1)
+                 a2:  > 69.5  : class(-)   num_elements(2)  predict_prob(0.5)
+                     a13:  = g  : class(-)   num_elements(1)  predict_prob(1)
+                     a13:  = p  : class(+)   num_elements(1)  predict_prob(1)
+             a15:  > 5552  : class(+)   num_elements(1)  predict_prob(1)
+         a9:  = t  : class(+)   num_elements(251)  predict_prob(0.800796812749004)
+             a2:  <= 14.17  : class(-)   num_elements(4)  predict_prob(1)
+             a2:  > 14.17  : class(+)   num_elements(247)  predict_prob(0.813765182186235)
+                 a14:  <= 583  : class(+)   num_elements(246)  predict_prob(0.817073170731707)
+                     a15:  <= 500  : class(+)   num_elements(166)  predict_prob(0.728915662650602)
+                         a14:  <= -1  : class(-)   num_elements(1)  predict_prob(1)
+                         a14:  > -1  : class(+)   num_elements(165)  predict_prob(0.733333333333333)
+                             a14:  <= 100  : class(+)   num_elements(72)  predict_prob(0.902777777777778)
+                                 a3:  <= 18.5  : class(+)   num_elements(69)  predict_prob(0.927536231884058)
+                                     a3:  <= 16  : class(+)   num_elements(67)  predict_prob(0.940298507462687)
+                                         a3:  <= 5  : class(+)   num_elements(30)  predict_prob(0.866666666666667)
+                                             a2:  <= 44  : class(+)   num_elements(29)  predict_prob(0.896551724137931)
+                                             a2:  > 44  : class(-)   num_elements(1)  predict_prob(1)
+                                         a3:  > 5  : class(+)   num_elements(37)  predict_prob(1)
+                                     a3:  > 16  : class(-)   num_elements(2)  predict_prob(0.5)
+                                         a12:  = f  : class(-)   num_elements(1)  predict_prob(1)
+                                         a12:  = t  : class(+)   num_elements(1)  predict_prob(1)
+                                 a3:  > 18.5  : class(-)   num_elements(3)  predict_prob(0.666666666666667)
+                                     a7:  = ff  : class(-)   num_elements(2)  predict_prob(1)
+                                     a7:  = v  : class(+)   num_elements(1)  predict_prob(1)
+                             a14:  > 100  : class(+)   num_elements(93)  predict_prob(0.602150537634409)
+                                 a8:  <= 10  : class(+)   num_elements(91)  predict_prob(0.615384615384615)
+                                     a2:  <= 59.67  : class(+)   num_elements(89)  predict_prob(0.629213483146067)
+                                         a2:  <= 16.25  : class(-)   num_elements(1)  predict_prob(1)
+                                         a2:  > 16.25  : class(+)   num_elements(88)  predict_prob(0.636363636363636)
+                                             a2:  <= 23  : class(-)   num_elements(12)  predict_prob(0.75)
+                                             a2:  > 23  : class(+)   num_elements(76)  predict_prob(0.697368421052632)
+                                     a2:  > 59.67  : class(-)   num_elements(2)  predict_prob(1)
+                                 a8:  > 10  : class(-)   num_elements(2)  predict_prob(1)
+                     a15:  > 500  : class(+)   num_elements(80)  predict_prob(1)
+                 a14:  > 583  : class(-)   num_elements(1)  predict_prob(1)');
 
-SELECT MADLIB_SCHEMA.rf_test('MADLIB_SCHEMA.crx_dt_test','infogain','A2,A3,A8,A11,A14,A15',
-    'a16','MADLIB_SCHEMA.crx_dt_test',10,'explicit',5);
-SELECT MADLIB_SCHEMA.c45_test('MADLIB_SCHEMA.crx_dt_test','infogain','A2,A3,A8,A11,A14,A15',
-    'a16','MADLIB_SCHEMA.crx_dt_test','MADLIB_SCHEMA.crx_dt_test',10,'explicit',
+SELECT rf_test('crx_dt_test','infogain','A2,A3,A8,A11,A14,A15',
+    'a16','crx_dt_test',10,'explicit',5);
+SELECT c45_test('crx_dt_test','infogain','A2,A3,A8,A11,A14,A15',
+    'a16','crx_dt_test','crx_dt_test',10,'explicit',
     'Tree 1
-    Root Node  : class(-)   num_elements(490)  predict_prob(0.557142857142857)                                  
-         a9:  = f  : class(-)   num_elements(239)  predict_prob(0.933054393305439)                               
-             a6:  = aa  : class(-)   num_elements(14)  predict_prob(1)                                           
-             a6:  = c  : class(-)   num_elements(48)  predict_prob(0.9375)                                       
-                 a3:  <= 0.83  : class(-)   num_elements(16)  predict_prob(0.8125)                               
-                     a2:  <= 21.92  : class(-)   num_elements(8)  predict_prob(1)                                
-                     a2:  > 21.92  : class(-)   num_elements(8)  predict_prob(0.625)                             
-                         a10:  = f  : class(-)   num_elements(6)  predict_prob(0.5)                              
-                             a14:  <= 128  : class(+)   num_elements(2)  predict_prob(1)                         
-                             a14:  > 128  : class(-)   num_elements(4)  predict_prob(0.75)                       
-                                 a3:  <= 0.125  : class(+)   num_elements(1)  predict_prob(1)                    
-                                 a3:  > 0.125  : class(-)   num_elements(3)  predict_prob(1)                     
-                         a10:  = t  : class(-)   num_elements(2)  predict_prob(1)                                
-                 a3:  > 0.83  : class(-)   num_elements(32)  predict_prob(1)                                     
-             a6:  = cc  : class(-)   num_elements(7)  predict_prob(0.714285714285714)                            
-                 a1:  = a  : class(+)   num_elements(2)  predict_prob(1)                                         
-                 a1:  = b  : class(-)   num_elements(5)  predict_prob(1)                                         
-             a6:  = d  : class(-)   num_elements(15)  predict_prob(0.933333333333333)                            
-                 a5:  = g  : class(-)   num_elements(14)  predict_prob(1)                                        
-                 a5:  = p  : class(+)   num_elements(1)  predict_prob(1)                                         
-             a6:  = e  : class(-)   num_elements(7)  predict_prob(1)                                             
-             a6:  = ff  : class(-)   num_elements(33)  predict_prob(0.96969696969697)                            
-                 a13:  = g  : class(-)   num_elements(30)  predict_prob(1)                                       
-                 a13:  = p  : class(+)   num_elements(1)  predict_prob(1)                                        
-                 a13:  = s  : class(-)   num_elements(2)  predict_prob(1)                                        
-             a6:  = i  : class(-)   num_elements(31)  predict_prob(0.967741935483871)                            
-                 a2:  <= 40.83  : class(-)   num_elements(27)  predict_prob(1)                                   
-                 a2:  > 40.83  : class(-)   num_elements(4)  predict_prob(0.75)                                  
-                     a14:  <= 141  : class(-)   num_elements(3)  predict_prob(1)                                 
-                     a14:  > 141  : class(+)   num_elements(1)  predict_prob(1)                                  
-             a6:  = j  : class(-)   num_elements(6)  predict_prob(1)                                             
-             a6:  = k  : class(-)   num_elements(23)  predict_prob(0.956521739130435)                            
-                 a15:  <= 2100  : class(-)   num_elements(22)  predict_prob(1)                                   
-                 a15:  > 2100  : class(+)   num_elements(1)  predict_prob(1)                                     
-             a6:  = m  : class(-)   num_elements(12)  predict_prob(0.916666666666667)                            
-                 a7:  = bb  : class(+)   num_elements(1)  predict_prob(1)                                        
-                 a7:  = v  : class(-)   num_elements(11)  predict_prob(1)                                        
-             a6:  = q  : class(-)   num_elements(12)  predict_prob(0.916666666666667)                            
-                 a7:  = h  : class(-)   num_elements(3)  predict_prob(1)                                         
-                 a7:  = n  : class(+)   num_elements(1)  predict_prob(1)                                         
-                 a7:  = v  : class(-)   num_elements(8)  predict_prob(1)                                         
-             a6:  = r  : class(-)   num_elements(1)  predict_prob(1)                                             
-             a6:  = w  : class(-)   num_elements(20)  predict_prob(0.95)                                         
-                 a2:  <= 21.25  : class(-)   num_elements(4)  predict_prob(0.75)                                 
-                     a10:  = f  : class(+)   num_elements(1)  predict_prob(1)                                    
-                     a10:  = t  : class(-)   num_elements(3)  predict_prob(1)                                    
-                 a2:  > 21.25  : class(-)   num_elements(16)  predict_prob(1)                                    
-             a6:  = x  : class(-)   num_elements(5)  predict_prob(0.6)                                           
-                 a15:  <= 0  : class(+)   num_elements(2)  predict_prob(1)                                       
-                 a15:  > 0  : class(-)   num_elements(3)  predict_prob(1)                                        
-             a6:  = null  : class(-)   num_elements(5)  predict_prob(0.6)                                        
-                 a2:  <= 34.58  : class(-)   num_elements(3)  predict_prob(1)                                    
-                 a2:  > 34.58  : class(+)   num_elements(2)  predict_prob(1)                                     
-         a9:  = t  : class(+)   num_elements(251)  predict_prob(0.800796812749004)                               
-             a15:  <= 225  : class(+)   num_elements(145)  predict_prob(0.668965517241379)                       
-                 a6:  = aa  : class(+)   num_elements(17)  predict_prob(0.529411764705882)                       
-                     a3:  <= 6.5  : class(-)   num_elements(9)  predict_prob(0.777777777777778)                  
-                         a14:  <= 200  : class(-)   num_elements(5)  predict_prob(1)                             
-                         a14:  > 200  : class(-)   num_elements(4)  predict_prob(0.5)                            
-                             a3:  <= 3.5  : class(+)   num_elements(2)  predict_prob(1)                          
-                             a3:  > 3.5  : class(-)   num_elements(2)  predict_prob(1)                           
-                     a3:  > 6.5  : class(+)   num_elements(8)  predict_prob(0.875)                               
-                         a5:  = g  : class(+)   num_elements(7)  predict_prob(1)                                 
-                         a5:  = p  : class(-)   num_elements(1)  predict_prob(1)                                 
-                 a6:  = c  : class(+)   num_elements(23)  predict_prob(0.521739130434783)                        
-                     a11:  <= 5  : class(-)   num_elements(20)  predict_prob(0.55)                               
-                         a2:  <= 29.92  : class(+)   num_elements(13)  predict_prob(0.615384615384615)           
-                             a8:  <= 1.5  : class(-)   num_elements(9)  predict_prob(0.555555555555556)          
-                                 a15:  <= 0  : class(+)   num_elements(6)  predict_prob(0.666666666666667)       
-                                     a2:  <= 21.5  : class(-)   num_elements(3)  predict_prob(0.666666666666667) 
-                                         a10:  = f  : class(-)   num_elements(2)  predict_prob(1)                
-                                         a10:  = t  : class(+)   num_elements(1)  predict_prob(1)                
-                                     a2:  > 21.5  : class(+)   num_elements(3)  predict_prob(1)                  
-                                 a15:  > 0  : class(-)   num_elements(3)  predict_prob(1)                        
-                             a8:  > 1.5  : class(+)   num_elements(4)  predict_prob(1)                           
-                         a2:  > 29.92  : class(-)   num_elements(7)  predict_prob(0.857142857142857)             
-                             a14:  <= 0  : class(+)   num_elements(1)  predict_prob(1)                           
-                             a14:  > 0  : class(-)   num_elements(6)  predict_prob(1)                            
-                     a11:  > 5  : class(+)   num_elements(3)  predict_prob(1)                                    
-                 a6:  = cc  : class(+)   num_elements(13)  predict_prob(0.923076923076923)                       
-                     a14:  <= 440  : class(+)   num_elements(12)  predict_prob(1)                                
-                     a14:  > 440  : class(-)   num_elements(1)  predict_prob(1)                                  
-                 a6:  = d  : class(-)   num_elements(6)  predict_prob(0.5)                                       
-                     a14:  <= 100  : class(+)   num_elements(4)  predict_prob(0.75)                              
-                         a14:  <= -1  : class(-)   num_elements(1)  predict_prob(1)                              
-                         a14:  > -1  : class(+)   num_elements(3)  predict_prob(1)                               
-                     a14:  > 100  : class(-)   num_elements(2)  predict_prob(1)                                  
-                 a6:  = e  : class(+)   num_elements(7)  predict_prob(0.714285714285714)                         
-                     a7:  = bb  : class(-)   num_elements(1)  predict_prob(1)                                    
-                     a7:  = h  : class(+)   num_elements(2)  predict_prob(1)                                     
-                     a7:  = v  : class(+)   num_elements(1)  predict_prob(1)                                     
-                     a7:  = z  : class(+)   num_elements(3)  predict_prob(0.666666666666667)                     
-                         a12:  = f  : class(-)   num_elements(1)  predict_prob(1)                                
-                         a12:  = t  : class(+)   num_elements(2)  predict_prob(1)                                
-                 a6:  = ff  : class(-)   num_elements(3)  predict_prob(1)                                        
-                 a6:  = i  : class(+)   num_elements(8)  predict_prob(0.75)                                      
-                     a3:  <= 2.335  : class(+)   num_elements(4)  predict_prob(1)                                
-                     a3:  > 2.335  : class(-)   num_elements(4)  predict_prob(0.5)                               
-                         a11:  <= 2  : class(-)   num_elements(2)  predict_prob(1)                               
-                         a11:  > 2  : class(+)   num_elements(2)  predict_prob(1)                                
-                 a6:  = j  : class(-)   num_elements(2)  predict_prob(0.5)                                       
-                     a10:  = f  : class(-)   num_elements(1)  predict_prob(1)                                    
-                     a10:  = t  : class(+)   num_elements(1)  predict_prob(1)                                    
-                 a6:  = k  : class(+)   num_elements(9)  predict_prob(0.555555555555556)                         
-                     a3:  <= 1.165  : class(-)   num_elements(3)  predict_prob(1)                                
-                     a3:  > 1.165  : class(+)   num_elements(6)  predict_prob(0.833333333333333)                 
-                         a15:  <= 0  : class(+)   num_elements(5)  predict_prob(1)                               
-                         a15:  > 0  : class(-)   num_elements(1)  predict_prob(1)                                
-                 a6:  = m  : class(+)   num_elements(11)  predict_prob(0.545454545454545)                        
-                     a13:  = g  : class(+)   num_elements(6)  predict_prob(1)                                    
-                     a13:  = s  : class(-)   num_elements(5)  predict_prob(1)                                    
-                 a6:  = q  : class(+)   num_elements(24)  predict_prob(0.791666666666667)                        
-                     a2:  <= 37.75  : class(+)   num_elements(16)  predict_prob(0.6875)                          
-                         a14:  <= 120  : class(+)   num_elements(9)  predict_prob(0.888888888888889)             
-                             a2:  <= 18.67  : class(-)   num_elements(1)  predict_prob(1)                        
-                             a2:  > 18.67  : class(+)   num_elements(8)  predict_prob(1)                         
-                         a14:  > 120  : class(-)   num_elements(7)  predict_prob(0.571428571428571)              
-                             a2:  <= 25.42  : class(-)   num_elements(3)  predict_prob(1)                        
-                             a2:  > 25.42  : class(+)   num_elements(4)  predict_prob(0.75)                      
-                                 a11:  <= 6  : class(+)   num_elements(3)  predict_prob(1)                       
-                                 a11:  > 6  : class(-)   num_elements(1)  predict_prob(1)                        
-                     a2:  > 37.75  : class(+)   num_elements(8)  predict_prob(1)                                 
-                 a6:  = w  : class(+)   num_elements(13)  predict_prob(0.846153846153846)                        
-                     a14:  <= 240  : class(+)   num_elements(9)  predict_prob(1)                                 
-                     a14:  > 240  : class(-)   num_elements(4)  predict_prob(0.5)                                
-                         a13:  = g  : class(-)   num_elements(3)  predict_prob(0.666666666666667)                
-                             a15:  <= 0  : class(-)   num_elements(2)  predict_prob(1)                           
-                             a15:  > 0  : class(+)   num_elements(1)  predict_prob(1)                            
-                         a13:  = s  : class(+)   num_elements(1)  predict_prob(1)                                
-                 a6:  = x  : class(+)   num_elements(9)  predict_prob(0.888888888888889)                         
-                     a10:  = f  : class(-)   num_elements(1)  predict_prob(1)                                    
-                     a10:  = t  : class(+)   num_elements(8)  predict_prob(1)                                    
-             a15:  > 225  : class(+)   num_elements(106)  predict_prob(0.981132075471698)                        
-                 a8:  <= 1  : class(+)   num_elements(25)  predict_prob(0.92)                                    
-                     a6:  = aa  : class(+)   num_elements(1)  predict_prob(1)                                    
-                     a6:  = c  : class(-)   num_elements(2)  predict_prob(0.5)                                   
-                         a10:  = f  : class(-)   num_elements(1)  predict_prob(1)                                
-                         a10:  = t  : class(+)   num_elements(1)  predict_prob(1)                                
-                     a6:  = cc  : class(+)   num_elements(4)  predict_prob(1)                                    
-                     a6:  = e  : class(+)   num_elements(1)  predict_prob(1)                                     
-                     a6:  = j  : class(+)   num_elements(1)  predict_prob(1)                                     
-                     a6:  = k  : class(+)   num_elements(1)  predict_prob(1)                                     
-                     a6:  = m  : class(+)   num_elements(2)  predict_prob(1)                                     
-                     a6:  = q  : class(+)   num_elements(5)  predict_prob(0.8)                                   
-                         a3:  <= 1  : class(-)   num_elements(1)  predict_prob(1)                                
-                         a3:  > 1  : class(+)   num_elements(4)  predict_prob(1)                                 
-                     a6:  = w  : class(+)   num_elements(4)  predict_prob(1)                                     
-                     a6:  = x  : class(+)   num_elements(4)  predict_prob(1)                                     
-                 a8:  > 1  : class(+)   num_elements(81)  predict_prob(1)');    
-DROP TABLE IF EXISTS MADLIB_SCHEMA.crx_dt_test;
+    Root Node  : class(-)   num_elements(490)  predict_prob(0.557142857142857)
+         a9:  = f  : class(-)   num_elements(239)  predict_prob(0.933054393305439)
+             a6:  = aa  : class(-)   num_elements(14)  predict_prob(1)
+             a6:  = c  : class(-)   num_elements(48)  predict_prob(0.9375)
+                 a3:  <= 0.83  : class(-)   num_elements(16)  predict_prob(0.8125)
+                     a2:  <= 21.92  : class(-)   num_elements(8)  predict_prob(1)
+                     a2:  > 21.92  : class(-)   num_elements(8)  predict_prob(0.625)
+                         a10:  = f  : class(-)   num_elements(6)  predict_prob(0.5)
+                             a14:  <= 128  : class(+)   num_elements(2)  predict_prob(1)
+                             a14:  > 128  : class(-)   num_elements(4)  predict_prob(0.75)
+                                 a3:  <= 0.125  : class(+)   num_elements(1)  predict_prob(1)
+                                 a3:  > 0.125  : class(-)   num_elements(3)  predict_prob(1)
+                         a10:  = t  : class(-)   num_elements(2)  predict_prob(1)
+                 a3:  > 0.83  : class(-)   num_elements(32)  predict_prob(1)
+             a6:  = cc  : class(-)   num_elements(7)  predict_prob(0.714285714285714)
+                 a1:  = a  : class(+)   num_elements(2)  predict_prob(1)
+                 a1:  = b  : class(-)   num_elements(5)  predict_prob(1)
+             a6:  = d  : class(-)   num_elements(15)  predict_prob(0.933333333333333)
+                 a5:  = g  : class(-)   num_elements(14)  predict_prob(1)
+                 a5:  = p  : class(+)   num_elements(1)  predict_prob(1)
+             a6:  = e  : class(-)   num_elements(7)  predict_prob(1)
+             a6:  = ff  : class(-)   num_elements(33)  predict_prob(0.96969696969697)
+                 a13:  = g  : class(-)   num_elements(30)  predict_prob(1)
+                 a13:  = p  : class(+)   num_elements(1)  predict_prob(1)
+                 a13:  = s  : class(-)   num_elements(2)  predict_prob(1)
+             a6:  = i  : class(-)   num_elements(31)  predict_prob(0.967741935483871)
+                 a2:  <= 40.83  : class(-)   num_elements(27)  predict_prob(1)
+                 a2:  > 40.83  : class(-)   num_elements(4)  predict_prob(0.75)
+                     a14:  <= 141  : class(-)   num_elements(3)  predict_prob(1)
+                     a14:  > 141  : class(+)   num_elements(1)  predict_prob(1)
+             a6:  = j  : class(-)   num_elements(6)  predict_prob(1)
+             a6:  = k  : class(-)   num_elements(23)  predict_prob(0.956521739130435)
+                 a15:  <= 2100  : class(-)   num_elements(22)  predict_prob(1)
+                 a15:  > 2100  : class(+)   num_elements(1)  predict_prob(1)
+             a6:  = m  : class(-)   num_elements(12)  predict_prob(0.916666666666667)
+                 a7:  = bb  : class(+)   num_elements(1)  predict_prob(1)
+                 a7:  = v  : class(-)   num_elements(11)  predict_prob(1)
+             a6:  = q  : class(-)   num_elements(12)  predict_prob(0.916666666666667)
+                 a7:  = h  : class(-)   num_elements(3)  predict_prob(1)
+                 a7:  = n  : class(+)   num_elements(1)  predict_prob(1)
+                 a7:  = v  : class(-)   num_elements(8)  predict_prob(1)
+             a6:  = r  : class(-)   num_elements(1)  predict_prob(1)
+             a6:  = w  : class(-)   num_elements(20)  predict_prob(0.95)
+                 a2:  <= 21.25  : class(-)   num_elements(4)  predict_prob(0.75)
+                     a10:  = f  : class(+)   num_elements(1)  predict_prob(1)
+                     a10:  = t  : class(-)   num_elements(3)  predict_prob(1)
+                 a2:  > 21.25  : class(-)   num_elements(16)  predict_prob(1)
+             a6:  = x  : class(-)   num_elements(5)  predict_prob(0.6)
+                 a15:  <= 0  : class(+)   num_elements(2)  predict_prob(1)
+                 a15:  > 0  : class(-)   num_elements(3)  predict_prob(1)
+             a6:  = null  : class(-)   num_elements(5)  predict_prob(0.6)
+                 a2:  <= 34.58  : class(-)   num_elements(3)  predict_prob(1)
+                 a2:  > 34.58  : class(+)   num_elements(2)  predict_prob(1)
+         a9:  = t  : class(+)   num_elements(251)  predict_prob(0.800796812749004)
+             a15:  <= 225  : class(+)   num_elements(145)  predict_prob(0.668965517241379)
+                 a6:  = aa  : class(+)   num_elements(17)  predict_prob(0.529411764705882)
+                     a3:  <= 6.5  : class(-)   num_elements(9)  predict_prob(0.777777777777778)
+                         a14:  <= 200  : class(-)   num_elements(5)  predict_prob(1)
+                         a14:  > 200  : class(-)   num_elements(4)  predict_prob(0.5)
+                             a3:  <= 3.5  : class(+)   num_elements(2)  predict_prob(1)
+                             a3:  > 3.5  : class(-)   num_elements(2)  predict_prob(1)
+                     a3:  > 6.5  : class(+)   num_elements(8)  predict_prob(0.875)
+                         a5:  = g  : class(+)   num_elements(7)  predict_prob(1)
+                         a5:  = p  : class(-)   num_elements(1)  predict_prob(1)
+                 a6:  = c  : class(+)   num_elements(23)  predict_prob(0.521739130434783)
+                     a11:  <= 5  : class(-)   num_elements(20)  predict_prob(0.55)
+                         a2:  <= 29.92  : class(+)   num_elements(13)  predict_prob(0.615384615384615)
+                             a8:  <= 1.5  : class(-)   num_elements(9)  predict_prob(0.555555555555556)
+                                 a15:  <= 0  : class(+)   num_elements(6)  predict_prob(0.666666666666667)
+                                     a2:  <= 21.5  : class(-)   num_elements(3)  predict_prob(0.666666666666667)
+                                         a10:  = f  : class(-)   num_elements(2)  predict_prob(1)
+                                         a10:  = t  : class(+)   num_elements(1)  predict_prob(1)
+                                     a2:  > 21.5  : class(+)   num_elements(3)  predict_prob(1)
+                                 a15:  > 0  : class(-)   num_elements(3)  predict_prob(1)
+                             a8:  > 1.5  : class(+)   num_elements(4)  predict_prob(1)
+                         a2:  > 29.92  : class(-)   num_elements(7)  predict_prob(0.857142857142857)
+                             a14:  <= 0  : class(+)   num_elements(1)  predict_prob(1)
+                             a14:  > 0  : class(-)   num_elements(6)  predict_prob(1)
+                     a11:  > 5  : class(+)   num_elements(3)  predict_prob(1)
+                 a6:  = cc  : class(+)   num_elements(13)  predict_prob(0.923076923076923)
+                     a14:  <= 440  : class(+)   num_elements(12)  predict_prob(1)
+                     a14:  > 440  : class(-)   num_elements(1)  predict_prob(1)
+                 a6:  = d  : class(-)   num_elements(6)  predict_prob(0.5)
+                     a14:  <= 100  : class(+)   num_elements(4)  predict_prob(0.75)
+                         a14:  <= -1  : class(-)   num_elements(1)  predict_prob(1)
+                         a14:  > -1  : class(+)   num_elements(3)  predict_prob(1)
+                     a14:  > 100  : class(-)   num_elements(2)  predict_prob(1)
+                 a6:  = e  : class(+)   num_elements(7)  predict_prob(0.714285714285714)
+                     a7:  = bb  : class(-)   num_elements(1)  predict_prob(1)
+                     a7:  = h  : class(+)   num_elements(2)  predict_prob(1)
+                     a7:  = v  : class(+)   num_elements(1)  predict_prob(1)
+                     a7:  = z  : class(+)   num_elements(3)  predict_prob(0.666666666666667)
+                         a12:  = f  : class(-)   num_elements(1)  predict_prob(1)
+                         a12:  = t  : class(+)   num_elements(2)  predict_prob(1)
+                 a6:  = ff  : class(-)   num_elements(3)  predict_prob(1)
+                 a6:  = i  : class(+)   num_elements(8)  predict_prob(0.75)
+                     a3:  <= 2.335  : class(+)   num_elements(4)  predict_prob(1)
+                     a3:  > 2.335  : class(-)   num_elements(4)  predict_prob(0.5)
+                         a11:  <= 2  : class(-)   num_elements(2)  predict_prob(1)
+                         a11:  > 2  : class(+)   num_elements(2)  predict_prob(1)
+                 a6:  = j  : class(-)   num_elements(2)  predict_prob(0.5)
+                     a10:  = f  : class(-)   num_elements(1)  predict_prob(1)
+                     a10:  = t  : class(+)   num_elements(1)  predict_prob(1)
+                 a6:  = k  : class(+)   num_elements(9)  predict_prob(0.555555555555556)
+                     a3:  <= 1.165  : class(-)   num_elements(3)  predict_prob(1)
+                     a3:  > 1.165  : class(+)   num_elements(6)  predict_prob(0.833333333333333)
+                         a15:  <= 0  : class(+)   num_elements(5)  predict_prob(1)
+                         a15:  > 0  : class(-)   num_elements(1)  predict_prob(1)
+                 a6:  = m  : class(+)   num_elements(11)  predict_prob(0.545454545454545)
+                     a13:  = g  : class(+)   num_elements(6)  predict_prob(1)
+                     a13:  = s  : class(-)   num_elements(5)  predict_prob(1)
+                 a6:  = q  : class(+)   num_elements(24)  predict_prob(0.791666666666667)
+                     a2:  <= 37.75  : class(+)   num_elements(16)  predict_prob(0.6875)
+                         a14:  <= 120  : class(+)   num_elements(9)  predict_prob(0.888888888888889)
+                             a2:  <= 18.67  : class(-)   num_elements(1)  predict_prob(1)
+                             a2:  > 18.67  : class(+)   num_elements(8)  predict_prob(1)
+                         a14:  > 120  : class(-)   num_elements(7)  predict_prob(0.571428571428571)
+                             a2:  <= 25.42  : class(-)   num_elements(3)  predict_prob(1)
+                             a2:  > 25.42  : class(+)   num_elements(4)  predict_prob(0.75)
+                                 a11:  <= 6  : class(+)   num_elements(3)  predict_prob(1)
+                                 a11:  > 6  : class(-)   num_elements(1)  predict_prob(1)
+                     a2:  > 37.75  : class(+)   num_elements(8)  predict_prob(1)
+                 a6:  = w  : class(+)   num_elements(13)  predict_prob(0.846153846153846)
+                     a14:  <= 240  : class(+)   num_elements(9)  predict_prob(1)
+                     a14:  > 240  : class(-)   num_elements(4)  predict_prob(0.5)
+                         a13:  = g  : class(-)   num_elements(3)  predict_prob(0.666666666666667)
+                             a15:  <= 0  : class(-)   num_elements(2)  predict_prob(1)
+                             a15:  > 0  : class(+)   num_elements(1)  predict_prob(1)
+                         a13:  = s  : class(+)   num_elements(1)  predict_prob(1)
+                 a6:  = x  : class(+)   num_elements(9)  predict_prob(0.888888888888889)
+                     a10:  = f  : class(-)   num_elements(1)  predict_prob(1)
+                     a10:  = t  : class(+)   num_elements(8)  predict_prob(1)
+             a15:  > 225  : class(+)   num_elements(106)  predict_prob(0.981132075471698)
+                 a8:  <= 1  : class(+)   num_elements(25)  predict_prob(0.92)
+                     a6:  = aa  : class(+)   num_elements(1)  predict_prob(1)
+                     a6:  = c  : class(-)   num_elements(2)  predict_prob(0.5)
+                         a10:  = f  : class(-)   num_elements(1)  predict_prob(1)
+                         a10:  = t  : class(+)   num_elements(1)  predict_prob(1)
+                     a6:  = cc  : class(+)   num_elements(4)  predict_prob(1)
+                     a6:  = e  : class(+)   num_elements(1)  predict_prob(1)
+                     a6:  = j  : class(+)   num_elements(1)  predict_prob(1)
+                     a6:  = k  : class(+)   num_elements(1)  predict_prob(1)
+                     a6:  = m  : class(+)   num_elements(2)  predict_prob(1)
+                     a6:  = q  : class(+)   num_elements(5)  predict_prob(0.8)
+                         a3:  <= 1  : class(-)   num_elements(1)  predict_prob(1)
+                         a3:  > 1  : class(+)   num_elements(4)  predict_prob(1)
+                     a6:  = w  : class(+)   num_elements(4)  predict_prob(1)
+                     a6:  = x  : class(+)   num_elements(4)  predict_prob(1)
+                 a8:  > 1  : class(+)   num_elements(81)  predict_prob(1)');


### PR DESCRIPTION
Jira: MADLIB-684

There is no need to use a temporary table for
test results since a temporary schema is created
before the test starts. Further, any DB object
should be created w/o schema prefix, since the
test is executed in the temporary schema context.
Drop statements should also be avoided since the
default schema will be cleaned outside.

Other changes:
- Removed all trailing whitespace characters. 
  Trailing whitespace should be removed since it 
  adds unnecessary diff lines in the commit.
