### PR TITLE
Madlib 689

### DIFF
--- a/methods/sketch/src/pg_gp/countmin.c
+++ b/methods/sketch/src/pg_gp/countmin.c
@@ -25,20 +25,19 @@
  * "the answer is within \epsilon of the true answer with probability 1-\delta."
  */
 
-#include "postgres.h"
-#include "postgresql/server/utils/fmgroids.h"
-#include "utils/array.h"
-#include "utils/elog.h"
-#include "utils/builtins.h"
-#include "utils/lsyscache.h"
-#include "utils/numeric.h"
-#include "nodes/execnodes.h"
-#include "fmgr.h"
-#include "sketch_support.h"
-#include "catalog/pg_type.h"
-#include "countmin.h"
-
+#include <postgres.h>
+#include <utils/fmgroids.h>
+#include <utils/array.h>
+#include <utils/elog.h>
+#include <utils/builtins.h>
+#include <utils/lsyscache.h>
+#include <utils/numeric.h>
+#include <nodes/execnodes.h>
+#include <fmgr.h>
+#include <catalog/pg_type.h>
 #include <ctype.h>
+#include "sketch_support.h"
+#include "countmin.h" 
 
 PG_FUNCTION_INFO_V1(__cmsketch_int8_trans);
 
@@ -120,13 +119,10 @@ bytea *cmsketch_check_transval(PG_FUNCTION_ARGS, bool initargs)
 
 bytea *cmsketch_init_transval()
 {
-    cmtransval *transval;
-
     /* allocate and zero out a transval via palloc0 */
     bytea *     transblob = (bytea *)palloc0(CM_TRANSVAL_SZ);
     SET_VARSIZE(transblob, CM_TRANSVAL_SZ);
 
-    transval = (cmtransval *)VARDATA(transblob);
     return(transblob);
 }
 

--- a/methods/sketch/src/pg_gp/countmin.h
+++ b/methods/sketch/src/pg_gp/countmin.h
@@ -130,8 +130,6 @@ typedef struct {
 /*! base size of an MFV transval */
 #define MFV_TRANSVAL_SZ(i) (VARHDRSZ + sizeof(mfvtransval) + i*sizeof(offsetcnt))
 
-#define MFV_DATA(mfv) ((char*)mfv + VARHDRSZ + sizeof(mfvtransval) + mfv->max_mfvs*sizeof(offsetcnt))
-
 /*! free space remaining for text values */
 #define MFV_TRANSVAL_CAPACITY(transblob) (VARSIZE(transblob) - VARHDRSZ - \
                                           ((mfvtransval *)VARDATA(transblob))-> \

--- a/methods/sketch/src/pg_gp/countmin.h
+++ b/methods/sketch/src/pg_gp/countmin.h
@@ -48,8 +48,6 @@ typedef uint64 countmin[DEPTH][NUMCOUNTERS];
 typedef struct {
     int64 args[MAXARGS];  /*! carry along additional args for finalizer */
     int   nargs;          /*! number of args being carried for finalizer */
-    Oid   typOid;         /*! oid of the data type we are sketching */
-    Oid   outFuncOid;     /*! oid of the OutFunc for that data type */
     countmin sketches[RANGES];
 } cmtransval;
 
@@ -142,7 +140,7 @@ typedef struct {
 /* countmin aggregate protos */
 Datum  countmin_trans_c(countmin, Datum, Oid, Oid);
 bytea *cmsketch_check_transval(PG_FUNCTION_ARGS, bool);
-bytea *cmsketch_init_transval(Oid);
+bytea *cmsketch_init_transval();
 void   countmin_dyadic_trans_c(cmtransval *, Datum);
 
 /* countmin scalar function protos */

--- a/methods/sketch/src/pg_gp/countmin.h
+++ b/methods/sketch/src/pg_gp/countmin.h
@@ -46,10 +46,10 @@ typedef uint64 countmin[DEPTH][NUMCOUNTERS];
  * \endinternal
  */
 typedef struct {
-    Datum args[MAXARGS];  /*! carry along additional args for finalizer */
-    int nargs;            /*! number of args being carried for finalizer */
-    Oid typOid;     /*! oid of the data type we are sketching */
-    Oid outFuncOid; /*! oid of the OutFunc for that data type */
+    int64 args[MAXARGS];  /*! carry along additional args for finalizer */
+    int   nargs;          /*! number of args being carried for finalizer */
+    Oid   typOid;         /*! oid of the data type we are sketching */
+    Oid   outFuncOid;     /*! oid of the OutFunc for that data type */
     countmin sketches[RANGES];
 } cmtransval;
 
@@ -131,6 +131,8 @@ typedef struct {
 
 /*! base size of an MFV transval */
 #define MFV_TRANSVAL_SZ(i) (VARHDRSZ + sizeof(mfvtransval) + i*sizeof(offsetcnt))
+
+#define MFV_DATA(mfv) ((char*)mfv + VARHDRSZ + sizeof(mfvtransval) + mfv->max_mfvs*sizeof(offsetcnt))
 
 /*! free space remaining for text values */
 #define MFV_TRANSVAL_CAPACITY(transblob) (VARSIZE(transblob) - VARHDRSZ - \

--- a/methods/sketch/src/pg_gp/fm.c
+++ b/methods/sketch/src/pg_gp/fm.c
@@ -25,17 +25,17 @@
 
 /* THIS CODE MAY NEED TO BE REVISITED TO ENSURE ALIGNMENT! */
 
-#include "postgres.h"
-#include "utils/array.h"
-#include "utils/elog.h"
-#include "utils/builtins.h"
-#include "utils/lsyscache.h"
-#include "libpq/md5.h"
-#include "nodes/execnodes.h"
-#include "fmgr.h"
+#include <postgres.h>
+#include <utils/array.h>
+#include <utils/elog.h>
+#include <utils/builtins.h>
+#include <utils/lsyscache.h>
+#include <libpq/md5.h>
+#include <nodes/execnodes.h>
+#include <fmgr.h>
+#include <ctype.h>
 #include "sketch_support.h"
 #include "sortasort.h"
-#include <ctype.h>
 
 #ifndef NO_PG_MODULE_MAGIC
 PG_MODULE_MAGIC;

--- a/methods/sketch/src/pg_gp/mfvsketch.c
+++ b/methods/sketch/src/pg_gp/mfvsketch.c
@@ -28,19 +28,19 @@
 
 
 
-#include "postgres.h"
-#include "utils/array.h"
-#include "utils/elog.h"
-#include "utils/builtins.h"
-#include "utils/lsyscache.h"
-#include "utils/numeric.h"
-#include "utils/typcache.h"
-#include "nodes/execnodes.h"
-#include "fmgr.h"
+#include <postgres.h>
+#include <utils/array.h>
+#include <utils/elog.h>
+#include <utils/builtins.h>
+#include <utils/lsyscache.h>
+#include <utils/numeric.h>
+#include <utils/typcache.h>
+#include <nodes/execnodes.h>
+#include <fmgr.h>
+#include <catalog/pg_type.h>
+#include <funcapi.h>
 #include "sketch_support.h"
-#include "catalog/pg_type.h"
 #include "countmin.h"
-#include "funcapi.h"
 
 #include <ctype.h>
 

--- a/methods/sketch/src/pg_gp/sketch_support.c
+++ b/methods/sketch/src/pg_gp/sketch_support.c
@@ -407,7 +407,7 @@ size_t ExtractDatumLen(Datum x, int len, bool byVal, size_t capacity)
     {
         size = len;
         if (capacity != (size_t)-1 && size > capacity) {
-            elog(ERROR, "internal used trans state has been damaged unexpectly");
+            elog(ERROR, "invalid transition state");
         }
     }
     else if (len == -1) 
@@ -422,7 +422,7 @@ size_t ExtractDatumLen(Datum x, int len, bool byVal, size_t capacity)
                 size = VARSIZE_ANY(data);
             } 
             else {
-                elog(ERROR, "internal used trans state has been damaged unexpectly");
+                elog(ERROR, "invalid transition state");
             }
         }
     }
@@ -437,7 +437,7 @@ size_t ExtractDatumLen(Datum x, int len, bool byVal, size_t capacity)
             for (idx = 0; idx < capacity && data[idx] != 0; idx ++, size ++) {
             }
             if (idx >= capacity) {
-                elog(ERROR, "internal used trans state has been damaged unexpectly");
+                elog(ERROR, "invalid transition state");
             }
             size ++;
         }

--- a/methods/sketch/src/pg_gp/sketch_support.c
+++ b/methods/sketch/src/pg_gp/sketch_support.c
@@ -33,15 +33,15 @@
 */
 /* THIS CODE MAY NEED TO BE REVISITED TO ENSURE ALIGNMENT! */
 
-#include "postgres.h"
-#include "utils/array.h"
-#include "utils/elog.h"
-#include "nodes/execnodes.h"
-#include "fmgr.h"
+#include <postgres.h>
+#include <utils/array.h>
+#include <utils/elog.h>
+#include <nodes/execnodes.h>
+#include <fmgr.h>
+#include <utils/builtins.h>
+#include <libpq/md5.h>
+#include <utils/lsyscache.h>
 #include "sketch_support.h"
-#include "utils/builtins.h"
-#include "libpq/md5.h"
-#include "utils/lsyscache.h"
 
 
 

--- a/methods/sketch/src/pg_gp/sketch_support.c
+++ b/methods/sketch/src/pg_gp/sketch_support.c
@@ -43,6 +43,8 @@
 #include "libpq/md5.h"
 #include "utils/lsyscache.h"
 
+
+
 /*!
  * Simple linear function to find the rightmost bit that's set to one
  * (i.e. the # of trailing zeros to the right).
@@ -295,7 +297,7 @@ bytea *sketch_md5_bytea(Datum dat, Oid typOid)
     char outbuf[MD5_HASHLEN*2+1];
     bytea *out = palloc0(MD5_HASHLEN+VARHDRSZ);    
     bool byval = get_typbyval(typOid);
-    int len = ExtractDatumLen(dat, get_typlen(typOid), byval);
+    int len = ExtractDatumLen(dat, get_typlen(typOid), byval, -1);
     void *datp = DatumExtractPointer(dat, byval);
     /* 
      * it's very common to be hashing 0 for countmin sketches.  Rather than 
@@ -345,7 +347,7 @@ Datum sketch_rightmost_one(PG_FUNCTION_ARGS)
     size_t sketchsz = PG_GETARG_INT32(1);          /* size in bits */
     size_t sketchnum = PG_GETARG_INT32(2);          /* from the left! */
     char * bits = VARDATA(bitmap);
-    size_t len = VARSIZE_ANY_EXHDR(bitmap);
+    size_t len = (size_t)VARSIZE_ANY_EXHDR(bitmap);
 
     return rightmost_one((uint8 *)bits, len, sketchsz, sketchnum);
 }
@@ -356,7 +358,7 @@ Datum sketch_leftmost_zero(PG_FUNCTION_ARGS)
     size_t sketchsz = PG_GETARG_INT32(1);          /* size in bits */
     size_t sketchnum = PG_GETARG_INT32(2);          /* from the left! */
     char * bits = VARDATA(bitmap);
-    size_t len = VARSIZE_ANY_EXHDR(bitmap);
+    size_t len = (size_t)VARSIZE_ANY_EXHDR(bitmap);
 
     return leftmost_zero((uint8 *)bits, len, sketchsz, sketchnum);
 }
@@ -390,19 +392,62 @@ int4 safe_log2(int64 x)
     return out;
 }
 
-size_t ExtractDatumLen(Datum x, int len, bool byVal)
+/* 
+ * We need process c string and var especially here, it is really ugly, 
+ * but we have to.  
+ * Because here the user can change the binary representations directly.
+ */
+size_t ExtractDatumLen(Datum x, int len, bool byVal, size_t capacity)
 {
     (void) byVal; /* avoid warning about unused parameter */
+    size_t size = 0;
+    size_t idx = 0;
+    char   *data = NULL;
     if (len > 0) 
-        return len;
+    {
+        size = len;
+        if (capacity != (size_t)-1 && size > capacity) {
+            elog(ERROR, "internal used trans state has been damaged unexpectly");
+        }
+    }
     else if (len == -1) 
-        return VARSIZE_ANY(DatumGetPointer(x));
+    {
+        if (capacity == (size_t)-1) {
+            size = VARSIZE_ANY(DatumGetPointer(x));
+        }
+        else {
+            data = (char*)DatumGetPointer(x);
+            if ((capacity >= VARHDRSZ) 
+                || (capacity >= 1 && VARATT_IS_1B(data))) {
+                size = VARSIZE_ANY(data);
+            } 
+            else {
+                elog(ERROR, "internal used trans state has been damaged unexpectly");
+            }
+        }
+    }
     else if (len == -2) 
-        return strlen((char *)DatumGetPointer(x));
+    {
+        if (capacity == (size_t)-1) {
+            return strlen((char *)DatumGetPointer(x)) + 1;
+        }
+        else {
+            data = (char*)DatumGetPointer(x);
+            size = 0;
+            for (idx = 0; idx < capacity && data[idx] != 0; idx ++, size ++) {
+            }
+            if (idx >= capacity) {
+                elog(ERROR, "internal used trans state has been damaged unexpectly");
+            }
+            size ++;
+        }
+    }
     else {
         elog(ERROR, "Datum typelength error in ExtractDatumLen: len is %u", (unsigned)len);
         return 0;
     }
+
+    return size;
 }
 
 /* 

--- a/methods/sketch/src/pg_gp/sketch_support.h
+++ b/methods/sketch/src/pg_gp/sketch_support.h
@@ -29,5 +29,5 @@ void   int64_big_endianize(uint64 *, uint32, bool);
 /*! macro to convert a Datum into a pointer suitable for memcpy */
 #define DatumExtractPointer(x, byVal)  (byVal ? (void *)&x : DatumGetPointer(x))
 
-size_t ExtractDatumLen(Datum x, int len, bool byVal);
+size_t ExtractDatumLen(Datum x, int len, bool byVal, size_t capacity);
 #endif /* SKETCH_SUPPORT_H */

--- a/methods/sketch/src/pg_gp/sortasort.c
+++ b/methods/sketch/src/pg_gp/sortasort.c
@@ -80,8 +80,8 @@ int sorta_cmp(const void *i, const void *j, void *thunk)
      * we always use typByVal = true, since we've marshalled the data into place
      */
     if (len < 0) {
-        len = (int)ExtractDatumLen(PointerGetDatum(dat1), len, s->typByVal);
-        if ((shorter = (len - ExtractDatumLen(PointerGetDatum(dat2), len, s->typByVal))))
+        len = (int)ExtractDatumLen(PointerGetDatum(dat1), len, s->typByVal, -1);
+        if ((shorter = (len - ExtractDatumLen(PointerGetDatum(dat2), len, s->typByVal, -1))))
             /* order by length */
             return shorter;
         /* else drop through */
@@ -110,7 +110,7 @@ int sortasort_try_insert(sortasort *s_in, Datum dat, int len)
         return TRUE;
     }
 
-    len = ExtractDatumLen(dat, len, s_in->typByVal);    
+    len = ExtractDatumLen(dat, len, s_in->typByVal, -1);    
     
     /* sanity check */
     if (found < -1 || found >= (int) s_in->num_vals)
@@ -170,7 +170,7 @@ int sortasort_find(sortasort *s, Datum dat)
     int    themin = 0, themax = hi - 1;
     size_t i;
     int    addend, subtrahend;
-    size_t len = ExtractDatumLen(dat, s->typLen, s->typByVal);
+    size_t len = ExtractDatumLen(dat, s->typLen, s->typByVal, -1);
 
     /* binary search on the front of the sortasort */
     if (themax >= (int)s->num_vals) {

--- a/methods/sketch/src/pg_gp/sortasort.c
+++ b/methods/sketch/src/pg_gp/sortasort.c
@@ -22,8 +22,8 @@
  * sorted.
  */
 //#include <ctype.h>
-#include "postgres.h"
-#include "fmgr.h"
+#include <postgres.h>
+#include <fmgr.h>
 #include "sortasort.h"
 #include "sketch_support.h"
 

--- a/methods/sketch/src/pg_gp/sortasort.h
+++ b/methods/sketch/src/pg_gp/sortasort.h
@@ -31,9 +31,12 @@ typedef struct {
     unsigned dir[];        /*! storage of the strings */
 } sortasort;
 
-#define SORTASORT_DATA(s)  (((char *)(s->dir)) + \
-    (s->capacity * (sizeof (s->dir[0]))))
-#define SORTASORT_GETVAL(s, i) (SORTASORT_DATA(s) + s->dir[i])
+
+
+/*
+ * get the ith item stored in sortasort
+ */
+char *sortasort_getval(sortasort *s, unsigned i); 
 
 int sortasort_try_insert(sortasort *, Datum, int);
 sortasort *sortasort_init(sortasort *, size_t, size_t, int, bool);


### PR DESCRIPTION
In order to fix the security issues of the sketch method described in MADLIB-630, at the entry point of each UDF,  we did strictly checking of the contents stored in a vararea to make sure that each access to elements in the vararea is safe.  This checking degenerates the performance. 

Because these step functions only access each item at most one time on each call, in order to avoid performance degeneration, we only do checking when access the specific element. The performance
degeneration decreases from 50% at most to 20%.
