### PR TITLE
Fix performance regression from v0.4 in sketch estimators

### DIFF
--- a/methods/sketch/src/pg_gp/countmin.h
+++ b/methods/sketch/src/pg_gp/countmin.h
@@ -130,8 +130,6 @@ typedef struct {
 /*! base size of an MFV transval */
 #define MFV_TRANSVAL_SZ(i) (VARHDRSZ + sizeof(mfvtransval) + i*sizeof(offsetcnt))
 
-#define MFV_DATA(mfv) ((char*)mfv + VARHDRSZ + sizeof(mfvtransval) + mfv->max_mfvs*sizeof(offsetcnt))
-
 /*! free space remaining for text values */
 #define MFV_TRANSVAL_CAPACITY(transblob) (VARSIZE(transblob) - VARHDRSZ - \
                                           ((mfvtransval *)VARDATA(transblob))-> \

--- a/methods/sketch/src/pg_gp/fm.c
+++ b/methods/sketch/src/pg_gp/fm.c
@@ -100,8 +100,6 @@ typedef struct {
 /* check whter the contents in  fmtransval::storage is safe for sortasort */
 void check_sortasort(sortasort *st, size_t st_size) {
     size_t left_len = st_size;
-    size_t cur_size = 0;
-    size_t cur_capacity = 0;
 
     if (left_len < sizeof(sortasort)) {
         elog(ERROR, "invalid transition state for fmsketch");
@@ -114,26 +112,6 @@ void check_sortasort(sortasort *st, size_t st_size) {
 
     if (left_len < st->capacity*sizeof(st->storage_cur) + st->storage_sz) {
         elog(ERROR, "invalid transition state for fmsketch");
-    }
-    left_len = st->storage_sz;
-
-    /*
-     * the following checking may be inefficiency, but by doing this centrally,
-     * we can avoid spreading the checking code everywhere.
-     */
-    for (unsigned i = 0; i < st->num_vals; i ++) {
-        cur_capacity = left_len - st->dir[i];
-
-        if (st->dir[i] >= left_len) {
-            elog(ERROR, "invalid transition state for fmsketch");
-        }
-
-        cur_size = ExtractDatumLen(PointerGetDatum(SORTASORT_DATA(st) + st->dir[i]),
-            st->typLen, st->typByVal, cur_capacity);
-
-        if (cur_size > cur_capacity) {
-            elog(ERROR, "invalid transition state for fmsketch");
-        }
     }
 }
 
@@ -301,7 +279,7 @@ Datum __fmsketch_trans(PG_FUNCTION_ARGS)
              */
             for (i = 0; i < MINVALS; i++)
                 __fmsketch_trans_c(newblob,
-                                   PointerExtractDatum(SORTASORT_GETVAL(s,i), s->typByVal));
+                                   PointerExtractDatum(sortasort_getval(s,i), s->typByVal));
 
             /*
              * XXXX would like to pfree the old transblob, but the memory allocator doesn't like it
@@ -525,7 +503,7 @@ Datum __fmsketch_merge(PG_FUNCTION_ARGS)
              * the bigger one.
              */
             for (i = 0; i < sortashort->num_vals; i++) {
-                Datum the_val = PointerExtractDatum(SORTASORT_GETVAL(sortashort,i),
+                Datum the_val = PointerExtractDatum(sortasort_getval(sortashort,i),
                                                     transval1->typByVal);
                 int the_len = ExtractDatumLen(the_val, transval1->typLen,
                                               transval1->typByVal, -1);
@@ -551,14 +529,14 @@ Datum __fmsketch_merge(PG_FUNCTION_ARGS)
     if (transval1->status == SMALL) {
         s1 = (sortasort *)(transval1->storage);
         for(i = 0; i < s1->num_vals; i++) {
-            __fmsketch_trans_c(tblob_big, PointerExtractDatum(SORTASORT_GETVAL(s1,i),
+            __fmsketch_trans_c(tblob_big, PointerExtractDatum(sortasort_getval(s1,i),
                                                               transval1->typByVal));
         }
     }
     if (transval2->status == SMALL) {
         s2 = (sortasort *)(transval2->storage);
         for(i = 0; i < s2->num_vals; i++) {
-            __fmsketch_trans_c(tblob_big, PointerExtractDatum(SORTASORT_GETVAL(s2,i),
+            __fmsketch_trans_c(tblob_big, PointerExtractDatum(sortasort_getval(s2,i),
                                                               transval1->typByVal));
         }
     }

--- a/methods/sketch/src/pg_gp/mfvsketch.c
+++ b/methods/sketch/src/pg_gp/mfvsketch.c
@@ -47,8 +47,6 @@
 /* check whether the content in the given bytea is safe for mfvtransval */
 void check_mfvtransval(bytea *storage) {
     size_t left_len = VARSIZE(storage);
-    size_t cur_size = 0;
-    size_t cur_capacity = 0;
     Oid     outFuncOid;
     bool    typIsVarLen;
 
@@ -81,27 +79,6 @@ void check_mfvtransval(bytea *storage) {
 
     if (left_len < sizeof(offsetcnt)*mfv->max_mfvs) {
         elog(ERROR, "invalid transition state for mfvsketch");
-    }
-    /* offset is relative to mfvtransval */
-    left_len = VARSIZE(storage) - VARHDRSZ;
-
-    /*
-     * the following checking may be inefficiency, but by doing this centrally,
-     * we can avoid spreading the checking code everywhere.
-     */
-    for (unsigned i = 0; i < mfv->next_mfv; i ++) {
-        cur_capacity = left_len - mfv->mfvs[i].offset;
-
-        if (mfv->mfvs[i].offset > left_len) {
-            elog(ERROR, "invalid transition state for mfvsketch");
-        }
-
-        cur_size = ExtractDatumLen(PointerGetDatum(MFV_DATA(mfv) + mfv->mfvs[i].offset),
-            mfv->typLen, mfv->typByVal, cur_capacity);
-
-        if (cur_size > cur_capacity) {
-            elog(ERROR, "invalid transition state for mfvsketch");
-        }
     }
 }
 
@@ -276,14 +253,19 @@ void *mfv_transval_getval(bytea *blob, uint32 i)
     void *       retval = (void *)(((char*)tvp) + tvp->mfvs[i].offset);
     Datum        dat = PointerExtractDatum(retval, tvp->typByVal);
 
-    if (i > tvp->next_mfv)
+    if (i >= tvp->next_mfv)
         elog(ERROR,
              "attempt to get frequent value at illegal index %d in mfv sketch",
              i);
     if (tvp->mfvs[i].offset > VARSIZE(blob) - VARHDRSZ
         || tvp->mfvs[i].offset < MFV_TRANSVAL_SZ(tvp->max_mfvs)-VARHDRSZ)
         elog(ERROR, "illegal offset %u in mfv sketch", tvp->mfvs[i].offset);
-    if (tvp->mfvs[i].offset  + ExtractDatumLen(dat, tvp->typLen, tvp->typByVal, -1)
+    /*
+     * call ExtractDatumLen to make sure enough space, this checking is unnecessary,
+     * it is used to prevent gcc from optimizing out the ExtractDatumLen function call.
+     */
+    if (tvp->mfvs[i].offset
+        + ExtractDatumLen(dat, tvp->typLen, tvp->typByVal, VARSIZE(blob) - VARHDRSZ - tvp->mfvs[i].offset)
         > VARSIZE(blob) - VARHDRSZ)
         elog(ERROR, "value overruns size of mfv sketch");
 
@@ -306,7 +288,7 @@ void mfv_copy_datum(bytea *transblob, int index, Datum dat)
 {
     mfvtransval *transval = (mfvtransval *)VARDATA(transblob);
     size_t       datumLen = ExtractDatumLen(dat, transval->typLen, transval->typByVal, -1);
-    void *       curval = mfv_transval_getval(transblob,index);
+    void *       curval = (char*)transval +  transval->mfvs[index].offset;
 
     memmove(curval, (void *)DatumExtractPointer(dat, transval->typByVal), datumLen);
 }

--- a/methods/sketch/src/pg_gp/sortasort.c
+++ b/methods/sketch/src/pg_gp/sortasort.c
@@ -27,6 +27,33 @@
 #include "sortasort.h"
 #include "sketch_support.h"
 
+#define SORTASORT_DATA(s)  (((char *)(s->dir)) + \
+    (s->capacity * (sizeof (s->dir[0]))))
+
+/*
+ * get the ith item stored in sortasort
+ */
+char *sortasort_getval(sortasort *s, unsigned i) {
+    char *data_ptr = SORTASORT_DATA(s);
+    char *res = NULL;
+    Datum dat;
+    if (i >= s->num_vals) {
+        elog(ERROR, "attempt to get item at illegal index %d in sortasort", i);
+    }
+    if (s->dir[i] >= s->storage_sz) {
+        elog(ERROR, "illegal offset %u in sortasort", s->dir[i]);
+    }
+    res = data_ptr + s->dir[i];
+    dat = PointerExtractDatum(res, s->typByVal);
+    if (s->dir[i]
+        + ExtractDatumLen(dat, s->typLen, s->typByVal, s->storage_sz - s->dir[i])
+        > s->storage_sz) {
+        elog(ERROR, "value overruns size of sortasort");
+    }
+
+    return res;
+}
+
 /*!
  * given a pre-allocated sortasort, set up its metadata
  * first argument s is the
@@ -69,10 +96,8 @@ int sorta_cmp(const void *i, const void *j, void *thunk)
 {
     /* the "thunk" in this case is the sortasort being sorted */
     sortasort *s = (sortasort *)thunk;
-    int        first = *(int *)i;
-    int        second = *(int *)j;
-    char      *dat1 = SORTASORT_DATA(s) + first;
-    char      *dat2 = SORTASORT_DATA(s) + second;
+    char      *dat1 = sortasort_getval(s, ((unsigned *)i) - s->dir);
+    char      *dat2 = sortasort_getval(s, ((unsigned *)j) - s->dir);
     int        len = s->typLen;
     int        shorter;
 
@@ -181,7 +206,7 @@ int sortasort_find(sortasort *s, Datum dat)
     }
     theguess = hi / 2;
     while (themin < themax ) {
-        if (!(diff = memcmp(SORTASORT_GETVAL(s,theguess),
+        if (!(diff = memcmp(sortasort_getval(s,theguess),
                             DatumExtractPointer(dat, s->typByVal),
                             len)))
             return theguess;
@@ -204,7 +229,7 @@ int sortasort_find(sortasort *s, Datum dat)
 
     /* if we got here, continue with a naive linear search on the tail */
     for (i = hi; i < s->num_vals; i++)
-        if (!memcmp(SORTASORT_GETVAL(s, i),
+        if (!memcmp(sortasort_getval(s, i),
                     DatumExtractPointer(dat, s->typByVal),
                     len))
             return i;

--- a/methods/sketch/src/pg_gp/sortasort.h
+++ b/methods/sketch/src/pg_gp/sortasort.h
@@ -31,9 +31,12 @@ typedef struct {
     unsigned dir[];        /*! storage of the strings */
 } sortasort;
 
-#define SORTASORT_DATA(s)  (((char *)(s->dir)) + \
-    (s->capacity * (sizeof (s->dir[0]))))
-#define SORTASORT_GETVAL(s, i) (SORTASORT_DATA(s) + s->dir[i])
+
+
+/*
+ * get the ith item stored in sortasort
+ */
+char *sortasort_getval(sortasort *s, unsigned i);
 
 int sortasort_try_insert(sortasort *, Datum, int);
 sortasort *sortasort_init(sortasort *, size_t, size_t, int, bool);


### PR DESCRIPTION
Jira: MADLIB-689 - http://jira.madlib.net/browse/MADLIB-689

In order to fix the security issues of the sketch method described in
MADLIB-630, at the entry point of each UDF, we did strictly checking of
the contents stored in a vararea to make sure that each access to
elements in the vararea is safe. This checking degenerates the
performance.

Because these step functions only access each item at most one time on
each call, in order to avoid performance degeneration, we only do
checking when access the specific element. The performance degeneration
decreases from 50% at most to 20%.
