### PR TITLE
BugFix:MADLIB-702

### DIFF
--- a/methods/array_ops/src/pg_gp/array_ops.c
+++ b/methods/array_ops/src/pg_gp/array_ops.c
@@ -847,7 +847,7 @@ Datum General_2Array_to_Element(ArrayType *v1, ArrayType *v2, Datum(*element_fun
 	
 	int ndims,nitems; 
 	int *dims1,*lbs1,ndims1,nitems1; 
-	int *dims2,*lbs2,ndims2,nitems2; 
+	int *dims2,*lbs2,ndims2; 
 	int i, type_size;
 	bool typbyval;
 	char *dat1,*dat2;
@@ -883,7 +883,6 @@ Datum General_2Array_to_Element(ArrayType *v1, ArrayType *v2, Datum(*element_fun
 	dat1 = ARR_DATA_PTR(v1);
 	dat2 = ARR_DATA_PTR(v2);
 	nitems1 = ArrayGetNItems(ndims1, dims1);
-	nitems2 = ArrayGetNItems(ndims2, dims2);
 	
 	ndims = ndims1;
 	for (i = 0; i < ndims; i++)
@@ -959,8 +958,8 @@ Datum General_2Array_to_Array(ArrayType *v1, ArrayType *v2, char*(*element_funct
 	char *result = NULL, *result_point;
 	
 	int *dims,*lbs,ndims,nitems; 
-	int *dims1,*lbs1,ndims1,nitems1; 
-	int *dims2,*lbs2,ndims2,nitems2; 
+	int *dims1,*lbs1,ndims1; 
+	int *dims2,*lbs2,ndims2; 
 	int i, type_size;
 	bool typbyval;
 	char *dat1,*dat2;
@@ -995,8 +994,6 @@ Datum General_2Array_to_Array(ArrayType *v1, ArrayType *v2, char*(*element_funct
 	
 	dat1 = ARR_DATA_PTR(v1);
 	dat2 = ARR_DATA_PTR(v2);
-	nitems1 = ArrayGetNItems(ndims1, dims1);
-	nitems2 = ArrayGetNItems(ndims2, dims2);
 	
 	ndims = ndims1;
 	dims = (int *) palloc(ndims * sizeof(int));
@@ -1100,7 +1097,7 @@ Datum General_Array_to_Array(ArrayType *v1, Datum elt2, char*(*element_function)
 	char *result = NULL, *result_point;
 	
 	int *dims,*lbs,ndims,nitems; 
-	int *dims1,*lbs1,ndims1,nitems1; 
+	int *dims1,*lbs1,ndims1; 
 	int i, type_size;
 	bool typbyval;
 	char *dat1;
@@ -1120,7 +1117,6 @@ Datum General_Array_to_Array(ArrayType *v1, Datum elt2, char*(*element_function)
 	dims1 = ARR_DIMS(v1);
 	
 	dat1 = ARR_DATA_PTR(v1);
-	nitems1 = ArrayGetNItems(ndims1, dims1);
 	
 	ndims = ndims1;
 	dims = (int *) palloc(ndims * sizeof(int));

--- a/methods/cart/src/pg_gp/dt.c
+++ b/methods/cart/src/pg_gp/dt.c
@@ -2529,7 +2529,6 @@ Datum dt_array_indexed_agg_sfunc(PG_FUNCTION_ARGS)
 	int32_t         elem_cnt;
 	int32_t         elem_idx;
 	int32_t         iterator_idx;
-	int 		    lbs[1];
 	
     dt_check_error_value
         (
@@ -2588,7 +2587,6 @@ Datum dt_array_indexed_agg_sfunc(PG_FUNCTION_ARGS)
 		build_state.dvalues[elem_idx << 1]       = elem;
 		build_state.dvalues[(elem_idx << 1) + 1] =  
 			Float8GetDatum(PG_ARGISNULL(1) ? 1 : 0);
-		lbs[0] = 1;
 
 		state = construct_array(build_state.dvalues, build_state.nelems,
 			build_state.element_type, build_state.typlen, 

--- a/methods/sketch/src/pg_gp/countmin.c
+++ b/methods/sketch/src/pg_gp/countmin.c
@@ -205,7 +205,6 @@ Datum __cmsketch_merge(PG_FUNCTION_ARGS)
 {
     bytea *     counterblob1 = PG_GETARG_BYTEA_P(0);
     bytea *     counterblob2 = PG_GETARG_BYTEA_P(1);
-    cmtransval *transval1 = (cmtransval *)VARDATA(counterblob1);
     cmtransval *transval2 = (cmtransval *)VARDATA(counterblob2);
     cmtransval *newtrans;
     countmin *  sketches2 = NULL;
@@ -221,7 +220,6 @@ Datum __cmsketch_merge(PG_FUNCTION_ARGS)
         PG_RETURN_DATUM(PointerGetDatum(counterblob1));
     else if (!CM_TRANSVAL_INITIALIZED(counterblob1)) {
         counterblob1 = cmsketch_init_transval();
-        transval1 = (cmtransval *)VARDATA(counterblob1);
     }
     else if (!CM_TRANSVAL_INITIALIZED(counterblob2)) {
         counterblob2 = cmsketch_init_transval();

--- a/methods/sketch/src/pg_gp/fm.c
+++ b/methods/sketch/src/pg_gp/fm.c
@@ -370,7 +370,6 @@ Datum __fmsketch_trans_c(bytea *transblob, Datum indat)
     uint64       index;
     uint8 *      c;
     int          rmost;
-    Datum        result;
     // char        *hex;
     bytea       *hashed;
 
@@ -398,9 +397,8 @@ Datum __fmsketch_trans_c(bytea *transblob, Datum indat)
      * i.e. position 0 is the rightmost.
      * so to set the bit at rmost from the left, we subtract from the total number of bits.
      */
-    result =
-        array_set_bit_in_place(bitmaps, NMAP, MD5_HASHLEN_BITS, index,
-                               (MD5_HASHLEN_BITS - 1) - rmost);
+    array_set_bit_in_place(bitmaps, NMAP, MD5_HASHLEN_BITS, index,
+                           (MD5_HASHLEN_BITS - 1) - rmost);
     return PointerGetDatum(transblob);
 }
 

--- a/src/modules/convex/algo/igd.hpp
+++ b/src/modules/convex/algo/igd.hpp
@@ -71,10 +71,12 @@ IGD<State, ConstState, Task>::merge(state_type &state,
     // Order:         111111111  22222  3333333333333333
 
     // model averaging, weighted by rows seen
-    double totalNumRows = state.algo.numRows + otherState.algo.numRows;
-    state.algo.incrModel *= (1. * state.algo.numRows) / otherState.algo.numRows;
+    double totalNumRows = static_cast<double>(state.algo.numRows + otherState.algo.numRows);
+    state.algo.incrModel *= static_cast<double>(state.algo.numRows) / 
+        static_cast<double>(otherState.algo.numRows);
     state.algo.incrModel += otherState.algo.incrModel;
-    state.algo.incrModel *= (1. * otherState.algo.numRows) / totalNumRows;
+    state.algo.incrModel *= static_cast<double>(otherState.algo.numRows) / 
+        static_cast<double>(totalNumRows);
 }
 
 template <class State, class ConstState, class Task>

--- a/src/modules/convex/type/state.hpp
+++ b/src/modules/convex/type/state.hpp
@@ -101,7 +101,7 @@ public:
      * me. But I am not sure where I can move this to...
      */
     inline void computeRMSE() {
-        task.RMSE = sqrt(algo.loss / algo.numRows);
+        task.RMSE = sqrt(algo.loss / static_cast<double>(algo.numRows));
     }
 
     static inline uint32_t arraySize(const uint16_t inRowDim, 

--- a/src/modules/linalg/average.cpp
+++ b/src/modules/linalg/average.cpp
@@ -48,7 +48,7 @@ public:
 
         mStorage = inAllocator.allocateArray<double, dbal::AggregateContext,
             dbal::DoZero, dbal::ThrowBadAlloc>(
-                arraySize(inNumDimensions));
+                static_cast<uint32_t>(arraySize(inNumDimensions)));
         rebind(inNumDimensions);
         numDimensions = inNumDimensions;
     }
@@ -107,7 +107,7 @@ avg_vector_transition::run(AnyType& args) {
     MappedColumnVector x = args[1].getAs<MappedColumnVector>();
 
     if (state.numRows == 0)
-        state.initialize(*this, x.size());
+        state.initialize(*this, static_cast<uint16_t>(x.size()));
     else if (x.size() != state.sumOfVectors.size()
         || state.numDimensions !=
             static_cast<uint32_t>(state.sumOfVectors.size()))
@@ -141,7 +141,7 @@ avg_vector_final::run(AnyType& args) {
 
     MutableNativeColumnVector avgVector(allocateArray<double>(
         state.sumOfVectors.size()));
-    avgVector = state.sumOfVectors / state.numRows;
+    avgVector = state.sumOfVectors / static_cast<int32_t>(state.numRows);
     return avgVector;
 }
 
@@ -152,7 +152,7 @@ normalized_avg_vector_transition::run(AnyType& args) {
     MappedColumnVector x = args[1].getAs<MappedColumnVector>();
 
     if (state.numRows == 0)
-        state.initialize(*this, x.size());
+        state.initialize(*this, static_cast<uint16_t>(x.size()));
     else if (x.size() != state.sumOfVectors.size()
         || state.numDimensions !=
             static_cast<uint32_t>(state.sumOfVectors.size()))
@@ -170,7 +170,7 @@ normalized_avg_vector_final::run(AnyType& args) {
 
     MutableNativeColumnVector avgVector(allocateArray<double>(
         state.sumOfVectors.size()));
-    avgVector = (state.sumOfVectors / state.numRows).normalized();
+    avgVector = (state.sumOfVectors / static_cast<int32_t>(state.numRows)).normalized();
     return avgVector;
 }
 

--- a/src/modules/linalg/matrix_agg.cpp
+++ b/src/modules/linalg/matrix_agg.cpp
@@ -64,15 +64,16 @@ public:
             MatrixAggState oldSelf = *this;
             mStorage = inAllocator.allocateArray<double, dbal::AggregateContext,
                 dbal::DoZero, dbal::ThrowBadAlloc>(
-                    arraySize(numRows, numColsReserved));
+                    static_cast<uint32_t>(arraySize(numRows, numColsReserved)));
             rebind(numRows, numColsReserved);
             numRows = oldSelf.numRows;
             numCols = oldSelf.numCols;
-            matrix.leftCols(numCols) = oldSelf.matrix.leftCols(numCols);
+            matrix.leftCols(static_cast<int>(numCols)) = 
+                oldSelf.matrix.leftCols(static_cast<int>(numCols));
         }
 
         rebind(numRows, numCols + 1);
-        return matrix.col(numCols++);
+        return matrix.col(static_cast<int>(numCols++));
     }
 
 private:
@@ -95,7 +96,8 @@ private:
     void rebind(uint64_t inNumRows, uint64_t inNumCols) {
         numRows.rebind(&mStorage[0]);
         numCols.rebind(&mStorage[1]);
-        matrix.rebind(&mStorage[2], inNumRows, inNumCols);
+        matrix.rebind(&mStorage[2], static_cast<int>(inNumRows), 
+            static_cast<int>(inNumCols));
 
         madlib_assert(mStorage.size()
             >= arraySize(inNumRows, inNumCols),
@@ -132,7 +134,7 @@ AnyType
 matrix_agg_final::run(AnyType& args) {
     MatrixAggState<ArrayHandle<double> > state = args[0];
 
-    return MappedMatrix(state.matrix.leftCols(state.numCols));
+    return MappedMatrix(state.matrix.leftCols(static_cast<int>(state.numCols)));
 }
 
 AnyType

--- a/src/modules/regress/LinearRegression_impl.hpp
+++ b/src/modules/regress/LinearRegression_impl.hpp
@@ -42,9 +42,9 @@ void
 LinearRegressionAccumulator<Container>::bind(ByteStream_type& inStream) {
     inStream
         >> numRows >> widthOfX >> y_sum >> y_square_sum;
-    uint16_t actualWidthOfX = widthOfX.isNull()
+    uint16_t actualWidthOfX = static_cast<uint16_t>(widthOfX.isNull()
         ? 0
-        : static_cast<uint16_t>(widthOfX);
+        : static_cast<uint16_t>(widthOfX));
     inStream
         >> X_transp_Y.rebind(actualWidthOfX)
         >> X_transp_X.rebind(actualWidthOfX, actualWidthOfX);

--- a/src/modules/regress/multilogistic.cpp
+++ b/src/modules/regress/multilogistic.cpp
@@ -219,9 +219,9 @@ mlogregr_irls_step_transition::run(AnyType &args) {
     MappedColumnVector x = args[3].getAs<MappedColumnVector>();
 
     // Get the category & numCategories as integer
-    int16_t category = args[1].getAs<int>();
+    int32_t category = args[1].getAs<int>();
     // Number of categories after pivoting (We pivot around the first category)
-    int16_t numCategories = (args[2].getAs<int>() - 1);
+    int32_t numCategories = (args[2].getAs<int>() - 1);
 
     // The following check was added with MADLIB-138.
     if (!x.is_finite())

--- a/src/modules/stats/one_way_anova.cpp
+++ b/src/modules/stats/one_way_anova.cpp
@@ -270,7 +270,7 @@ one_way_anova_final::run(AnyType &args) {
     double grand_mean = state.sum.sum() / state.num.sum();
     double sum_squares_between = 0;
 
-    for (uint64_t idx = 0; idx < state.numGroups; idx++)
+    for (int32_t idx = 0; idx < static_cast<int32_t>(state.numGroups); idx++)
         sum_squares_between += state.num(idx)
                              * std::pow(state.sum(idx) / state.num(idx)
                                         - grand_mean, 2);


### PR DESCRIPTION
Eliminate warnings on gcc 4.6.

There are two kinds of warnings.

First, type conversion, from uint64_t to double, between signed and
unsigned types. For type conversion, we add cast explicitly.

Second, unused auto variables. We just remove them.
