### PR TITLE
CRF: Added ordered aggregates check for install-check

### DIFF
--- a/src/ports/postgres/modules/crf/test/crf_train_large.sql_in
+++ b/src/ports/postgres/modules/crf/test/crf_train_large.sql_in
@@ -6,6 +6,9 @@
 -- 2) There should be no DROP statements in this script, since
 --    all objects created in the default schema will be cleaned-up outside.
 ---------------------------------------------------------------------------
+m4_include(`SQLCommon.m4')
+m4_changequote(<!,!>)
+m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,<!
 
 	-- Regex table
 CREATE TABLE train_new_segmenttbl(start_pos integer,doc_id integer,seg_text text,label integer,max_pos integer);
@@ -122,12 +125,8 @@ INSERT INTO train_new_segmenttbl VALUES
 (27, 4, 'more', 21, 30),
 (28, 4, 'competitive', 7, 30),
 (29, 4, 'abroad', 20, 30),
-(30, 4, '.', 44, 30);
-m4_changequote(<!,!>)
- INSERT INTO  train_new_segmenttbl VALUES
-(0, 5, <!'``'!>, 40, 49);
-m4_changequote(,)
-INSERT INTO  train_new_segmenttbl VALUES
+(30, 4, '.', 44, 30),
+(0, 5, '``', 40, 49),
 (1, 5, 'demand', 12, 49),
 (2, 5, 'has', 32, 49),
 (3, 5, 'caught', 30, 49),
@@ -152,12 +151,8 @@ INSERT INTO  train_new_segmenttbl VALUES
 (22, 5, '''''', 39, 49),
 (23, 5, 'at', 6, 49),
 (24, 5, 'a', 3, 49),
-(25, 5, 'rate', 12, 49);
-m4_changequote(<!,!>)
- INSERT INTO  train_new_segmenttbl VALUES
-(26, 5, <!'``'!>, 40, 49);
-m4_changequote(,)
-INSERT INTO  train_new_segmenttbl VALUES
+(25, 5, 'rate', 12, 49),
+(26, 5, '``', 40, 49),
 (27, 5, 'close', 20, 49),
 (28, 5, 'to', 25, 49),
 (29, 5, 'or', 1, 49),
@@ -459,12 +454,8 @@ INSERT INTO train_new_regex VALUES
 (189, 'E.', 7, 20, 1.771180632746488),
 (190, 'W_abroad', -1, 20, 3.795196762237916),
 (191, 'E.', 20, 44, 2.295613975954753),
-(192, 'S.', -1, 40, 2.186455757483502);
-m4_changequote(<!,!>)
- INSERT INTO  expected_crf_feature_new VALUES
-(193, <!'W_``'!>, -1, 40, 5.004869688499841);
-m4_changequote(,)
-INSERT INTO  expected_crf_feature_new VALUES
+(192, 'S.', -1, 40, 2.186455757483502),
+(193, 'W_``', -1, 40, 5.004869688499841),
 (194, 'E.', 40, 12, 2.5755893774727556),
 (195, 'E.', 12, 32, 1.7721648420817446),
 (196, 'W_has', -1, 32, 3.93625538731919),
@@ -589,3 +580,6 @@ INSERT INTO  expected_crf_feature_new VALUES
 			FROM expected_crf_feature_new 
 		) AS U
 	)s2;
+
+!>)
+m4_changequote(<!`!>,<!'!>)


### PR DESCRIPTION
Jira: MADLIB-725
Description: Add ordered aggregates check to crf_train_large
so that it is skipped if the db does not support (e.g. PG8.4)
