### PR TITLE
Quantile: Suppress assign float to integer

### DIFF
--- a/src/ports/postgres/modules/quantile/quantile.sql_in
+++ b/src/ports/postgres/modules/quantile/quantile.sql_in
@@ -88,7 +88,7 @@ Begin
          'quantile_size' is computed in terms of element count
     */
     EXECUTE 'SELECT array[MIN('||col_name||'), AVG('||col_name||'), MAX('||col_name||')], COUNT(*) FROM '||table_name||' ' INTO size, count;
-    quantile_size = count*quantile;
+    quantile_size = (count*quantile)::BIGINT;
     full_size = count;
 
     -- check for bad input


### PR DESCRIPTION
Jira: MADLIB-601

quantile_big used BIGINT to store the number of rows. The code need to calculate quantile_size by multiplying the total number of rows with the quantile, whose result type is a FLOAT8. The code tries to assign this result to a BIGINT directly, and this operation causes problem.

To fix this, we make a coerce on the result.
