### PR TITLE
Kmeans_new: make kmeans++ method support SVEC

### DIFF
--- a/src/ports/postgres/modules/kmeans_new/kmeans_new.py_in
+++ b/src/ports/postgres/modules/kmeans_new/kmeans_new.py_in
@@ -213,7 +213,7 @@ def compute_kmeanspp_seeding(schema_madlib, rel_args, rel_state, rel_source,
         if it.test("_args.initial_centroids IS NULL"):
             it.update("""
                 SELECT
-                    ARRAY[{schema_madlib}.weighted_sample(_src.{expr_point}, 1)]
+                    ARRAY[{schema_madlib}.weighted_sample(_src.{expr_point}::FLOAT8[], 1)]
                 FROM {rel_source} AS _src
                 """)
         else:
@@ -227,13 +227,13 @@ def compute_kmeanspp_seeding(schema_madlib, rel_args, rel_state, rel_source,
                         SELECT _state FROM {rel_state}
                         WHERE _iteration = {iteration}
                     ) || {schema_madlib}.weighted_sample(
-                            _src.{expr_point},
+                            _src.{expr_point}::FLOAT8[],
                             ({schema_madlib}.closest_column(
                                 (
                                     SELECT _state FROM {rel_state}
                                     WHERE _iteration = {iteration}
                                 ),
-                                _src.{expr_point},
+                                _src.{expr_point}::FLOAT8[],
                                 (SELECT fn_dist FROM {rel_args})
                             )).distance
                         )
@@ -276,7 +276,7 @@ def compute_kmeans_random_seeding(schema_madlib, rel_args, rel_state,
         while m > 0:
             it.update("""
                 SELECT
-                    _state._state || {schema_madlib}.matrix_agg(_point)
+                    _state._state || {schema_madlib}.matrix_agg(_point::FLOAT8[])
                 FROM (
                         SELECT
                             {expr_point} AS _point
@@ -344,7 +344,7 @@ def compute_kmeans(schema_madlib, rel_args, rel_state, rel_source,
             it.update("""
                 SELECT
                     CAST((
-                        {schema_madlib}.matrix_agg(_centroid),
+                        {schema_madlib}.matrix_agg(_centroid::FLOAT8[]),
 m4_ifdef(<!__GREENPLUM__!>,<!m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,,<!
                         {schema_madlib}.
 !>)!>)
@@ -373,7 +373,7 @@ m4_ifdef(<!__GREENPLUM__!>,<!m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,,<!
                                 AS INTEGER
                             )
                         ) AS _num_reassigned,
-                        {agg_centroid}(_point) AS _centroid
+                        {agg_centroid}(_point::FLOAT8[]) AS _centroid
                     FROM (
                         SELECT
                             -- PostgreSQL/Greenplum tuning:
@@ -385,7 +385,7 @@ m4_ifdef(<!__GREENPLUM__!>,<!m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,,<!
                                     SELECT (_state).centroids FROM {rel_state}
                                     WHERE _iteration = {iteration}
                                 ),
-                                _src.{expr_point},
+                                _src.{expr_point}::FLOAT8[],
                                 (SELECT fn_dist FROM {rel_args})
                             ) AS _new_centroid,
                             ({schema_madlib}.closest_column(
@@ -393,7 +393,7 @@ m4_ifdef(<!__GREENPLUM__!>,<!m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,,<!
                                     SELECT (_state).centroids FROM {rel_state}
                                     WHERE _iteration = {iteration} - 1
                                 ),
-                                _src.{expr_point},
+                                _src.{expr_point}::FLOAT8[],
                                 (SELECT fn_dist FROM {rel_args})
                             )).column_id AS _old_centroid_id
                         FROM {rel_source} AS _src

--- a/src/ports/postgres/modules/kmeans_new/kmeans_new.sql_in
+++ b/src/ports/postgres/modules/kmeans_new/kmeans_new.sql_in
@@ -962,7 +962,7 @@ BEGIN
         SELECT MADLIB_SCHEMA.kmeans(
             $1, $2,
             (
-                SELECT MADLIB_SCHEMA.matrix_agg($sql$ || expr_centroid || $sql$)
+                SELECT MADLIB_SCHEMA.matrix_agg($sql$ || expr_centroid::FLOAT8[] || $sql$)
                 FROM $sql$ || textin(regclassout(class_rel_initial_centroids))
                     || $sql$
             ),


### PR DESCRIPTION
Jira: madlib-730
In current code, we cannot correctly handle SVEC input. In this fix, I explicitly convert SVEC to array whenever necessary to fix the issues.
