### PR TITLE
K-means: Fix parameter k to be of type integer

### DIFF
--- a/src/modules/linalg/metric.cpp
+++ b/src/modules/linalg/metric.cpp
@@ -208,7 +208,7 @@ AnyType
 closest_columns::run(AnyType& args) {
     MappedMatrix M = args[0].getAs<MappedMatrix>();
     MappedColumnVector x = args[1].getAs<MappedColumnVector>();
-    uint16_t num = args[2].getAs<uint16_t>();
+    uint32_t num = args[2].getAs<uint32_t>();
     FunctionHandle dist = args[3].getAs<FunctionHandle>()
         .unsetFunctionCallOptions(FunctionHandle::GarbageCollectionAfterCall);
 

--- a/src/ports/postgres/modules/kmeans_new/kmeans_new.py_in
+++ b/src/ports/postgres/modules/kmeans_new/kmeans_new.py_in
@@ -412,7 +412,7 @@ m4_ifdef(<!__GREENPLUM__!>,<!m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,,<!
                             ) || {schema_madlib}.kmeanspp_seeding(
                                 '{rel_source}',
                                 '{expr_point}',
-                                (SELECT CAST(k AS INT2) FROM {rel_args}),
+                                (SELECT CAST(k AS INTEGER) FROM {rel_args}),
                                 textin(regprocout(
                                     (SELECT fn_dist FROM {rel_args})
                                 )),

--- a/src/ports/postgres/modules/kmeans_new/kmeans_new.sql_in
+++ b/src/ports/postgres/modules/kmeans_new/kmeans_new.sql_in
@@ -396,7 +396,7 @@ BEGIN
     IF (max_num_iterations < 0) THEN
         RAISE EXCEPTION 'Number of iterations must be a non-negative integer.';
     END IF;
-
+    
     -- We first setup the argument table. Rationale: We want to avoid all data
     -- conversion between native types and Python code. Instead, we use Python
     -- as a pure driver layer.
@@ -498,7 +498,7 @@ LANGUAGE sql AS $$
 $$;
 
 CREATE FUNCTION MADLIB_SCHEMA.internal_execute_using_kmeanspp_seeding_args(
-    sql VARCHAR, INT2, REGPROC, DOUBLE PRECISION[][]
+    sql VARCHAR, INTEGER, REGPROC, DOUBLE PRECISION[][]
 ) RETURNS VOID
 VOLATILE
 CALLED ON NULL INPUT
@@ -532,7 +532,7 @@ LANGUAGE plpythonu VOLATILE;
 CREATE FUNCTION MADLIB_SCHEMA.kmeanspp_seeding(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2,
+    k INTEGER,
     fn_dist VARCHAR /*+ DEFAULT 'squared_dist_norm2' */,
     initial_centroids DOUBLE PRECISION[][] /*+ DEFAULT NULL */
 ) RETURNS DOUBLE PRECISION[][] AS $$
@@ -542,7 +542,15 @@ DECLARE
     oldClientMinMessages VARCHAR;
     class_rel_source REGCLASS;
     proc_fn_dist REGPROCEDURE;
+    num_points INTEGER;
+    num_centroids INTEGER;
 BEGIN
+    IF (initial_centroids IS NOT NULL) THEN
+	num_centroids := array_upper(initial_centroids,1);
+    ELSE
+	num_centroids := k;
+    END IF;
+
     class_rel_source := rel_source;
     proc_fn_dist := fn_dist
         || '(DOUBLE PRECISION[], DOUBLE PRECISION[])';
@@ -553,7 +561,17 @@ BEGIN
     IF (k <= 0) THEN
         RAISE EXCEPTION 'Number of clusters k must be a positive integer.';
     END IF;
-
+    IF (k > 32767) THEN
+	RAISE EXCEPTION 'Number of clusters k must be <= 32767 (for results to be returned in a reasonable amount of time).';
+    END IF;
+    EXECUTE $sql$ SELECT count(*) FROM $sql$ || textin(regclassout(rel_source)) INTO num_points ;
+    IF (num_points < k OR num_points < num_centroids) THEN
+	RAISE EXCEPTION 'Number of centroids is greater than number of points.';
+    END IF;
+    IF (k < num_centroids) THEN
+	RAISE WARNING 'Number of clusters k is less than number of supplied initial centroids. Number of final clusters will equal number of supplied initial centroids.';
+    END IF;
+    
     -- We first setup the argument table. Rationale: We want to avoid all data
     -- conversion between native types and Python code. Instead, we use Python
     -- as a pure driver layer.
@@ -596,7 +614,7 @@ $$ LANGUAGE plpgsql VOLATILE;
 CREATE FUNCTION MADLIB_SCHEMA.kmeanspp_seeding(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2,
+    k INTEGER,
     fn_dist VARCHAR
 ) RETURNS DOUBLE PRECISION[][]
 LANGUAGE sql AS $$
@@ -606,7 +624,7 @@ $$;
 CREATE FUNCTION MADLIB_SCHEMA.kmeanspp_seeding(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2
+    k INTEGER
 ) RETURNS DOUBLE PRECISION[][]
 LANGUAGE sql AS $$
     SELECT MADLIB_SCHEMA.kmeanspp_seeding($1, $2, $3,
@@ -635,7 +653,7 @@ $$;
 CREATE FUNCTION MADLIB_SCHEMA.kmeanspp(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2,
+    k INTEGER,
     fn_dist VARCHAR /*+ DEFAULT 'squared_dist_norm2' */,
     agg_centroid VARCHAR /*+ DEFAULT 'avg' */,
     max_num_iterations INTEGER /*+ DEFAULT 20 */,
@@ -660,7 +678,7 @@ $$;
 CREATE FUNCTION MADLIB_SCHEMA.kmeanspp(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2,
+    k INTEGER,
     fn_dist VARCHAR,
     agg_centroid VARCHAR,
     max_num_iterations INTEGER
@@ -684,7 +702,7 @@ $$;
 CREATE FUNCTION MADLIB_SCHEMA.kmeanspp(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2,
+    k INTEGER,
     fn_dist VARCHAR,
     agg_centroid VARCHAR
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
@@ -707,7 +725,7 @@ $$;
 CREATE FUNCTION MADLIB_SCHEMA.kmeanspp(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2,
+    k INTEGER,
     fn_dist VARCHAR
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
@@ -729,7 +747,7 @@ $$;
 CREATE FUNCTION MADLIB_SCHEMA.kmeanspp(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2
+    k INTEGER
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
 STRICT
@@ -750,7 +768,7 @@ END
 $$;
 
 CREATE FUNCTION MADLIB_SCHEMA.internal_execute_using_kmeans_random_seeding_args(
-    sql VARCHAR, INT2, DOUBLE PRECISION[][]
+    sql VARCHAR, INTEGER, DOUBLE PRECISION[][]
 ) RETURNS VOID
 VOLATILE
 CALLED ON NULL INPUT
@@ -781,7 +799,7 @@ LANGUAGE plpythonu VOLATILE;
 CREATE FUNCTION MADLIB_SCHEMA.kmeans_random_seeding(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2,
+    k INTEGER,
     initial_centroids DOUBLE PRECISION[][] /*+ DEFAULT NULL */
 ) RETURNS DOUBLE PRECISION[][] AS $$
 DECLARE
@@ -790,11 +808,29 @@ DECLARE
     oldClientMinMessages VARCHAR;
     class_rel_source REGCLASS;
     proc_fn_dist REGPROCEDURE;
+    num_points INTEGER;
+    num_centroids INTEGER;
 BEGIN
     class_rel_source := rel_source;
+    num_centroids := k;
+    IF (initial_centroids IS NOT NULL) THEN
+	num_centroids := array_upper(initial_centroids,1);
+    ELSE
+	num_centroids := k;
+    END IF;
 
     IF (k <= 0) THEN
         RAISE EXCEPTION 'Number of clusters k must be a positive integer.';
+    END IF;
+    IF (k > 32767) THEN
+	RAISE EXCEPTION 'Number of clusters k must be <= 32767 (for results to be returned in a reasonable amount of time).';
+    END IF;
+    EXECUTE $sql$ SELECT count(*) FROM $sql$ || textin(regclassout(rel_source)) INTO num_points;
+    IF (num_points < k  OR num_points < num_centroids) THEN
+	RAISE EXCEPTION 'Number of centroids is greater than number of points.';
+    END IF;
+    IF (k < num_centroids) THEN
+	RAISE WARNING 'Number of clusters k is less than number of supplied initial centroids. Number of final clusters will equal number of supplied initial centroids.';
     END IF;
 
     -- We first setup the argument table. Rationale: We want to avoid all data
@@ -839,7 +875,7 @@ $$ LANGUAGE plpgsql VOLATILE;
 CREATE FUNCTION MADLIB_SCHEMA.kmeans_random_seeding(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2
+    k INTEGER
 ) RETURNS DOUBLE PRECISION[][]
 LANGUAGE sql AS $$
     SELECT MADLIB_SCHEMA.kmeans_random_seeding($1, $2, $3, NULL)
@@ -867,7 +903,7 @@ $$;
 CREATE FUNCTION MADLIB_SCHEMA.kmeans_random(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2,
+    k INTEGER,
     fn_dist VARCHAR /*+ DEFAULT 'squared_dist_norm2' */,
     agg_centroid VARCHAR /*+ DEFAULT 'avg' */,
     max_num_iterations INTEGER /*+ DEFAULT 20 */,
@@ -892,7 +928,7 @@ $$;
 CREATE FUNCTION MADLIB_SCHEMA.kmeans_random(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2,
+    k INTEGER,
     fn_dist VARCHAR,
     agg_centroid VARCHAR,
     max_num_iterations INTEGER
@@ -916,7 +952,7 @@ $$;
 CREATE FUNCTION MADLIB_SCHEMA.kmeans_random(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2,
+    k INTEGER,
     fn_dist VARCHAR,
     agg_centroid VARCHAR
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
@@ -939,7 +975,7 @@ $$;
 CREATE FUNCTION MADLIB_SCHEMA.kmeans_random(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2,
+    k INTEGER,
     fn_dist VARCHAR
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
@@ -962,7 +998,7 @@ $$;
 CREATE FUNCTION MADLIB_SCHEMA.kmeans_random(
     rel_source VARCHAR,
     expr_point VARCHAR,
-    k INT2
+    k INTEGER
 ) RETURNS MADLIB_SCHEMA.kmeans_new_result
 VOLATILE
 STRICT
@@ -1213,7 +1249,7 @@ BEGIN
                 (MADLIB_SCHEMA.closest_columns(
                     $1,
                     $sql$ || expr_point || $sql$,
-                    2::INT2,
+                    2::INTEGER,
                     $2
                 )).distances
             FROM

--- a/src/ports/postgres/modules/kmeans_new/test/kmeans.sql_in
+++ b/src/ports/postgres/modules/kmeans_new/test/kmeans.sql_in
@@ -32,9 +32,9 @@ FROM kmeans_2d
 ORDER BY random()
 LIMIT 10;
 
-SELECT * FROM kmeanspp('kmeans_2d', 'position', 10::SMALLINT);
+SELECT * FROM kmeanspp('kmeans_2d', 'position', 10);
 
-SELECT * FROM kmeans_random('kmeans_2d', 'position', 10::SMALLINT);
+SELECT * FROM kmeans_random('kmeans_2d', 'position', 10);
 
 SELECT * FROM kmeans('kmeans_2d', 'position', 'centroids', 'position');
 

--- a/src/ports/postgres/modules/linalg/linalg.sql_in
+++ b/src/ports/postgres/modules/linalg/linalg.sql_in
@@ -153,7 +153,7 @@ CREATE TYPE MADLIB_SCHEMA.closest_column_result AS (
  *     <tt>DOUBLE PRECISION[] x DOUBLE PRECISION[] -> DOUBLE PRECISION</tt>.
  *
  * @returns A composite value:
- *  - <tt>columns_id INT2</tt> - The 0-based index of the column of \f$ M \f$
+ *  - <tt>columns_id INTEGER</tt> - The 0-based index of the column of \f$ M \f$
  *     that is closest to \f$ x \f$. In case of ties, the first such index is
  *     returned. That is, \c columns_id is the minimum element in the set
  *     \f$ \arg\min_{i=0,\dots,l-1} \operatorname{dist}(\vec{m_i}, \vec x) \f$.
@@ -210,7 +210,7 @@ CREATE TYPE MADLIB_SCHEMA.closest_columns_result AS (
 CREATE FUNCTION MADLIB_SCHEMA.closest_columns(
     M DOUBLE PRECISION[][],
     x DOUBLE PRECISION[],
-    num INT2,
+    num INTEGER,
     dist REGPROC /*+ DEFAULT 'squared_dist_norm2' */
 ) RETURNS MADLIB_SCHEMA.closest_columns_result
 IMMUTABLE
@@ -221,7 +221,7 @@ AS 'MODULE_PATHNAME';
 CREATE FUNCTION MADLIB_SCHEMA.closest_columns(
     M DOUBLE PRECISION[][],
     x DOUBLE PRECISION[],
-    num INT2
+    num INTEGER
 ) RETURNS MADLIB_SCHEMA.closest_columns_result
 IMMUTABLE
 STRICT

--- a/src/ports/postgres/modules/linalg/test/linalg.sql_in
+++ b/src/ports/postgres/modules/linalg/test/linalg.sql_in
@@ -121,7 +121,7 @@ SELECT
             ARRAY[0,1]
         ]::DOUBLE PRECISION[][],
         ARRAY[.5,.5]::DOUBLE PRECISION[],
-        2::INT2,
+        2::INTEGER,
         'squared_dist_norm2'
     );
 
@@ -159,7 +159,7 @@ FROM (
                 ARRAY[1,1],
                 ARRAY[0,1]
             ]::DOUBLE PRECISION[][] AS matrix,
-            2::INT2 AS num,
+            2 AS num,
             'squared_dist_norm2'::REGPROC AS metric
     ) AS ignored
 ) AS ignored;


### PR DESCRIPTION
instead of small int

JIRA: MADLIB-697
Fixed kmeans seeding functions and closest_columns to allow number
of centroids k to be of type integer.  Also added in parameter
checks to ensure k is within a valid range.
