### PR TITLE
The new kmeans: Fixed the bug caused by the commit for MADlib-730

### DIFF
--- a/src/ports/postgres/modules/kmeans_new/kmeans_new.sql_in
+++ b/src/ports/postgres/modules/kmeans_new/kmeans_new.sql_in
@@ -1066,7 +1066,7 @@ BEGIN
         SELECT MADLIB_SCHEMA.kmeans(
             $1, $2,
             (
-                SELECT MADLIB_SCHEMA.matrix_agg($sql$ || expr_centroid::FLOAT8[] || $sql$)
+                SELECT MADLIB_SCHEMA.matrix_agg(($sql$ || expr_centroid || $sql$)::FLOAT8[])
                 FROM $sql$ || textin(regclassout(class_rel_initial_centroids))
                     || $sql$
             ),


### PR DESCRIPTION
Jira MADlib-734

The commit (f7d1f) for MADlib-730 would convert the centroids column
to float8[] using a wrong way, which fails the install-check. This
commit corrects this.
