### PR TITLE
Naive Bayes: Fix install-check errors

### DIFF
--- a/src/config/Modules.yml
+++ b/src/config/Modules.yml
@@ -6,6 +6,7 @@ modules:
     - name: assoc_rules
       depends: ['svec']
     - name: bayes
+      depends: ['array_ops']
     - name: compatibility
       depends: ['utilities']
     - name: conjugate_gradient

--- a/src/ports/postgres/modules/bayes/bayes.py_in
+++ b/src/ports/postgres/modules/bayes/bayes.py_in
@@ -244,7 +244,7 @@ def __get_keys_and_prob_values_sql(**kwargs):
 				classify.key,
 				featureprobs.class,
 				classify.attr, max(classify.value) as cvalue,
-				max(classify.value) || array_agg(featureprobs.value) as fpvalue,
+				max(classify.value)::DOUBLE PRECISION || array_agg(featureprobs.value) as fpvalue,
 				0::bigint || array_agg(featureprobs.cnt) as fp_cnt,
 				max(featureprobs.attr_cnt) as fp_attr_cnt,
 				classpriors.class_cnt,


### PR DESCRIPTION
Jira: MADLIB-738

Install-check produced errors because of type cast problems in naive Bayes code that was taken care of in this fix.
