### PR TITLE
Naive Bayes: Rectify type cast errors

### DIFF
--- a/src/config/Modules.yml
+++ b/src/config/Modules.yml
@@ -6,6 +6,7 @@ modules:
     - name: assoc_rules
       depends: ['svec']
     - name: bayes
+      depends: ['array_ops']
     - name: compatibility
       depends: ['utilities']
     - name: conjugate_gradient

--- a/src/ports/greenplum/4.0/config/Modules.yml
+++ b/src/ports/greenplum/4.0/config/Modules.yml
@@ -5,7 +5,7 @@ modules:
     - name: array_ops
 #    - name: assoc_rules
 #      depends: ['svec']
-#    - name: bayes
+    - name: bayes
     - name: compatibility
       depends: ['utilities']
     - name: conjugate_gradient

--- a/src/ports/greenplum/4.0/config/Modules.yml
+++ b/src/ports/greenplum/4.0/config/Modules.yml
@@ -5,7 +5,7 @@ modules:
     - name: array_ops
 #    - name: assoc_rules
 #      depends: ['svec']
-    - name: bayes
+#    - name: bayes
     - name: compatibility
       depends: ['utilities']
     - name: conjugate_gradient

--- a/src/ports/postgres/modules/bayes/bayes.py_in
+++ b/src/ports/postgres/modules/bayes/bayes.py_in
@@ -1,4 +1,5 @@
 # coding=utf-8
+m4_changequote(<!,!>)
 
 """@file bayes.py_in
 
@@ -244,8 +245,14 @@ def __get_keys_and_prob_values_sql(**kwargs):
 				classify.key,
 				featureprobs.class,
 				classify.attr, max(classify.value) as cvalue,
-				max(classify.value)::DOUBLE PRECISION || array_agg(featureprobs.value) as fpvalue,
-				0::bigint || array_agg(featureprobs.cnt) as fp_cnt,
+				max(classify.value)::DOUBLE PRECISION ||
+                    m4_ifdef(<!__GREENPLUM__!>,<!m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,,<!
+                        {schema_madlib}.!>)!>)
+                    array_agg(featureprobs.value) as fpvalue,
+				0::bigint ||
+                    m4_ifdef(<!__GREENPLUM__!>,<!m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,,<!
+                        {schema_madlib}.!>)!>)
+                    array_agg(featureprobs.cnt) as fp_cnt,
 				max(featureprobs.attr_cnt) as fp_attr_cnt,
 				classpriors.class_cnt,
 				classpriors.all_cnt
@@ -769,3 +776,5 @@ def __verify_attr_num(sourceTable, attrColumn, numAttr):
     if (dsize <> 0):
         plpy.error('found %d records in "%s" where "%s" was not of expected length (%d)'\
             % (dsize, sourceTable, attrColumn, numAttr))
+
+m4_changequote(<!`!>,<!'!>)

--- a/src/ports/postgres/modules/bayes/bayes.py_in
+++ b/src/ports/postgres/modules/bayes/bayes.py_in
@@ -244,7 +244,7 @@ def __get_keys_and_prob_values_sql(**kwargs):
 				classify.key,
 				featureprobs.class,
 				classify.attr, max(classify.value) as cvalue,
-				max(classify.value) || array_agg(featureprobs.value) as fpvalue,
+				max(classify.value)::DOUBLE PRECISION || array_agg(featureprobs.value) as fpvalue,
 				0::bigint || array_agg(featureprobs.cnt) as fp_cnt,
 				max(featureprobs.attr_cnt) as fp_attr_cnt,
 				classpriors.class_cnt,

--- a/src/ports/postgres/modules/bayes/bayes.sql_in
+++ b/src/ports/postgres/modules/bayes/bayes.sql_in
@@ -1,4 +1,4 @@
-/* ----------------------------------------------------------------------- *//** 
+/* ----------------------------------------------------------------------- *//**
  *
  * @file bayes.sql_in
  *
@@ -140,7 +140,7 @@ can by verified by hand.
 -#  The training and the classification data:
 \verbatim
 sql> SELECT * FROM training;
- id | class | attributes 
+ id | class | attributes
 ----+-------+------------
   1 |     1 | {1,2,3}
   2 |     1 | {1,2,1}
@@ -151,7 +151,7 @@ sql> SELECT * FROM training;
 (6 rows)
 
 sql> select * from toclassify;
- id | attributes 
+ id | attributes
 ----+------------
   1 | {0,2,1}
   2 | {1,2,3}
@@ -159,20 +159,20 @@ sql> select * from toclassify;
 \endverbatim
 -#  Precompute feature probabilities and class priors
 \verbatim
-sql> SELECT madlib.create_nb_prepared_data_tables( 
+sql> SELECT madlib.create_nb_prepared_data_tables(
 'training', 'class', 'attributes', 3, 'nb_feature_probs', 'nb_class_priors');
 \endverbatim
 -#  Optionally check the contents of the precomputed tables:
 \verbatim
 sql> SELECT * FROM nb_class_priors;
- class | class_cnt | all_cnt 
+ class | class_cnt | all_cnt
 -------+-----------+---------
      1 |         3 |       6
      2 |         3 |       6
 (2 rows)
 
 sql> SELECT * FROM nb_feature_probs;
- class | attr | value | cnt | attr_cnt 
+ class | attr | value | cnt | attr_cnt
 -------+------+-------+-----+----------
      1 |    1 |     0 |   0 |        2
      1 |    1 |     1 |   3 |        2
@@ -186,7 +186,7 @@ sql> SELECT madlib.create_nb_classify_view (
 'nb_feature_probs', 'nb_class_priors', 'toclassify', 'id', 'attributes', 3, 'nb_classify_view_fast');
 
 sql> SELECT * FROM nb_classify_view_fast;
- key | nb_classification 
+ key | nb_classification
 -----+-------------------
    1 | {2}
    2 | {1}
@@ -198,7 +198,7 @@ sql> SELECT madlib.create_nb_probs_view (
 'nb_feature_probs', 'nb_class_priors', 'toclassify', 'id', 'attributes', 3, 'nb_probs_view_fast');
 
 sql> SELECT * FROM nb_probs_view_fast;
- key | class | nb_prob 
+ key | class | nb_prob
 -----+-------+---------
    1 |     1 |     0.4
    1 |     2 |     0.6
@@ -381,7 +381,7 @@ LANGUAGE plpythonu VOLATILE;
  *    <em>numAttrs</em>, '<em>destName</em>'
  *);</pre>
  * -# Show Naive Bayes classifications:
- *    <pre>SELECT * FROM <em>destName</em>;</pre>  
+ *    <pre>SELECT * FROM <em>destName</em>;</pre>
  *
  * @internal
  * @sa This function is a wrapper for bayes::create_classification(). See there
@@ -415,18 +415,18 @@ LANGUAGE plpythonu VOLATILE;
 
 /**
  * @brief Create view with columns <tt>(key, class, nb_prob)</tt>
- * 
+ *
  * The created view will be of the following form:
- * 
+ *
  * <pre>VIEW <em>destName</em> (
  *    key ANYTYPE,
  *    class INTEGER,
  *    nb_prob FLOAT8
  *)</pre>
- * 
+ *
  * where \c nb_prob is the Naive-Bayes probability that \c class is the true
  * class of the record in \em classifySource identified by \c key.
- * 
+ *
  * @param featureProbsSource Name of table with precomputed feature
  *        probabilities, as created with create_nb_prepared_data_tables()
  * @param classPriorsSource Name of table with precomputed class priors, as
@@ -449,7 +449,7 @@ LANGUAGE plpythonu VOLATILE;
  *    <em>numAttrs</em>, '<em>destName</em>'
  *);</pre>
  * -# Show Naive Bayes probabilities:
- *    <pre>SELECT * FROM <em>destName</em>;</pre>  
+ *    <pre>SELECT * FROM <em>destName</em>;</pre>
  *
  * @internal
  * @sa This function is a wrapper for bayes::create_bayes_probabilities().
@@ -483,17 +483,17 @@ LANGUAGE plpythonu VOLATILE;
 /**
  * @brief Create a SQL function mapping arrays of attribute values to the Naive
  *        Bayes classification.
- * 
+ *
  * The created SQL function is bound to the given feature probabilities and
  * class priors. Its declaration will be:
- * 
+ *
  * <tt>
  * FUNCTION <em>destName</em> (attributes INTEGER[], smoothingFactor DOUBLE PRECISION)
  * RETURNS INTEGER[]</tt>
  *
  * The return type is \c INTEGER[] because the Naive Bayes classification might
  * be ambiguous (in which case all of the most likely candiates are returned).
- * 
+ *
  * @param featureProbsSource Name of table with precomputed feature
  *        probabilities, as created with create_nb_prepared_data_tables()
  * @param classPriorsSource Name of table with precomputed class priors, as


### PR DESCRIPTION
Jira: MADLIB-738

Commit d7cd128 introduced type casts errors triggering a failure in
install-checks. This fix takes care of the type cast error.
Also, GPDPB 4.0 does not support array_agg. Hence we use m4 macros to
detect the platform and use the array_agg defined in array_ops
if necessary.

Other changes:
    Removed trailing whitespace
