### PR TITLE
Revert to old Naive Bayes (from commit f32a706)

### DIFF
--- a/src/ports/postgres/modules/bayes/bayes.py_in
+++ b/src/ports/postgres/modules/bayes/bayes.py_in
@@ -1,5 +1,4 @@
 # coding=utf-8
-m4_changequote(<!,!>)
 
 """@file bayes.py_in
 
@@ -27,7 +26,7 @@ Naive Bayes: Setup Functions
     - Even adding infinitely many \f$ \log_{10}(x)@f$ for @f$0 < x \le 1 \f$ will
       never cause an overflow because addition will have no effect once the sum
       reaches approx $308 * 2^{53}$ (correspnding to the machine precision).
-
+    
     The functions __get_*_sql are private because we do not want to commit ourselves
     to a particular interface. We might want to be able to change implementation
     details should the need arise.
@@ -38,9 +37,9 @@ import plpy
 
 def __get_feature_probs_sql(**kwargs):
     """Return SQL query with columns (class, attr, value, cnt, attr_cnt).
-
+    
     For class c, attr i, and value a, cnt is #(c,i,a) and attr_cnt is \#i.
-
+    
     Note that the query will contain a row for every pair (class, value)
     occuring in the training data (so it might also contain rows where
     \#(c,i,a) = 0).
@@ -56,7 +55,7 @@ def __get_feature_probs_sql(**kwargs):
     @param trainingClassColumn name of column with class
     @param trainingAttrColumn name of column with attributes array
     @param numAttrs Number of attributes to use for classification
-
+        
     For meanings of \#(c,i,a), \#c, and \#i see the general description of
     \ref bayes.
     """
@@ -111,11 +110,11 @@ def __get_feature_probs_sql(**kwargs):
 def __get_attr_values_sql(**kwargs):
     """
     Return SQL query with columns (attr, value).
-
+    
     The query contains a row for each pair that occurs in the training data.
 
     @param trainingSource Name of relation containing the training data
-    @param trainingAttrColumn Name of attributes-array column in training data
+    @param trainingAttrColumn Name of attributes-array column in training data  
     @param numAttrs Number of attributes to use for classification
 
     @internal
@@ -126,11 +125,11 @@ def __get_attr_values_sql(**kwargs):
     [...] count(DISTINCT value) OVER (PARTITION BY attr) [...]
     @endverbatim
     @endinternal
-
+    
     """
 
     return """
-        SELECT
+        SELECT 
             generate_series(1, {numAttrs}) AS attr,
             unnest(trainingSource.{trainingAttrColumn}) AS value
         FROM
@@ -142,28 +141,28 @@ def __get_attr_values_sql(**kwargs):
 def __get_attr_counts_sql(**kwargs):
     """
     Return SQL query with columns (attr, attr_cnt)
-
+    
     For attr i, attr_cnt is \#i.
-
+    
     @param trainingSource Name of relation containing the training data
-    @param trainingAttrColumn Name of attributes-array column in training data
+    @param trainingAttrColumn Name of attributes-array column in training data  
     @param numAttrs Number of attributes to use for classification
-
+    
     """
 
     return """
-        SELECT
+        SELECT 
             attr, count(value) AS attr_cnt
         FROM
         (
-            SELECT
-                attr, value
+            SELECT 
+                attr, value            
             FROM (
-                SELECT
+                SELECT 
                     generate_series(1, {numAttrs}) AS attr,
                     unnest(trainingSource.{trainingAttrColumn}) AS value
                 FROM
-                    {trainingSource} AS trainingSource
+                    {trainingSource} AS trainingSource 
                 ) l
             GROUP BY attr, value
         ) m
@@ -174,17 +173,17 @@ def __get_attr_counts_sql(**kwargs):
 def __get_class_priors_sql(**kwargs):
     """
     Return SQL query with columns (class, class_cnt, all_cnt)
-
+    
     For class c, class_cnt is \#c. all_cnt is the total number of records in the
     training data.
 
     @param trainingSource Name of relation containing the training data
-    @param trainingClassColumn Name of class column in training data
-
+    @param trainingClassColumn Name of class column in training data    
+    
     """
 
     return """
-        SELECT * FROM
+        SELECT * FROM 
             (
             SELECT
                 trainingSource.{trainingClassColumn} AS class,
@@ -204,9 +203,14 @@ def __get_class_priors_sql(**kwargs):
 def __get_keys_and_prob_values_sql(**kwargs):
     """
     Return SQL query with columns (key, class, log_prob).
-
+    
     For class c and the attribute array identified by key k, log_prob is
     log( P(C = c) * P(A = a(k)[] | C = c) ).
+    
+    For each key k and class c, the query also contains a row (k, c, NULL). This
+    is for technical reasons (we want every key-class pair to appear in the
+    query. NULL serves as a default value if there is insufficient training data
+    to compute a probability value).
 
     @param numAttrs Number of attributes to use for classification
     @param classifySource Name of the relation that contains data to be classified
@@ -228,58 +232,48 @@ def __get_keys_and_prob_values_sql(**kwargs):
     # {classifySource} cannot be a subquery, because we use it more than once in
     # our generated SQL.
     return """
-   SELECT t3.key as key, t3.class as class, log(max(t3.class_cnt)::DOUBLE PRECISION / max(t3.all_cnt)::DOUBLE PRECISION) + sum(t3.log_prob) as log_prob
-   FROM (
-	SELECT
-		t2.key,
-		t2.class,
-		t2.attr,
-		t2.cvalue,
-		max(t2.fpValue) as fpValue, max(t2.fp_cnt) as fp_cnt,
-		max(t2.fp_attr_cnt) as fp_attr_cnt, t2.class_cnt, t2.all_cnt,
-		log((COALESCE(max(t2.fp_cnt),0) + {smoothingFactor})::DOUBLE PRECISION/(t2.class_cnt + {smoothingFactor} * max(t2.fp_attr_cnt))::DOUBLE PRECISION) as log_prob
-    FROM (
-		SELECT t1.key, t1.class, t1.attr, t1.cvalue, unnest(t1.fpvalue) as fpValue, unnest(t1.fp_cnt) as fp_cnt, t1.fp_attr_cnt, t1.class_cnt, t1.all_cnt
-		FROM (
-			SELECT
-				classify.key,
-				featureprobs.class,
-				classify.attr, max(classify.value) as cvalue,
-				max(classify.value)::FLOAT8 ||
-                    m4_ifdef(<!__GREENPLUM__!>,<!m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,,<!
-                        {schema_madlib}.!>)!>)
-                    array_agg(featureprobs.value)::FLOAT8[] as fpvalue,
-				0::BIGINT ||
-                    m4_ifdef(<!__GREENPLUM__!>,<!m4_ifdef(<!__HAS_ORDERED_AGGREGATES__!>,,<!
-                        {schema_madlib}.!>)!>)
-                    array_agg(featureprobs.cnt)::BIGINT[] as fp_cnt,
-				max(featureprobs.attr_cnt) as fp_attr_cnt,
-				classpriors.class_cnt,
-				classpriors.all_cnt
-			FROM
-					{classPriorsSource} AS classpriors,
-					{featureProbsSource} AS featureprobs,
-					(
-						SELECT
-							classifysource.{classifyKeyColumn} AS key,
-							generate_series(1, {numAttrs}) AS attr,
-							unnest(classifysource.{classifyAttrColumn}) AS value
-                        FROM
-							{classifySource} AS classifysource
-					) AS classify
-            WHERE
-					featureProbs.class = classPriors.class AND
-					featureProbs.attr = classify.attr
-			GROUP BY
-					classify.key, featureprobs.class, classify.attr, classpriors.class_cnt, classpriors.all_cnt
-		) t1
-	) t2
-	WHERE
-		t2.cvalue = t2.fpValue AND
-		{smoothingFactor} > 0 -- prevent division by 0
-	GROUP BY t2.key, t2.class, t2.attr, t2.cvalue, t2.class_cnt, t2.all_cnt
-   ) t3
-   GROUP BY t3.key, t3.class
+    SELECT t2.key, t2.class, t1.log_prob FROM
+    (
+        SELECT
+            classify.key,
+            classPriors.class,
+            CASE WHEN count(*) < {numAttrs} THEN NULL
+                 ELSE
+                    log(classPriors.class_cnt::DOUBLE PRECISION / classPriors.all_cnt)
+                    + sum( log((featureProbs.cnt::DOUBLE PRECISION + {smoothingFactor})
+                        / (classPriors.class_cnt + {smoothingFactor} * featureProbs.attr_cnt)) )
+                 END
+            AS log_prob
+        FROM
+            {featureProbsSource} AS featureProbs,
+            {classPriorsSource} AS classPriors,
+            (
+                SELECT
+                    classifySource.{classifyKeyColumn} AS key,
+                    generate_series(1, {numAttrs}) AS attr,
+                    unnest(classifySource.{classifyAttrColumn}) AS value
+                FROM
+                    {classifySource} AS classifySource
+            ) AS classify
+        WHERE
+            featureProbs.class = classPriors.class AND
+            featureProbs.attr = classify.attr AND
+            featureProbs.value = classify.value AND
+            ({smoothingFactor} > 0 OR featureProbs.cnt > 0) -- prevent division by 0
+        GROUP BY
+            classify.key, classPriors.class, classPriors.class_cnt, classPriors.all_cnt
+    ) t1
+    RIGHT OUTER JOIN
+    (
+        SELECT
+            classify.{classifyKeyColumn} AS key,
+            classes.class
+        FROM
+            {classifySource} AS classify,
+            {classPriorsSource} AS classes
+        GROUP BY classify.{classifyKeyColumn}, classes.class
+    ) t2 
+    ON t1.key = t2.key AND t1.class=t2.class
     """.format(**kwargs)
 
 
@@ -287,10 +281,10 @@ def __get_prob_values_sql(**kwargs):
     """
     Return SQL query with columns (class, log_prob), given an array of
     attributes.
-
+    
     The query binds to an attribute array a[]. For every class c, log_prob
     is log( P(C = c) * P(A = a[] | C = c) ).
-
+    
     @param classifyAttrColumn Array of attributes to bind to. This can be
            a column name of an outer query or a literal.
     @param smoothingFactor Smoothing factor to use for estimating the feature
@@ -303,7 +297,7 @@ def __get_prob_values_sql(**kwargs):
     @param featureProbsSource
            Relation (class, attr, value, cnt, attr_cnt) where
            (class, attr, value) = (c,i,a), cnt = \#(c,i,a), and attr_cnt = \#i
-
+    
     Note that unless \em classifyAttrColumn is a literal, the SQL query will
     become a correlated subquery and will not work in Greenplum.
 
@@ -339,9 +333,9 @@ def __get_prob_values_sql(**kwargs):
         featureProbs.attr = classify.__attr AND featureProbs.value = classify.value AND
         ({smoothingFactor} > 0 OR featureProbs.cnt > 0) -- prevent division by 0
     GROUP BY classPriors.class, classPriors.class_cnt, classPriors.all_cnt
-
+    
     UNION
-
+    
     SELECT
         classes.class,
         NULL
@@ -353,9 +347,9 @@ def __get_prob_values_sql(**kwargs):
 def __get_classification_sql(**kwargs):
     """
     Return SQL query with columns (key, nb_classification, nb_log_probability)
-
+    
     @param keys_and_prob_values Relation (key, class, log_prob)
-
+    
     """
 
     kwargs.update(
@@ -378,36 +372,36 @@ def create_prepared_data_table(**kwargs):
 
 def create_prepared_data(**kwargs):
     """Precompute all class priors and feature probabilities.
-
+    
     When the precomputations are stored in a table, this function will create
     indices that speed up lookups necessary for Naive Bayes classification.
     Moreover, it runs ANALYZE on the new tables to allow for optimized query
     plans.
-
+    
     Class priors are stored in a relation with columns
     (class, class_cnt, all_cnt).
-
+    
     @param trainingSource Name of relation containing the training data
     @param trainingClassColumn Name of class column in training data
-    @param trainingAttrColumn Name of attributes-array column in training data
+    @param trainingAttrColumn Name of attributes-array column in training data  
     @param numAttrs Number of attributes to use for classification
-
+    
     @param whatToCreate (Optional) Either \c 'TABLE' OR \c 'VIEW' (the default).
     @param classPriorsDestName Name of class-priors relation to create
-    @param featureProbsDestName Name of feature-probabilities relation to create
-
+    @param featureProbsDestName Name of feature-probabilities relation to create 
+        
     """
     if not kwargs.has_key('numAttrs'):
         plpy.error("'numAttrs' must be provided")
-
+    
     if not kwargs.has_key('trainingSource'):
         plpy.error("'trainingSource' must be provided")
 
     if not kwargs.has_key('trainingAttrColumn'):
         plpy.error("'trainingAttrColumn' must be provided")
 
-    __verify_attr_num(
-        kwargs["trainingSource"],
+    __verify_attr_num( 
+        kwargs["trainingSource"], 
         kwargs["trainingAttrColumn"],
         kwargs["numAttrs"])
 
@@ -424,7 +418,7 @@ def create_prepared_data(**kwargs):
             {attr_counts_sql};
             ALTER TABLE {attrCountsSource} ADD PRIMARY KEY (attr);
             ANALYZE {attrCountsSource};
-
+            
             DROP TABLE IF EXISTS {attrValuesSource};
             CREATE TEMPORARY TABLE {attrValuesSource}
             AS
@@ -454,7 +448,7 @@ def create_prepared_data(**kwargs):
             ALTER TABLE {classPriorsDestName} ADD PRIMARY KEY (class);
             ANALYZE {classPriorsDestName};
             """.format(**kwargs))
-
+    
     kwargs.update(dict(
             classPriorsSource = kwargs['classPriorsDestName']
         ))
@@ -476,7 +470,7 @@ def create_prepared_data(**kwargs):
 
 
 def create_classification_view(**kwargs):
-    """Wrapper around create_classification() to create a view (and not a table)
+    """Wrapper around create_classification() to create a view (and not a table) 
     """
     kwargs.update(whatToCreate = 'VIEW')
     create_classification(**kwargs)
@@ -485,11 +479,11 @@ def create_classification_view(**kwargs):
 def create_classification(**kwargs):
     """
     Create a view/table with columns (key, nb_classification).
-
+    
     The created relation will be
-
+    
     <tt>{TABLE|VIEW} <em>destName</em> (key, nb_classification)</tt>
-
+    
     where \c nb_classification is an array containing the most likely
     class(es) of the record in \em classifySource identified by \c key.
 
@@ -520,10 +514,10 @@ def create_classification(**kwargs):
     @param trainingClassColumn
            Name of class column in training data
     @param trainingAttrColumn
-           Name of attributes-array column in \em trainingSource
+           Name of attributes-array column in \em trainingSource    
 
     """
-
+    
     __init_prepared_data(kwargs)
 
     if kwargs.has_key('trainingSource') <> kwargs.has_key('trainingAttrColumn'):
@@ -531,10 +525,10 @@ def create_classification(**kwargs):
 
     if not kwargs.has_key('numAttrs'):
         plpy.error("'numAttrs' must be provided")
-
+    
     if 'trainingSource' in kwargs:
-        __verify_attr_num(
-            kwargs["trainingSource"],
+        __verify_attr_num( 
+            kwargs["trainingSource"], 
             kwargs["trainingAttrColumn"],
             kwargs["numAttrs"])
 
@@ -544,11 +538,11 @@ def create_classification(**kwargs):
     if not kwargs.has_key('classifyAttrColumn'):
         plpy.error("'classifyAttrColumn' must be provided")
 
-    __verify_attr_num(
-        kwargs["classifySource"],
+    __verify_attr_num( 
+        kwargs["classifySource"], 
         kwargs["classifyAttrColumn"],
         kwargs["numAttrs"])
-
+    
     kwargs.update(
         keys_and_prob_values = "(" + __get_keys_and_prob_values_sql(**kwargs) + ")"
         )
@@ -563,21 +557,21 @@ def create_classification(**kwargs):
 
 
 def create_bayes_probabilities_view(**kwargs):
-    """Wrapper around create_bayes_probabilities() to create a view (and not a table)
+    """Wrapper around create_bayes_probabilities() to create a view (and not a table) 
     """
     kwargs.update(whatToCreate = 'VIEW')
     create_bayes_probabilities(**kwargs)
 
 def create_bayes_probabilities(**kwargs):
     """Create table/view with columns (key, class, nb_prob)
-
+    
     The created relation will be
-
+    
     <tt>{TABLE|VIEW} <em>destName</em> (key, class, nb_prob)</tt>
-
+    
     where \c nb_prob is the Naive-Bayes probability that \c class is the true
     class of the record in \em classifySource identified by \c key.
-
+    
     There are two sets of arguments this function can be called with. The
     following parameters are always needed:
     @param numAttrs Number of attributes to use for classification
@@ -601,8 +595,8 @@ def create_bayes_probabilities(**kwargs):
     @param trainingClassColumn
            Name of class column in training data
     @param trainingAttrColumn
-           Name of attributes-array column in training data
-
+           Name of attributes-array column in training data 
+    
     @internal
     \par Implementation Notes:
 
@@ -612,7 +606,7 @@ def create_bayes_probabilities(**kwargs):
  P(C = c) = ---------------------------------    (*)
             --
             \   P(C = c') * P(A = a | C = c')
-            /_
+            /_ 
               c'
                          __
 where P(A = a | C = c) = ||  P(A_i = a_i | C = c).
@@ -642,10 +636,10 @@ where P(A = a | C = c) = ||  P(A_i = a_i | C = c).
 
     if not kwargs.has_key('numAttrs'):
         plpy.error("'numAttrs' must be provided")
-
+    
     if 'trainingSource' in kwargs:
-        __verify_attr_num(
-            kwargs["trainingSource"],
+        __verify_attr_num( 
+            kwargs["trainingSource"], 
             kwargs["trainingAttrColumn"],
             kwargs["numAttrs"])
 
@@ -655,8 +649,8 @@ where P(A = a | C = c) = ||  P(A_i = a_i | C = c).
     if not kwargs.has_key('classifyAttrColumn'):
         plpy.error("'classifyAttrColumn' must be provided")
 
-    __verify_attr_num(
-        kwargs["classifySource"],
+    __verify_attr_num( 
+        kwargs["classifySource"], 
         kwargs["classifyAttrColumn"],
         kwargs["numAttrs"])
 
@@ -690,13 +684,13 @@ where P(A = a | C = c) = ||  P(A_i = a_i | C = c).
 def create_classification_function(**kwargs):
     """Create a SQL function mapping arrays of attribute values to the Naive
     Bayes classification.
-
+    
     The created SQL function will be:
-
+    
     <tt>
     FUNCTION <em>destName</em> (attributes INTEGER[], smoothingFactor DOUBLE PRECISION)
     RETURNS INTEGER[]</tt>
-
+    
     There are two sets of arguments this function can be called with. The
     following parameters are always needed:
     @param classifyAttrColumn Array of attributes to bind to. This can be
@@ -717,8 +711,8 @@ def create_classification_function(**kwargs):
     Or have this function operate on the "raw" training data:
     @param trainingSource Name of relation containing the training data
     @param trainingClassColumn Name of class column in training data
-    @param trainingAttrColumn Name of attributes-array column in training data
-
+    @param trainingAttrColumn Name of attributes-array column in training data  
+    
     Note: Greenplum does not support executing STABLE and VOLATILE functions on
     segments. The created function can therefore only be called on the master.
     """
@@ -748,10 +742,10 @@ def __init_prepared_data(kwargs):
     a relation.
 
     """
-
+    
     if not 'classPriorsSource' in kwargs:
         kwargs.update(dict(
-                classPriorsSource = "(" + __get_class_priors_sql(**kwargs) + ")"
+                classPriorsSource = "(" + __get_class_priors_sql(**kwargs) + ")" 
             ))
     if not 'featureProbsSource' in kwargs:
         kwargs.update(dict(
@@ -775,6 +769,4 @@ def __verify_attr_num(sourceTable, attrColumn, numAttr):
     dsize = result[0]['size']
     if (dsize <> 0):
         plpy.error('found %d records in "%s" where "%s" was not of expected length (%d)'\
-            % (dsize, sourceTable, attrColumn, numAttr))
-
-m4_changequote(<!`!>,<!'!>)
+            % (dsize, sourceTable, attrColumn, numAttr))    

--- a/src/ports/postgres/modules/bayes/bayes.sql_in
+++ b/src/ports/postgres/modules/bayes/bayes.sql_in
@@ -1,4 +1,4 @@
-/* ----------------------------------------------------------------------- *//**
+/* ----------------------------------------------------------------------- *//** 
  *
  * @file bayes.sql_in
  *
@@ -140,7 +140,7 @@ can by verified by hand.
 -#  The training and the classification data:
 \verbatim
 sql> SELECT * FROM training;
- id | class | attributes
+ id | class | attributes 
 ----+-------+------------
   1 |     1 | {1,2,3}
   2 |     1 | {1,2,1}
@@ -151,7 +151,7 @@ sql> SELECT * FROM training;
 (6 rows)
 
 sql> select * from toclassify;
- id | attributes
+ id | attributes 
 ----+------------
   1 | {0,2,1}
   2 | {1,2,3}
@@ -159,20 +159,20 @@ sql> select * from toclassify;
 \endverbatim
 -#  Precompute feature probabilities and class priors
 \verbatim
-sql> SELECT madlib.create_nb_prepared_data_tables(
+sql> SELECT madlib.create_nb_prepared_data_tables( 
 'training', 'class', 'attributes', 3, 'nb_feature_probs', 'nb_class_priors');
 \endverbatim
 -#  Optionally check the contents of the precomputed tables:
 \verbatim
 sql> SELECT * FROM nb_class_priors;
- class | class_cnt | all_cnt
+ class | class_cnt | all_cnt 
 -------+-----------+---------
      1 |         3 |       6
      2 |         3 |       6
 (2 rows)
 
 sql> SELECT * FROM nb_feature_probs;
- class | attr | value | cnt | attr_cnt
+ class | attr | value | cnt | attr_cnt 
 -------+------+-------+-----+----------
      1 |    1 |     0 |   0 |        2
      1 |    1 |     1 |   3 |        2
@@ -186,7 +186,7 @@ sql> SELECT madlib.create_nb_classify_view (
 'nb_feature_probs', 'nb_class_priors', 'toclassify', 'id', 'attributes', 3, 'nb_classify_view_fast');
 
 sql> SELECT * FROM nb_classify_view_fast;
- key | nb_classification
+ key | nb_classification 
 -----+-------------------
    1 | {2}
    2 | {1}
@@ -198,7 +198,7 @@ sql> SELECT madlib.create_nb_probs_view (
 'nb_feature_probs', 'nb_class_priors', 'toclassify', 'id', 'attributes', 3, 'nb_probs_view_fast');
 
 sql> SELECT * FROM nb_probs_view_fast;
- key | class | nb_prob
+ key | class | nb_prob 
 -----+-------+---------
    1 |     1 |     0.4
    1 |     2 |     0.6
@@ -381,7 +381,7 @@ LANGUAGE plpythonu VOLATILE;
  *    <em>numAttrs</em>, '<em>destName</em>'
  *);</pre>
  * -# Show Naive Bayes classifications:
- *    <pre>SELECT * FROM <em>destName</em>;</pre>
+ *    <pre>SELECT * FROM <em>destName</em>;</pre>  
  *
  * @internal
  * @sa This function is a wrapper for bayes::create_classification(). See there
@@ -415,18 +415,18 @@ LANGUAGE plpythonu VOLATILE;
 
 /**
  * @brief Create view with columns <tt>(key, class, nb_prob)</tt>
- *
+ * 
  * The created view will be of the following form:
- *
+ * 
  * <pre>VIEW <em>destName</em> (
  *    key ANYTYPE,
  *    class INTEGER,
  *    nb_prob FLOAT8
  *)</pre>
- *
+ * 
  * where \c nb_prob is the Naive-Bayes probability that \c class is the true
  * class of the record in \em classifySource identified by \c key.
- *
+ * 
  * @param featureProbsSource Name of table with precomputed feature
  *        probabilities, as created with create_nb_prepared_data_tables()
  * @param classPriorsSource Name of table with precomputed class priors, as
@@ -449,7 +449,7 @@ LANGUAGE plpythonu VOLATILE;
  *    <em>numAttrs</em>, '<em>destName</em>'
  *);</pre>
  * -# Show Naive Bayes probabilities:
- *    <pre>SELECT * FROM <em>destName</em>;</pre>
+ *    <pre>SELECT * FROM <em>destName</em>;</pre>  
  *
  * @internal
  * @sa This function is a wrapper for bayes::create_bayes_probabilities().
@@ -483,17 +483,17 @@ LANGUAGE plpythonu VOLATILE;
 /**
  * @brief Create a SQL function mapping arrays of attribute values to the Naive
  *        Bayes classification.
- *
+ * 
  * The created SQL function is bound to the given feature probabilities and
  * class priors. Its declaration will be:
- *
+ * 
  * <tt>
  * FUNCTION <em>destName</em> (attributes INTEGER[], smoothingFactor DOUBLE PRECISION)
  * RETURNS INTEGER[]</tt>
  *
  * The return type is \c INTEGER[] because the Naive Bayes classification might
  * be ambiguous (in which case all of the most likely candiates are returned).
- *
+ * 
  * @param featureProbsSource Name of table with precomputed feature
  *        probabilities, as created with create_nb_prepared_data_tables()
  * @param classPriorsSource Name of table with precomputed class priors, as


### PR DESCRIPTION
JIRA: MADLIB-745, MADLIB-746
Revert to old Naive Bayes to avoid out-of-memory error and performance regression.  Still need to check for correctness (MADLIB-679).
