### PR TITLE
Naive Bayes: Explanations added to documentation for several possible

### DIFF
--- a/src/ports/postgres/modules/bayes/bayes.sql_in
+++ b/src/ports/postgres/modules/bayes/bayes.sql_in
@@ -74,6 +74,26 @@ where
 The case \f$ s = 1 \f$ is known as "Laplace smoothing". The case \f$ s = 0 \f$
 trivially reduces to maximum-likelihood estimates.
 
+\b Note:
+(1) The probabilities computed on the platforms of PostgreSQL and Greenplum database have very tiny
+difference due to the nature of floating point computation. Usually this is not important. However, if
+a data point has
+\f[
+P(C=c_i \mid A) \approx P(C=c_j \mid A)
+\f]
+for two classes, this data point might be classified into diferent classes on PostgreSQL and Greenplum. This
+leads to the classifications with a small difference on PostgreSQL and Greenplum for some data sets, but this does
+not affect the quality of the results.
+
+(2) The current implementation of Naive Bayes classification is only suitable for discontinuous attributes.
+
+For continuous
+data, a typical assumption, which is used usually for small data sets,  is that the continuous values associated with each class are distributed according to a Gaussian distribution,
+and then the probabilities \f$ P(A_i = a \mid C=c) \f$ can be estimated. Another common technique for handling continuous values, which is better for large data sets, is to use binning
+to discretize the values, and convert the continuous data into discontinuous [2]. The naive Bayes classification for continuous data will be implemented in the future version of MADlib.
+
+(3) One can still feed continuous data into the naive Bayes classification function. No warning is raised, but the result is not correct.
+
 @input
 
 The <b>training data</b> is expected to be of the following form:


### PR DESCRIPTION
problems

Jira MADlib-679

(1) The probabilities computed on the platforms of PostgreSQL and Greenplum
database have very tiny difference due to the nature of floating point
computation. Usually this is not important. However, if a data point has
equal (or very close) probabilities for two classes, this data point might
be classified into diferent classes on PostgreSQL and Greenplum. This leads
to the classifications with a small difference on PostgreSQL and Greenplum
for some data sets, but does not affect the quality of the results.

(2) The current implementation of Naive Bayes classification is only suitable
for discontinuous attributes.

(3) One can still feed continuous data into the naive Bayes classification
function. No warning is raised, but the result is not correct.
