### PR TITLE
NB Documentation: Add more explanation for classification

### DIFF
--- a/src/ports/postgres/modules/bayes/bayes.sql_in
+++ b/src/ports/postgres/modules/bayes/bayes.sql_in
@@ -86,7 +86,10 @@ PostgreSQL and Greenplum. This leads to the differences in classifications
 on PostgreSQL and Greenplum for some data sets, but this should not
 affect the quality of the results.
 
-(2) The current implementation of Naive Bayes classification is only suitable
+(2) When the probabilities for the two classes are exactly equal, the result is 
+an array of these two classes, but the order of the two classes is random. 
+
+(3) The current implementation of Naive Bayes classification is only suitable
 for discontinuous (categorial) attributes.
 
 For continuous data, a typical assumption, usually used for small datasets,
@@ -97,10 +100,11 @@ Another common technique for handling continuous values, which is better for
 large data sets, is to use binning to discretize the values, and convert the
 continuous data into nominal bins.
 
-(3) One can still provide continuous (floating point) data to the naive Bayes
-classification function. No warning is raised, but the result may not be as
-expected. The classification would work best if there are sufficient duplicate
-data points for each floating point value.
+(4) One can still provide continuous (floating point) data to the naive Bayes
+classification function. Floating point numbers can be used as categorial data. 
+The classification would work best if there are sufficient duplicate data points 
+for each floating point value. However, if one wants to use floating point number as
+continuous data, the result may not be as expected and no warning is raised. 
 
 @input
 


### PR DESCRIPTION
Jira: MADlib-679

When the probabilities for the two classes are exactly equal, the result is
an array of these two classes, but the order of the two classes is random.

One can still provide continuous (floating point) data to the naive Bayes
classification function. Floating point numbers can be used as categorial data.
