### PR TITLE
Naive Bayes: Fix the missing value in the result

### DIFF
--- a/src/ports/postgres/modules/bayes/bayes.py_in
+++ b/src/ports/postgres/modules/bayes/bayes.py_in
@@ -107,7 +107,7 @@ def __get_feature_probs_sql(**kwargs):
         """.format(**kwargs)
 
 
-def __get_attr_values_sql(**kwargs):
+def __get_attr_values_sql(**kwargs): # need to filter out NULL values
     """
     Return SQL query with columns (attr, value).
 
@@ -232,17 +232,42 @@ def __get_keys_and_prob_values_sql(**kwargs):
     # {classifySource} cannot be a subquery, because we use it more than once in
     # our generated SQL.
     return """
-    SELECT t2.key, t2.class, t1.log_prob FROM
+    SELECT t1.key, t1.class,
+    CASE WHEN {smoothingFactor} = 0 THEN
+      t1.log_prob
+    ELSE
+      -- log_prob is separated into two parts:
+      --     The following part of log_prob is for denominators, whose number should always be {numAttrs}.
+      -- A strange thing: When all of this query is put into a function definition, all branches of "case" will be kind of evaluated
+      --     and if {smoothingFactor} is 0 at this point, we will have "logrithm of zero" error. Since we are going to re-use
+      --     this code in __get_prob_values_sql, where everything will be put into a function definition, we have to use
+      --     a small trick to avoid this error: use "case when $2=0 then 1 else $2 end" inside log(), which is "sf" in the following.
+      --     This happens on both GPDB and PG
+     (t1.log_prob + sum(log(sf / (classPriors.class_cnt + ({smoothingFactor}::DOUBLE PRECISION) * attrCnts.attr_cnt))) )
+    END
+    AS log_prob
+    FROM
     (
         SELECT
             classify.key,
             classPriors.class,
-            CASE WHEN count(*) < {numAttrs} THEN NULL
+            CASE WHEN count(*) < {numAttrs} AND {smoothingFactor} = 0 -- smoothing factor < 0 case is dealt with in
+                                                                      --     create_classification_function
+                                                                      --     which is the only place that smoothing
+                                                                      --     factor can be different from 1
+                 THEN
+                    NULL
+                 WHEN {smoothingFactor} = 0 THEN -- train set has all the values
+                       log(classPriors.class_cnt::DOUBLE PRECISION / classPriors.all_cnt)
+                     + sum( log(featureProbs.cnt::DOUBLE PRECISION / classPriors.class_cnt) )
                  ELSE
-                    log(classPriors.class_cnt::DOUBLE PRECISION / classPriors.all_cnt)
-                    + sum( log((featureProbs.cnt::DOUBLE PRECISION + {smoothingFactor})
-                        / (classPriors.class_cnt + {smoothingFactor} * featureProbs.attr_cnt)) )
-                 END
+                      -- log_prob is separated into two parts:
+                      --     The part here is mainly for numerators, whose number might be smaller
+                      --     than {numAttrs} if the test set has values that are not in the training
+                      --     set. The prior probability is also included.
+                        log(classPriors.class_cnt::DOUBLE PRECISION / classPriors.all_cnt)
+                    + sum( log(featureProbs.cnt::DOUBLE PRECISION / sf + 1) )
+            END
             AS log_prob
         FROM
             {featureProbsSource} AS featureProbs,
@@ -254,26 +279,24 @@ def __get_keys_and_prob_values_sql(**kwargs):
                     unnest(classifySource.{classifyAttrColumn}) AS value
                 FROM
                     {classifySource} AS classifySource
-            ) AS classify
+            ) AS classify,
+            (select case when {smoothingFactor}=0 then 1 else {smoothingFactor} end as sf) as foo
         WHERE
             featureProbs.class = classPriors.class AND
             featureProbs.attr = classify.attr AND
             featureProbs.value = classify.value AND
-            ({smoothingFactor} > 0 OR featureProbs.cnt > 0) -- prevent division by 0
+            (featureProbs.cnt > 0) 
         GROUP BY
             classify.key, classPriors.class, classPriors.class_cnt, classPriors.all_cnt
-    ) t1
-    RIGHT OUTER JOIN
-    (
-        SELECT
-            classify.{classifyKeyColumn} AS key,
-            classes.class
-        FROM
-            {classifySource} AS classify,
-            {classPriorsSource} AS classes
-        GROUP BY classify.{classifyKeyColumn}, classes.class
-    ) t2
-    ON t1.key = t2.key AND t1.class=t2.class
+    ) AS t1,
+        (select distinct class, attr, attr_cnt from {featureProbsSource}) AS attrCnts,
+        {classPriorsSource} AS classPriors,
+        (select case when {smoothingFactor}=0 then 1 else {smoothingFactor} end as sf) as foo
+    WHERE
+        classPriors.class = t1.class AND
+        attrCnts.class = t1.class
+    GROUP BY
+        t1.key, t1.class, t1.log_prob
     """.format(**kwargs)
 
 
@@ -302,47 +325,16 @@ def __get_prob_values_sql(**kwargs):
     become a correlated subquery and will not work in Greenplum.
 
     """
+    # Re-use the computation code from __get_keys_and_prob_values_sql
+    # We just need to attach a classifyKeyColumn to the array
+    # since there is only one row, we can set 1 as the key column
+    kwargs.update(
+        classifySource = "(SELECT 1 AS id, {classifyAttrColumn} AS attrColumn)".format(**kwargs),
+        classifyKeyColumn = "id",
+        classifyAttrColumn = "attrColumn"
+    )
 
-    # {classifyAttrColumn} binds to a names declared outside of the following
-    # SQL. We need to ensure that ther are no conflicting names with
-    # {classifyAttrColumn}. Therefore, we only introduce the unusual name
-    # __attr. Note that by the structure of the query, there can be no other
-    # name conflicts.
-    return """
-    SELECT
-        classPriors.class,
-        CASE WHEN count(*) < {numAttrs} THEN NULL
-             ELSE
-                log(classPriors.class_cnt::DOUBLE PRECISION / classPriors.all_cnt)
-                + sum( log((featureProbs.cnt::DOUBLE PRECISION + {smoothingFactor})
-                    / (classPriors.class_cnt + {smoothingFactor} * featureProbs.attr_cnt)) )
-             END
-        AS log_prob
-    FROM
-        {featureProbsSource} AS featureProbs,
-        {classPriorsSource} AS classPriors,
-        (
-            SELECT
-                __attr.__attr,
-                {classifyAttrColumn}[__attr.__attr] AS value
-            FROM
-                generate_series(1, {numAttrs}) AS __attr
-        ) AS classify
-    WHERE
-        featureProbs.class = classPriors.class AND
-        featureProbs.attr = classify.__attr AND featureProbs.value = classify.value AND
-        ({smoothingFactor} > 0 OR featureProbs.cnt > 0) -- prevent division by 0
-    GROUP BY classPriors.class, classPriors.class_cnt, classPriors.all_cnt
-
-    UNION
-
-    SELECT
-        classes.class,
-        NULL
-    FROM
-        {classPriorsSource} AS classes
-    """.format(**kwargs)
-
+    return __get_keys_and_prob_values_sql(**kwargs)
 
 def __get_classification_sql(**kwargs):
     """
@@ -405,6 +397,8 @@ def create_prepared_data(**kwargs):
         kwargs["trainingAttrColumn"],
         kwargs["numAttrs"])
 
+    oldMsgLevel = plpy.execute("SELECT setting FROM pg_settings WHERE name='client_min_messages'")[0]['setting']
+    
     if kwargs['whatToCreate'] == 'TABLE':
         # FIXME: ANALYZE is not portable.
         kwargs.update(dict(
@@ -412,6 +406,8 @@ def create_prepared_data(**kwargs):
             attrValuesSource = '_madlib_nb_attr_values'
         ))
         plpy.execute("""
+            SET client_min_messages = error;
+
             DROP TABLE IF EXISTS {attrCountsSource};
             CREATE TEMPORARY TABLE {attrCountsSource}
             AS
@@ -425,11 +421,14 @@ def create_prepared_data(**kwargs):
             {attr_values_sql};
             ALTER TABLE {attrValuesSource} ADD PRIMARY KEY (attr, value);
             ANALYZE {attrValuesSource};
+
+            SET client_min_messages = {oldMsgLevel};
             """.format(
                 attrCountsSource = kwargs['attrCountsSource'],
                 attrValuesSource = kwargs['attrValuesSource'],
                 attr_counts_sql = "(" + __get_attr_counts_sql(**kwargs) + ")",
-                attr_values_sql = "(" + __get_attr_values_sql(**kwargs) + ")"
+                attr_values_sql = "(" + __get_attr_values_sql(**kwargs) + ")",
+                oldMsgLevel = oldMsgLevel
                 )
             )
 
@@ -437,6 +436,9 @@ def create_prepared_data(**kwargs):
     kwargs.update(dict(
             sql = __get_class_priors_sql(**kwargs)
         ))
+
+    kwargs.update(oldMsgLevel = oldMsgLevel)
+    
     plpy.execute("""
         CREATE {whatToCreate} {classPriorsDestName}
         AS
@@ -445,8 +447,10 @@ def create_prepared_data(**kwargs):
         )
     if kwargs['whatToCreate'] == 'TABLE':
         plpy.execute("""
+            SET client_min_messages = error;
             ALTER TABLE {classPriorsDestName} ADD PRIMARY KEY (class);
             ANALYZE {classPriorsDestName};
+            SET client_min_messages = {oldMsgLevel};
             """.format(**kwargs))
 
     kwargs.update(dict(
@@ -460,12 +464,17 @@ def create_prepared_data(**kwargs):
         {sql}
         """.format(**kwargs)
         )
+    
     if kwargs['whatToCreate'] == 'TABLE':
         plpy.execute("""
+            SET client_min_messages = error;
+                     
             ALTER TABLE {featureProbsDestName} ADD PRIMARY KEY (class, attr, value);
             ANALYZE {featureProbsDestName};
             DROP TABLE {attrCountsSource};
             DROP TABLE {attrValuesSource};
+                     
+            SET client_min_messages = {oldMsgLevel};      
             """.format(**kwargs))
 
 
@@ -720,19 +729,45 @@ def create_classification_function(**kwargs):
         classifyAttrColumn = "$1",
         smoothingFactor = "$2"
         ))
+    
     __init_prepared_data(kwargs)
+
     kwargs.update(
         keys_and_prob_values = "(" + __get_prob_values_sql(**kwargs) + ")"
         )
+
+    oldMsgLevel = plpy.execute("SELECT setting FROM pg_settings WHERE name='client_min_messages'")[0]['setting']
+    kwargs.update(oldMsgLevel = oldMsgLevel)
+    
     plpy.execute("""
         CREATE FUNCTION {destName} (inAttributes INTEGER[], inSmoothingFactor DOUBLE PRECISION)
         RETURNS INTEGER[] AS
         $$
+        DECLARE rst INTEGER[];
+        BEGIN
+            SET client_min_messages = error;
+                 
+            IF inSmoothingFactor < 0 THEN
+                 RAISE EXCEPTION 'Smoothing factor cannot be smaller than 0!';
+            END IF;
+
+            DROP TABLE IF EXISTS __inter_results_bayes;
+            CREATE TEMP TABLE __inter_results_bayes AS (SELECT * FROM {keys_and_prob_values} AS key_and_nb_values);
+
+            IF (SELECT count(*)>0 FROM __inter_results_bayes WHERE log_prob is NULL) THEN
+                 RAISE EXCEPTION 'Smoothing factor cannot be 0 if test set has values not in training set!';
+            END IF;
+             
             SELECT
                 {schema_madlib}.argmax(class, log_prob)
-            FROM {keys_and_prob_values} AS key_and_nb_values
+            FROM __inter_results_bayes INTO rst;
+
+            SET client_min_messages = {oldMsgLevel};
+                 
+            RETURN rst;
+        END;
         $$
-        LANGUAGE sql STABLE
+        LANGUAGE plpgsql
         """.format(**kwargs))
 
 

--- a/src/ports/postgres/modules/bayes/bayes.sql_in
+++ b/src/ports/postgres/modules/bayes/bayes.sql_in
@@ -74,6 +74,17 @@ where
 The case \f$ s = 1 \f$ is known as "Laplace smoothing". The case \f$ s = 0 \f$
 trivially reduces to maximum-likelihood estimates.
 
+If the test set has values that do not present in the training set, we can still
+use the above equation to compute the probability, where we just let \f$ \#(c,i,a)=0 \f$.
+More specifically, in the computation of logrithm of the probability product, we have
+\f[
+\log \prod_{i=1}^n \Pr(A_i = a_i \mid C = c) = \sum_{i=1}^n \log \Pr(A_i = a_i \mid C = c)
+= \sum_{i=1}^m \log\left(\frac{\#(c,i,a_i)}{s}+1\right) + \sum_{i=1}^n \log\frac{s}{\#c + s\cdot\#i}
+\f]
+where \f$m<n\f$.
+Note that it is an error to use 0 as the smoothing factor in this case, and an exception
+will be raised. 
+
 \b Note:
 (1) The probabilities computed on the platforms of PostgreSQL and Greenplum
 database have a small difference due to the nature of floating point


### PR DESCRIPTION
Jira MADlib-523

When the test set has values that are in the training set, we use the
Laplace smoothing to avoid a NULL output.

Extra changes:
    The computation code is re-used in create_classification_function;
    Documentation is changed to reflect the fix;
    Useless notices and warnings during computation are removed
