### PR TITLE
resolve crf inference bottleneck 

### DIFF
--- a/src/ports/postgres/modules/crf/crf_feature_gen.sql_in
+++ b/src/ports/postgres/modules/crf/crf_feature_gen.sql_in
@@ -244,12 +244,12 @@ $$
     	segment_hashtbl = "pg_temp._madlib_segment_hashtbl"
     	unknown_segment_hashtbl = "pg_temp._madlib_unknown_segment_hashtbl"
     	rtbl = "pg_temp._madlib_rtbl"
-        rtbls = "pg_temp._madlib_rtbls"
+        rtbl_sum = "pg_temp._madlib_rtbl_sum"
     	mtbl = "pg_temp._madlib_mtbl"
     	tmp_segmenttbl = "pg_temp._madlib_tmp_segmenttbl"
     	tmp_dict = "pg_temp._madlib_tmp_dict"
 
-    	plpy.execute("""DROP TABLE IF EXISTS """ + prev_labeltbl + """,""" +  segment_hashtbl + """,""" + unknown_segment_hashtbl + """,""" + rtbl  + """,""" + mtbl + """,""" +  tmp_segmenttbl + """,""" + tmp_dict + """;""")
+    	plpy.execute("""DROP TABLE IF EXISTS """ + prev_labeltbl + """,""" +  segment_hashtbl + """,""" + unknown_segment_hashtbl + """,""" + rtbl  + """,""" + rtbl_sum + """,""" + mtbl + """,""" +  tmp_segmenttbl + """,""" + tmp_dict + """;""")
 
         plpy.execute("""CREATE TABLE """ + prev_labeltbl + """(id int);""")
 
@@ -262,7 +262,7 @@ $$
 
         # Generate a sparse matrix to store the r factors
         plpy.execute("""CREATE  TABLE """ + rtbl  + """ (seg_text text NOT NULL, label integer, value double precision);""")
-        plpy.execute("""CREATE  TABLE """ + rtbls  + """ (seg_text text NOT NULL, label integer, value integer);""")     
+        plpy.execute("""CREATE  TABLE """ + rtbl_sum  + """ (seg_text text NOT NULL, label integer, value integer);""")     
 
         # Generate M factor table
         plpy.execute("""CREATE  TABLE """ + mtbl + """(prev_label integer, label integer, value double precision);""")
@@ -377,7 +377,7 @@ m4_ifdef(`__HAS_ORDERED_AGGREGATES__', `
                         """  + featuretbl + """
                         WHERE  name = 'W_' || seg_text;""")
          
-        plpy.execute("""INSERT INTO """ + rtbls  + """(seg_text, label, value)
+        plpy.execute("""INSERT INTO """ + rtbl_sum  + """(seg_text, label, value)
                         SELECT seg_text,label,(sum(value)*1000)::integer
                         FROM   """ +  rtbl + """
                         GROUP BY seg_text,label;""")
@@ -386,16 +386,16 @@ m4_ifdef(`__HAS_ORDERED_AGGREGATES__', `
 m4_ifdef(`__HAS_ORDERED_AGGREGATES__', `
         plpy.execute("""INSERT INTO """ + viterbi_rtbl + """
                         SELECT seg_text, array_agg(value ORDER BY label)
-                        FROM """ + rtbls + """
+                        FROM """ + rtbl_sum + """
                         GROUP BY seg_text;""")
 ', `
         plpy.execute("""INSERT INTO """ + viterbi_rtbl + """
                         SELECT seg_text,ARRAY(
                             SELECT value
-                            FROM """ + rtbls + """
-                            where rtbl.seg_text=ss.seg_text
+                            FROM """ + rtbl_sum + """
+                            where rtbl_sum.seg_text = ss.seg_text
                             ORDER BY label)
-                        FROM """ + rtbls +""" as ss;""")
+                        FROM """ + rtbl_sum +""" as ss;""")
 ')
 
 $$ LANGUAGE plpythonu STRICT;

--- a/src/ports/postgres/modules/crf/crf_feature_gen.sql_in
+++ b/src/ports/postgres/modules/crf/crf_feature_gen.sql_in
@@ -228,7 +228,7 @@ $$
             """.format(viterbi_mtbl = viterbi_mtbl));
         plpy.execute("""
             CREATE TABLE {viterbi_rtbl}
-            (seg_text text, label integer, score integer);
+            (seg_text text, score integer[]);
             """.format(viterbi_rtbl = viterbi_rtbl))
         # Create index for performance
         plpy.execute("""
@@ -244,6 +244,7 @@ $$
     	segment_hashtbl = "pg_temp._madlib_segment_hashtbl"
     	unknown_segment_hashtbl = "pg_temp._madlib_unknown_segment_hashtbl"
     	rtbl = "pg_temp._madlib_rtbl"
+        rtbls = "pg_temp._madlib_rtbls"
     	mtbl = "pg_temp._madlib_mtbl"
     	tmp_segmenttbl = "pg_temp._madlib_tmp_segmenttbl"
     	tmp_dict = "pg_temp._madlib_tmp_dict"
@@ -261,6 +262,7 @@ $$
 
         # Generate a sparse matrix to store the r factors
         plpy.execute("""CREATE  TABLE """ + rtbl  + """ (seg_text text NOT NULL, label integer, value double precision);""")
+        plpy.execute("""CREATE  TABLE """ + rtbls  + """ (seg_text text NOT NULL, label integer, value integer);""")     
 
         # Generate M factor table
         plpy.execute("""CREATE  TABLE """ + mtbl + """(prev_label integer, label integer, value double precision);""")
@@ -374,11 +376,26 @@ m4_ifdef(`__HAS_ORDERED_AGGREGATES__', `
                         FROM   """ +  segment_hashtbl + """,
                         """  + featuretbl + """
                         WHERE  name = 'W_' || seg_text;""")
+         
+        plpy.execute("""INSERT INTO """ + rtbls  + """(seg_text, label, value)
+                        SELECT seg_text,label,(sum(value)*1000)::integer
+                        FROM   """ +  rtbl + """
+                        GROUP BY seg_text,label;""")
 
         # Factor table
-        plpy.execute("""INSERT INTO """ + viterbi_rtbl + """(seg_text, label, score)
-                        SELECT seg_text,label,(SUM(value)*1000)::integer AS score
-                        FROM   """ + rtbl  + """
-                        GROUP BY seg_text,label;""")
+m4_ifdef(`__HAS_ORDERED_AGGREGATES__', `
+        plpy.execute("""INSERT INTO """ + viterbi_rtbl + """
+                        SELECT seg_text, array_agg(value ORDER BY label)
+                        FROM """ + rtbls + """
+                        GROUP BY seg_text;""")
+', `
+        plpy.execute("""INSERT INTO """ + viterbi_rtbl + """
+                        SELECT seg_text,ARRAY(
+                            SELECT value
+                            FROM """ + rtbls + """
+                            where rtbl.seg_text=ss.seg_text
+                            ORDER BY label)
+                        FROM """ + rtbls +""" as ss;""")
+')
 
 $$ LANGUAGE plpythonu STRICT;

--- a/src/ports/postgres/modules/crf/viterbi.sql_in
+++ b/src/ports/postgres/modules/crf/viterbi.sql_in
@@ -78,7 +78,7 @@ MADLIB_SCHEMA.vcrf_label(segtbl text, factor_mtbl text, factor_rtbl text, labelt
 
   query = """
   -- for each sentence, store array representation of r_factors
-  select doc_id, array_union(score order by start_pos) as score
+  select doc_id, MADLIB_SCHEMA.array_union(score order by start_pos) as score
   into """ + r_factors + """
   from (select doc_id, start_pos, score
         from """ + factor_rtbl + """ factors,

--- a/src/ports/postgres/modules/crf/viterbi.sql_in
+++ b/src/ports/postgres/modules/crf/viterbi.sql_in
@@ -78,20 +78,9 @@ MADLIB_SCHEMA.vcrf_label(segtbl text, factor_mtbl text, factor_rtbl text, labelt
 
   query = """
   -- for each sentence, store array representation of r_factors
-m4_ifdef(`__HAS_ORDERED_AGGREGATES__', `
-  select doc_id, array_agg(score order by start_pos, label) as score
-', `
-  select doc_id, array(
-    select score
-    from """ + factor_rtbl + """ factors,
-         """ + segtbl_digits + """ seg
-    where factors.seg_text = seg.seg_text
-          and doc_id = ss.doc_id
-    order by start_pos, label
-  ) as score
-')
+  select doc_id, array_union(score order by start_pos) as score
   into """ + r_factors + """
-  from (select doc_id, start_pos, label, score
+  from (select doc_id, start_pos, score
         from """ + factor_rtbl + """ factors,
              """ + segtbl_digits + """ seg
         where factors.seg_text=seg.seg_text) as ss


### PR DESCRIPTION
This pull request resolve crf inference bottleneck. 
I changed the schema of viterbi_rtbl from  to  "(seg_text text, score integer[])"  to  "(seg_text text, label integer, score integer)".
This change will make the construction of the  'rfactors' table in the 'vcrf_label' function 44(tag set size -1) times faster ideally. 
