### PR TITLE
kmeans: Fixed the dist_angle metric to return values when norm is 0

### DIFF
--- a/src/modules/linalg/metric.cpp
+++ b/src/modules/linalg/metric.cpp
@@ -7,6 +7,7 @@
  *//* ----------------------------------------------------------------------- */
 
 #include <dbconnector/dbconnector.hpp>
+#include <limits>
 
 #include "metric.hpp"
 
@@ -114,7 +115,14 @@ distAngle(
     const MappedColumnVector& inX,
     const MappedColumnVector& inY) {
 
-    double cosine = dot(inX, inY) / (inX.norm() * inY.norm());
+	// Deal with the undefined case where one of the norm is zero
+	// Angle is not defined. Just return \pi.
+	double xnorm = inX.norm(), ynorm = inY.norm();
+	if (xnorm < std::numeric_limits<double>::denorm_min()
+		|| ynorm < std::numeric_limits<double>::denorm_min())
+		return std::acos(-1);
+	
+    double cosine = dot(inX, inY) / (xnorm * ynorm);
     if (cosine > 1)
         cosine = 1;
     else if (cosine < -1)


### PR DESCRIPTION
Jira MADlib-768

When distance metric 'madlib.dist_angle' is used, which is defined
as the angle between two vectors, Inf is obtained when either of the two
norms is 0. The angle is not defined mathematically. Just let the metric
return \pi under such circumstances to avoid error. This should not
affect the qulity of the result.
