### PR TITLE
cart: allow BIGINT for rf_train

### DIFF
--- a/methods/cart/src/pg_gp/dt.sql_in
+++ b/methods/cart/src/pg_gp/dt.sql_in
@@ -1853,18 +1853,18 @@ LANGUAGE C STRICT VOLATILE;
 CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.__sample_with_replacement
     ( 
     num_of_tree     INT,
-    size_per_tree   INT, 
+    size_per_tree   BIGINT, 
     src_table       TEXT,
     target_table    TEXT
     ) 
 RETURNS VOID AS $$
 DECLARE
     segment_num     INT;
-    sample_per_seg  INT;
+    sample_per_seg  BIGINT;
     sample_ratio    FLOAT8;
     record_num      FLOAT8;
-    min_id          INT;
-    max_id          INT;
+    min_id          BIGINT;
+    max_id          BIGINT;
     range           FLOAT8;
     stmt            TEXT;
 BEGIN
@@ -1899,7 +1899,7 @@ m4_changequote(>>>`<<<, >>>'<<<)
     sample_ratio= range/record_num;
 
     -- compute how many records should be sampled by each segment
-    sample_per_seg=((sample_ratio*num_of_tree*size_per_tree)/segment_num)::INT;
+    sample_per_seg=((sample_ratio*num_of_tree*size_per_tree)/segment_num)::BIGINT;
     
     -- add the weight field
 
@@ -2132,7 +2132,7 @@ BEGIN
         PERFORM MADLIB_SCHEMA.__sample_with_replacement
             (
             num_trees,
-            round(sampling_percentage * total_size)::INT,
+            round(sampling_percentage * total_size)::BIGINT,
             'tmp_dt_hori_table',
             cur_tr_table
             );


### PR DESCRIPTION
Jira: madlib-764

Currently, rf_train won't work if the ID field is a BIGINT. I modified
the function of __sample_with_replacement to correctly handle BIGINT
numbers.
