### PR TITLE
Compressed bitmap implementation.

### DIFF
--- a/src/modules/assoc_rules/assoc_rules.cpp
+++ b/src/modules/assoc_rules/assoc_rules.cpp
@@ -47,7 +47,7 @@ typedef struct perm_fctx
 void *
 gen_rules_from_cfp::SRF_init(AnyType &args) {
     perm_fctx     *myfctx        = NULL;
-    char          *positions     = args[0].getAs<char*>();
+    char          *positions     = text_to_cstring(args[0].getAs<text*>());
 
     // allocate memory for user context
     myfctx            = new perm_fctx();

--- a/src/modules/bitmap/BitmapUtil.hpp
+++ b/src/modules/bitmap/BitmapUtil.hpp
@@ -1,0 +1,651 @@
+#ifndef MADLIB_MODULES_BITMAP_BITMAP_UTILITY_HPP
+#define MADLIB_MODULES_BITMAP_BITMAP_UTILITY_HPP
+
+#include <dbconnector/dbconnector.hpp>
+
+#include "Bitmap_proto.hpp"
+#include "Bitmap_impl.hpp"
+
+namespace madlib {
+namespace modules {
+namespace bitmap {
+
+using madlib::dbconnector::postgres::TypeTraits;
+using madlib::dbconnector::postgres::madlib_get_typlenbyvalalign;
+
+/**
+ * @brief This class encapsulates the interfaces for manipulating the bitmap.
+ *        All functions are static.
+ *
+ */
+class BitmapUtil{
+protected:
+    enum BITMAPOP {EQ = 0, GT = 1, LT = -1} ;
+public:
+
+/**
+ * @brief the step function for aggregating the input numbers to a bitmap.
+ *
+ * @param args[0]   the array indicating the state
+ * @param args[1]   the input number
+ * @param args[2]   the number of empty elements will be dynamically
+ *                  added to the state array. The default value is 16
+ *
+ * @return the array indicating the state after inserted the input number.
+ * @note the bitmap(UDT) uses an integer array as underlying storage. Therefore,
+ *       we need to skip the type checks of the C++ AL:
+ *          + if the input argument is bitmap, we will get it as array.
+ *          + if the return value is bitmap, we will return it as array.
+ *
+ */
+template<typename T>
+static
+const ArrayType*
+bitmap_agg_sfunc
+(
+    AnyType &args
+){
+    madlib_assert(!args[1].isNull(),
+            std::invalid_argument("the value of the first parameter "
+                    "should not be null"));
+    int64_t input_bit = args[1].getAs<int64_t>();
+
+    // the default value for this parameter
+    int size_per_add = DEFAULT_SIZE_PER_ADD;
+    if (3 == args.numFields()){
+        madlib_assert(!args[2].isNull(),
+                std::invalid_argument("the value of the third parameter "
+                        "should not be null"));
+        size_per_add = args[2].getAs<int32_t>();
+        madlib_assert(size_per_add > 1,
+                std::invalid_argument("the input parameter size_per_add "
+                        "should no less than 2"));
+
+    }
+
+    AnyType state = args[0];
+
+    if (state.isNull()){
+        Bitmap<T> bitmap(size_per_add, size_per_add);
+        bitmap.insert(input_bit);
+        return bitmap.to_ArrayType();
+    }
+    // state is not null
+    Bitmap<T> bitmap(GETARG_MUTABLE_BITMAP(state), size_per_add);
+    bitmap.insert(input_bit);
+    return bitmap.updated() ? bitmap.to_ArrayType() : GETARG_IMMUTABLE_BITMAP(state).array();
+}
+
+
+/**
+ * @brief the pre-function for the bitmap_agg.
+ *
+ * @param args[0]   the first state
+ * @param args[1]   the second state
+ *
+ * @return an array of merging the first state and the second state.
+ *
+ */
+template <typename T>
+static
+const ArrayType*
+bitmap_agg_pfunc
+(
+    AnyType &args
+){
+    AnyType states[] = {args[0], args[1]};
+
+    int nonull_index = states[0].isNull() ?
+            (states[1].isNull() ? -1 : 1) : (states[1].isNull() ? 0 : 2);
+
+    // if the two states are all null, return one of them
+    if (nonull_index < 0)
+        return NULL;
+
+    // one of the arguments is null
+    // trim the zero elements in the non-null bitmap
+    if (nonull_index < 2){
+        // no need to increase the bitmap size
+        Bitmap<T> bitmap(GETARG_MUTABLE_BITMAP(states[nonull_index]));
+        if (bitmap.full()){
+            return GETARG_IMMUTABLE_BITMAP(states[nonull_index]).array();
+        }
+        return bitmap.to_ArrayType(false);
+    }
+
+    // all the arguments are not null
+    // the two state-arrays can be written without copying it
+    Bitmap<T> bm1(GETARG_MUTABLE_BITMAP(states[0]));
+    Bitmap<T> bm2(GETARG_MUTABLE_BITMAP(states[1]));
+    return bm1.op_or(bm2);
+}
+
+
+/**
+ * @brief The implementation of operator &.
+ *
+ * @param args[0]   the first bitmap
+ * @param args[1]   the second bitmap
+ *
+ * @return the result of args[0] & args[1].
+ *
+ */
+template<typename T>
+static
+const ArrayType*
+bitmap_and
+(
+    AnyType &args
+){
+    Bitmap<T> bm1(GETARG_IMMUTABLE_BITMAP(args[0]));
+    Bitmap<T> bm2(GETARG_IMMUTABLE_BITMAP(args[1]));
+    return bm1.op_and(bm2);
+}
+
+
+/**
+ * @brief The implementation of operator ^.
+ *
+ * @param args[0]   the first bitmap
+ * @param args[1]   the second bitmap
+ *
+ * @return the result of args[0] ^ args[1].
+ *
+ */
+template<typename T>
+static
+const ArrayType*
+bitmap_xor
+(
+    AnyType &args
+){
+    Bitmap<T> bm1(GETARG_IMMUTABLE_BITMAP(args[0]));
+    Bitmap<T> bm2(GETARG_IMMUTABLE_BITMAP(args[1]));
+    return bm1.op_xor(bm2);
+}
+
+
+/**
+ * @brief the implementation of operator ~
+ *
+ * @param args[0] the bitmap
+ *
+ * @return the result of ~args[0]
+ */
+template<typename T>
+static
+const ArrayType*
+bitmap_not
+(
+    AnyType &args
+){
+    Bitmap<T> bm(GETARG_IMMUTABLE_BITMAP(args[0]));
+    return bm.op_not();
+}
+
+/**
+ * @brief The implementation of operator |
+ *
+ * @param args[0]   the first bitmap
+ * @param args[1]   the second bitmap
+ *
+ * @return the result of args[0] | args[1].
+ *
+ */
+template<typename T>
+static
+const ArrayType*
+bitmap_or
+(
+    AnyType &args
+){
+    Bitmap<T> bm1(GETARG_IMMUTABLE_BITMAP(args[0]));
+    Bitmap<T> bm2(GETARG_IMMUTABLE_BITMAP(args[1]));
+    return bm1.op_or(bm2);
+}
+
+
+/*
+ * @brief set the value of the bit with the specified position to 1/0
+ *
+ * @param args[0]   the bitmap
+ * @param args[1]   the position of the bit
+ * @param args[2]   true for 1; false for 0
+ *
+ * @return the changed bitmap
+ */
+template<typename T>
+static
+const ArrayType*
+bitmap_set
+(
+    AnyType &args
+){
+
+    madlib_assert(!args[0].isNull() && !args[1].isNull() && !args[2].isNull(),
+            std::invalid_argument("the input parameters should not be null"));
+
+    int64_t number = args[1].getAs<int64_t>();
+    madlib_assert(number > 0,
+            std::invalid_argument("the input number should be greater than 0"));
+    bool needset = args[2].getAs<bool>();
+
+    Bitmap<T> bm(GETARG_CLONED_BITMAP(args[0]));
+
+    return needset ? bm.insert(number).to_ArrayType(false) : bm.reset(number);
+}
+
+
+/*
+ * @brief Test whether the specified bit is set
+ *
+ * @param args[0]   the bitmap
+ * @param args[1]   the specified bit to be tested
+ *
+ * @return True if the bit with the specified position in the bitmap is set,
+ *         otherwise, return False;
+ */
+template<typename T>
+static
+const bool
+bitmap_test
+(
+    AnyType &args
+){
+    madlib_assert(!args[0].isNull() && !args[1].isNull(),
+            std::invalid_argument("the input parameters should not be null"));
+
+    int64_t number = args[1].getAs<int64_t>();
+    madlib_assert(number > 0,
+            std::invalid_argument("the input number should be greater than 0"));
+
+    Bitmap<T> bm(GETARG_MUTABLE_BITMAP(args[0]));
+    return bm[number];
+}
+
+
+/**
+ * @brief get the number of bits whose value is 1.
+ *
+ * @param args[0]   the bitmap array
+ *
+ * @return the count of non-zero bits in the bitmap.
+ *
+ */
+template<typename T>
+static
+const int64_t
+bitmap_nonzero_count
+(
+    AnyType &args
+){
+    return (Bitmap<T>(GETARG_IMMUTABLE_BITMAP(args[0]))).nonzero_count();
+}
+
+
+/**
+ * @brief get the positions of the non-zero bits
+ *
+ * @param args[0]   the bitmap array
+ *
+ * @return the array contains the positions of the non-zero bits.
+ * @note the position starts from 1.
+ *
+ */
+template <typename T>
+static
+const ArrayType*
+bitmap_nonzero_positions
+(
+    AnyType &args
+){
+
+    return (Bitmap<T>(GETARG_IMMUTABLE_BITMAP(args[0]))).nonzero_positions();
+}
+
+
+/**
+ * @brief get the bitmap representation for the input array.
+ *
+ * @param args[0]   the input array.
+ *
+ * @return the bitmap for the input array.
+ * @note T is the type of the bitmap
+ *       X is the type of the input array
+ */
+template <typename T, typename X>
+static
+const ArrayType*
+bitmap_from_array
+(
+    AnyType &args
+){
+    MutableArrayHandle<X> handle = args[0].getAs< MutableArrayHandle<X> >();
+    madlib_assert(!ARR_HASNULL(handle.array()),
+            std::invalid_argument("the input array should not contains null"));
+
+    X* array = handle.ptr();
+    int size = handle.size();
+
+    if (0 == size)
+        return NULL;
+
+    qsort(array, size, sizeof(X), compare<X>);
+    Bitmap<T> bitmap(DEFAULT_SIZE_PER_ADD, DEFAULT_SIZE_PER_ADD);
+
+    for (int i = 0; i < size; ++i){
+        bitmap.insert((int64_t)array[i]);
+    }
+
+    return bitmap.to_ArrayType(false);
+}
+
+
+/**
+ * @brief construct a bitmap from the specified varbit
+ *
+ * @param args[0]   the varbit
+ *
+ * @return the bitmap representing the varbit
+ */
+template <typename T>
+static
+const ArrayType*
+bitmap_from_varbit
+(
+    AnyType &args
+){
+    return Bitmap<T>(args[0].getAs<VarBit*>()).to_ArrayType(false);
+}
+
+
+/**
+ * @brief the in function for the bitmap
+ *
+ * @param args[0]   the input string, which should be split by a comma.
+ *
+ * @return the bitmap representing the input string
+ */
+template <typename T>
+static
+const ArrayType*
+bitmap_in
+(
+    AnyType &args
+){
+    return (Bitmap<T>(args[0].getAs<char*>())).to_ArrayType(false);
+}
+
+
+/**
+ * @brief the out function for the bitmap
+ *
+ * @param args[0]   the bitmap
+ *
+ * @return the string representing the bitmap.
+ */
+template <typename T>
+static
+char*
+bitmap_out
+(
+    AnyType &args
+){
+    return (Bitmap<T>(GETARG_IMMUTABLE_BITMAP(args[0]))).to_string();
+}
+
+
+/**
+ * @brief convert the bitmap to varbit.
+ *
+ * @param args[0]   the bitmap
+ *
+ * @return the varbit representation for the bitmap.
+ */
+template <typename T>
+static
+VarBit*
+bitmap_return_varbit
+(
+    AnyType &args
+){
+    return (Bitmap<T>(GETARG_IMMUTABLE_BITMAP(args[0]))).to_varbit();
+}
+
+
+/**
+ * @brief return the internal representation (array) for the bitmap.
+ *
+ * @param args[0]   the bitmap
+ *
+ * @return the array representation for the bitmap.
+ */
+template <typename T>
+static
+const ArrayType*
+bitmap_return_array
+(
+    AnyType &args
+){
+    return GETARG_IMMUTABLE_BITMAP(args[0]).array();
+}
+
+
+/**
+ * @brief the init function for bitmap_unnest
+ */
+template <typename T>
+static
+void *
+bitmap_unnest_init(AnyType &args) {
+    ArrayHandle<T> arr = GETARG_IMMUTABLE_BITMAP(args[0]);
+    madlib_assert(arr.size() == (size_t)arr[0],
+            std::invalid_argument("invalid bitmap"));
+
+    // allocate memory for user context
+    unnest_fctx<T>*  fctx = new unnest_fctx<T>();
+    fctx->bitmap = arr.ptr();
+    fctx->size = arr.size();
+    fctx->index = 0;
+    fctx->word = 0;
+    fctx->cur_pos = 0;
+    fctx->max_pos = 0;
+
+    return fctx;
+}
+
+
+/**
+ * @brief the next function for bitmap_unnest
+ *
+ * @param user_fctx     the user context
+ * @param is_last_call  is it the last call
+ *
+ * @return the current value
+ */
+template <typename T>
+static
+int64_t
+bitmap_unnest_next(void *user_fctx, bool *is_last_call) {
+    madlib_assert(is_last_call,
+         std::invalid_argument("the paramter is_last_class should not be null"));
+
+    unnest_fctx<T> *fctx       = static_cast<unnest_fctx<T>*>(user_fctx);
+    T& curword = fctx->word;
+    int& index = fctx->index;
+    int64_t& cur_pos = fctx->cur_pos;
+    int64_t& max_pos = fctx->max_pos;
+
+    if (0 == curword){
+        ++index;
+        if (index >= fctx->size){
+            *is_last_call = true;
+            return -1;
+        }
+
+        // skip the composite words that represent continuous 0s
+        curword = fctx->bitmap[index];
+        while ((curword < 0) &&
+                (0 == ((BM_WORDCNT_MASK + 1) & curword))){
+            max_pos += (int64_t)(BM_WORDCNT_MASK & curword) * BM_BASE;
+            ++index;
+            madlib_assert(index < fctx->size,
+                 std::runtime_error("invalid bitmap"));
+            curword = fctx->bitmap[index];
+        }
+        cur_pos = max_pos;
+        max_pos += curword > 0 ? 31 :
+                (int64_t)(BM_WORDCNT_MASK & curword) * (int64_t)BM_BASE;
+    }
+
+    if (curword > 0){
+        // the normal word has 1s
+        T preword = 0;
+        do{
+            preword = curword;
+            curword >>= 1;
+            ++cur_pos;
+        }while (0 == (preword & 0x01));
+    }else{
+        // a composite word with 1s
+        ++cur_pos;
+        if (cur_pos >= max_pos){
+            curword = 0;
+        }
+    }
+
+    *is_last_call = false;
+    return cur_pos;
+}
+
+
+public:
+/**
+ * @brief the implementation for operator >
+ *
+ * @param args[0]   the bitmap
+ * @param args[1]   the bitmap
+ *
+ * @return args[0] > args[1]
+ *
+ */
+template <typename T>
+static
+const bool
+bitmap_gt
+(
+    AnyType &args
+){
+    return bitmap_cmp_internal<T>(args) == GT;
+}
+
+
+/**
+ * @brief the implementation for operator >=
+ *
+ * @param args[0]   the bitmap
+ * @param args[1]   the bitmap
+ *
+ * @return args[0] >= args[1]
+ *
+ */
+template <typename T>
+static
+const bool
+bitmap_ge
+(
+    AnyType &args
+){
+    BITMAPOP op = bitmap_cmp_internal<T>(args);
+    return (op == GT)  || (op == EQ);
+}
+
+
+/**
+ * @brief the implementation for operator =
+ *
+ * @param args[0]   the bitmap
+ * @param args[1]   the bitmap
+ *
+ * @return args[0] == args[1]
+ *
+ */
+template <typename T>
+static
+const bool
+bitmap_eq
+(
+    AnyType &args
+){
+    return bitmap_cmp_internal<T>(args) == EQ;
+}
+
+
+/**
+ * @brief compare the two bitmap
+ *
+ * @param args[0]   the bitmap
+ * @param args[1]   the bitmap
+ *
+ * @return 0 for equality; 1 for greater than; and -1 for less than
+ *
+ */
+template <typename T>
+static
+const int32_t
+bitmap_cmp
+(
+    AnyType &args
+){
+    return static_cast<int32_t>(bitmap_cmp_internal<T>(args));
+}
+
+protected:
+
+template <typename T>
+static
+const BITMAPOP
+bitmap_cmp_internal
+(
+    AnyType &args
+){
+    const T* lhs = (args[0].getAs< ArrayHandle<T> >(false)).ptr();
+    const T* rhs = (args[1].getAs< ArrayHandle<T> >(false)).ptr();
+
+    int size = (lhs[0] > rhs[0]) ? rhs[0] - 1 : lhs[0] - 1;
+    int res = memcmp(lhs + 1, rhs + 1,
+                     size * sizeof(T));
+
+    if (0 == res){
+        res = memcmp(lhs, rhs, sizeof(T));
+    }
+
+    return (0 == res) ? EQ : ((res < 0) ? LT : GT);
+}
+
+template <typename X>
+static
+int
+compare(const void* lhs, const void* rhs){
+    return *(X*)lhs - *(X*)rhs;
+}
+
+template <typename T>
+class unnest_fctx
+{
+public:
+    const T* bitmap;
+    int size;
+    int index;
+    T word;
+    int64_t cur_pos;
+    int64_t max_pos;
+};
+
+}; // class BitmapUtil
+
+} // namespace bitmap
+} // namespace modules
+} // namespace madlib
+
+#endif //  MADLIB_MODULES_BITMAP_BITMAP_PROTO_HPP

--- a/src/modules/bitmap/Bitmap_impl.hpp
+++ b/src/modules/bitmap/Bitmap_impl.hpp
@@ -1,0 +1,1288 @@
+#ifndef MADLIB_MODULES_BITMAP_BITMAP_IMPL_HPP
+#define MADLIB_MODULES_BITMAP_BITMAP_IMPL_HPP
+
+namespace madlib {
+namespace modules {
+namespace bitmap {
+
+// ctor
+template <typename T>
+inline
+Bitmap<T>::Bitmap
+(
+    int capacity,
+    int size_per_add
+) :
+    m_bmArray(NULL), m_bitmap(NULL), m_size(1), m_capacity(capacity),
+    m_size_per_add(size_per_add), m_bitmap_updated(true),
+    m_base(BM_BASE),
+    m_wordcnt_mask(BM_WORDCNT_MASK),
+    m_cw_zero_mask(BM_CW_ZERO_MASK),
+    m_cw_one_mask(BM_CW_ONE_MASK){
+    set_typInfo();
+    m_bmArray = BM_CONSTRUCT_ARRAY((Datum*)NULL, capacity);
+    m_bitmap = BM_ARR_DATA_PTR(m_bmArray, T);
+    m_bitmap[0] = 1;
+}
+
+// ctor
+template <typename T>
+inline
+Bitmap<T>::Bitmap
+(
+    ArrayType* arr,
+    Bitmap& rhs
+):
+m_bmArray(arr), m_bitmap(BM_ARR_DATA_PTR(arr, T)),
+m_size(BM_ARRAY_LENGTH(arr)), m_capacity(BM_ARRAY_LENGTH(arr)),
+m_size_per_add(rhs.m_size_per_add), m_bitmap_updated(false),
+m_base(rhs.m_base), m_wordcnt_mask(rhs.m_wordcnt_mask),
+m_cw_zero_mask(rhs.m_cw_zero_mask), m_cw_one_mask(rhs.m_cw_one_mask),
+m_typoid(rhs.m_typoid), m_typlen(rhs.m_typelen),
+m_typbyval(rhs.m_typbyval), m_typalign(rhs.m_typalign){
+BM_CHECK_ARRAY_SIZE(m_bitmap, m_size);
+}
+
+
+//ctor
+template <typename T>
+inline
+Bitmap<T>::Bitmap
+(
+    ArrayHandle<T> handle,
+    int size_per_add /* = DEFAULT_SIZE_PER_ADD */
+) :
+m_bmArray(const_cast<ArrayType*>(handle.array())),
+m_bitmap(const_cast<T*>(handle.ptr())), m_size(handle[0]),
+m_capacity(handle.size()), m_size_per_add(size_per_add),
+m_bitmap_updated(false), m_base(BM_BASE),
+m_wordcnt_mask(BM_WORDCNT_MASK),
+m_cw_zero_mask(BM_CW_ZERO_MASK),
+m_cw_one_mask(BM_CW_ONE_MASK) {
+    set_typInfo();
+    BM_CHECK_ARRAY_SIZE(m_bitmap, m_size);
+}
+
+
+//ctor
+template <typename T>
+inline
+Bitmap<T>::Bitmap
+(
+    Bitmap& rhs
+):
+m_bmArray(rhs.m_bmArray), m_bitmap(rhs.m_bitmap), m_size(rhs.m_size),
+m_capacity(rhs.m_capacity), m_size_per_add(rhs.m_size_per_add),
+m_bitmap_updated(rhs.m_bitmap_updated), m_base(rhs.m_base),
+m_wordcnt_mask(rhs.m_wordcnt_mask),
+m_cw_zero_mask(rhs.m_cw_zero_mask),
+m_cw_one_mask(rhs.m_cw_one_mask),
+m_typoid(rhs.m_typoid), m_typlen(rhs.m_typelen),
+m_typbyval(rhs.m_typbyval), m_typalign(rhs.m_typalign){
+}
+
+
+//ctor
+template <typename T>
+inline
+Bitmap<T>::Bitmap
+(
+    VarBit* bits
+):
+m_bmArray(NULL), m_bitmap(NULL), m_size(1), m_capacity(DEFAULT_SIZE_PER_ADD),
+m_size_per_add(DEFAULT_SIZE_PER_ADD), m_bitmap_updated(false),
+m_base(BM_BASE),
+m_wordcnt_mask(BM_WORDCNT_MASK),
+m_cw_zero_mask(BM_CW_ZERO_MASK),
+m_cw_one_mask(BM_CW_ONE_MASK){
+    // init the member variables
+    set_typInfo();
+    m_bmArray = BM_CONSTRUCT_ARRAY((Datum*)NULL, m_capacity);
+    m_bitmap = BM_ARR_DATA_PTR(m_bmArray, T);
+    m_bitmap[0] = 1;
+
+    bits8* pbits = VARBITS(bits);
+    int64_t bitlen = VARBITLEN(bits);
+    int64_t alignlen = ((bitlen + 7) >> 3) << 3;
+    int64_t ignorebits = alignlen - bitlen;
+    int64_t size = VARBITBYTES(bits) - 1;
+    int64_t beg_bit = 1;
+    int64_t cur_pos = 1;
+    bits8 curbit = 0;
+    for (; size >= 0; --size){
+        curbit = pbits[size] >> ignorebits;
+        cur_pos = beg_bit;
+        do{
+            if (1 == (curbit & 0x01)){
+                insert(cur_pos);
+            }
+            ++cur_pos;
+            curbit >>= 1;
+        }while (curbit > 0);
+        beg_bit += 8 - ignorebits;
+        ignorebits = 0;
+    }
+}
+
+
+//ctor
+template <typename T>
+inline
+Bitmap<T>::Bitmap
+(
+    char* str
+):
+m_bmArray(NULL), m_bitmap(NULL), m_size(1), m_capacity(DEFAULT_SIZE_PER_ADD),
+m_size_per_add(DEFAULT_SIZE_PER_ADD), m_bitmap_updated(false),
+m_base(BM_BASE),
+m_wordcnt_mask(BM_WORDCNT_MASK),
+m_cw_zero_mask(BM_CW_ZERO_MASK),
+m_cw_one_mask(BM_CW_ONE_MASK){
+    // init the member variables
+    set_typInfo();
+    m_bmArray = BM_CONSTRUCT_ARRAY((Datum*)NULL, m_capacity);
+    m_bitmap = BM_ARR_DATA_PTR(m_bmArray, T);
+    m_bitmap[0] = 1;
+
+    // convert the input string to a bitmap
+    char elem[MAXBITSOFINT64] = {'\0'};
+    int j = 0;
+    int64 input_pos = 0;
+
+    for (; *str != '\0'; ++str){
+        if (',' == *str){
+            elem[j] = '\0';
+            (void) scanint8(elem, false, &input_pos);
+            insert(input_pos);
+            j = 0;
+        }else{
+            elem[j++] = *str;
+        }
+    }
+
+    (void) scanint8(elem, false, &input_pos);
+    insert(input_pos);
+}
+
+
+/**
+ * @brief breakup the composite word, and insert the input number to it.
+ *        three conditions need to be considered here (assume that the active
+ *        word contains n normal words):
+ *        + if the input number is inserted into the 1st word, then the active
+ *          word will be breakup to:
+ *              "a normal word" + "a composite word with n - 1 words"
+ *        + if the input number is inserted into the nth word, then the active
+ *          word will be break up to:
+ *              "a composite word with n - 1 words" + "a normal word"
+ *        + if the input number is inserted into ith word (1<i<n), then the
+ *          active word will be breakup to:
+ *              "a composite word with i - 1 words" + "a normal word" + "a composite
+ *               word with n - i words
+ *
+ * @param newbitmap     the new bitmap for keeping the breakup bitmap. If the
+ *                      old bitmap is not large enough to keep the breakup
+ *                      bitmap, then we need to reallocate. Otherwise, the new
+ *                      bitmap is the same as the old bitmap (in this case,
+ *                      just move the elements)
+ * @param index         the index of the active word will be used to insert the
+ *                      input number
+ * @param pos_in_word   the inserting position for the input number
+ * @param word_pos      the word for the input number will
+ *                      be inserted to the new bitmap
+ * @param num_words     the number of words in the composite word
+ *
+ * @return the new bitmap.
+ */
+template<typename T>
+void
+Bitmap<T>::breakup_compword
+(
+    T* newbitmap,
+    int32_t index,
+    int32_t pos_in_word,
+    int32_t word_pos,
+    int32_t num_words
+){
+    memmove(newbitmap, m_bitmap, (index + 1) * sizeof(T));
+    // the inserted position is in the middle of a composite word
+    if (word_pos > 1 && word_pos < num_words){
+        memmove(newbitmap + index + 2,
+                m_bitmap + index, (m_size - index) * sizeof(T));
+        newbitmap[index] = (T)(word_pos - 1) | m_cw_zero_mask;
+        newbitmap[index + 2] = (T)(num_words - word_pos) | m_cw_zero_mask;
+        ++index;
+        m_size += 2;
+    }else{
+        memmove(newbitmap + index + 1,
+                m_bitmap + index, (m_size - index) * sizeof(T));
+        // the inserted position is in the beginning of a composite word
+        if (1 == word_pos){
+            newbitmap[index + 1] = (T)(num_words - 1) | m_cw_zero_mask;
+        }else{
+            // the inserted position is in the end of a composite word
+            newbitmap[index] = (T)(num_words - 1) | m_cw_zero_mask;
+            ++index;
+        }
+        m_size += 1;
+    }
+
+    newbitmap[index] = (T)1 << (pos_in_word - 1);
+    m_bitmap = newbitmap;
+    m_bitmap[0] = m_size;
+}
+
+
+/**
+ * @breif insert the specified number to the composite word
+ *
+ * @param number        the input number
+ * @param num_words     the number of words in the composite word
+ * @param index         the subscript of bitmap array where the input
+ *                      number will be inserted
+ */
+template<typename T>
+void
+Bitmap<T>::insert_compword
+(
+    int64_t number,
+    int64_t num_words,
+    int index
+){
+    int pos_in_word = get_pos_word(number);
+
+    if (1 == num_words){
+        m_bitmap[index] = (T)1 << (pos_in_word - 1);
+        return;
+    }
+
+    int64_t word_pos = BM_NUMWORDS_FOR_BITS(number);
+    T* newbitmap = m_bitmap;
+
+    // need to increase the memory size
+    if (((1 == word_pos || num_words == word_pos) && m_size == m_capacity) ||
+        (word_pos > 1 && word_pos < num_words && m_size >= m_capacity - 1)){
+            m_capacity += m_size_per_add;
+            newbitmap = alloc_bitmap(m_capacity);
+            m_bitmap_updated = true;
+    }
+
+    breakup_compword(newbitmap, index, pos_in_word, word_pos, num_words);
+}
+
+
+/**
+ * @brief append the given number to the bitmap.
+ *
+ * @param number   the input number
+ *
+ * @return the new bitmap after appended.
+ *
+ */
+template <typename T>
+inline
+void
+Bitmap<T>::append
+(
+    int64_t number
+){
+    int64_t need_elems = 1;
+    T max_bits = (T)BM_MAXBITS_IN_COMP;
+    int64_t num_words = BM_NUMWORDS_FOR_BITS(number);
+    int64_t cur_pos = get_pos_word(number);
+    int i = m_size;
+
+    if (num_words <= max_bits + 1){
+        // a composite word can represent all zeros,
+        // then two new elements are enough
+        need_elems = (1 == num_words) ? 1 : 2;
+    }else{
+        // we need 2 more composite words to represent all zeros
+        need_elems = (num_words - 1 + max_bits - 1) / max_bits + 1;
+        num_words = (num_words - 1) % max_bits + 1;
+    }
+
+    if (need_elems + m_size > m_capacity){
+        m_capacity += BM_ALIGN(need_elems, m_size_per_add);
+        m_bitmap = alloc_bitmap(m_capacity, m_bitmap, m_size);
+        m_bitmap_updated = true;
+    }
+
+    // fill the composite words
+    for (; need_elems > 2; --need_elems){
+        m_bitmap[i++] = m_cw_zero_mask | max_bits;
+        ++m_size;
+    }
+
+    // the first word is composite word
+    // the second is a normal word
+    if ((2 == need_elems) && (num_words > 1)){
+        m_bitmap[i] = m_cw_zero_mask | (T)(num_words - 1);
+        m_bitmap[++i] = (T)1 << (cur_pos - 1);
+        m_size += 2;
+    }else{
+        // only one normal word can represent the input number
+        m_bitmap[i] = (T)1 << (cur_pos - 1);
+        m_size += 1;
+    }
+
+    // set the size of the bitmap
+    m_bitmap[0] = m_size;
+}
+
+
+/**
+ * @brief if all the available bits of the normal word are 1s/0s, then
+ *        we convert it to a composite word (A). Furthermore, if its previous word
+ *        is composite (B) and they(A and B) have the same sign, then merge them.
+ *
+ * @param curword   the current word
+ * @param i         the index of the current word
+ *
+ */
+template <typename T>
+inline
+void
+Bitmap<T>::merge_norm_to_comp
+(
+    T& curword,
+    int i
+){
+    T& preword = m_bitmap[i - 1];
+    // the previous word is not composite, or
+    // it represents the maximum composite word for continuous one, or
+    // it's a composite word with zero
+    if (preword > 0 ||
+        !(BM_COMPWORD_ONE(preword)) ||
+        BM_COMP_ONE_MAX(preword)){
+        curword = m_cw_one_mask | 1;
+    }else{
+        memmove(m_bitmap + i, m_bitmap + (i + 1),
+                (m_size - i - 1) * sizeof(T));
+        preword += 1;
+        m_size -= 1;
+        m_bitmap[0] = m_size;
+    }
+}
+
+
+/**
+ * @brief insert the give number to the bitmap.
+ *
+ * @param number   the input number
+ *
+ * @return the new bitmap after inserted.
+ *
+ * @note duplicated numbers are allowed
+ *
+ */
+template <typename T>
+inline
+Bitmap<T>&
+Bitmap<T>::insert
+(
+    int64_t number
+){
+    madlib_assert(number > 0,
+            std::invalid_argument("the bit position must be a positive number"));
+
+    int64_t cur_pos = 0;
+    int64_t num_words = 1;
+    int i = 1;
+
+    // visit each element of the bitmap array to find the right word to
+    // insert the input number
+    for (i = 1; i < m_size; ++i){
+        T& curword = m_bitmap[i];
+        if (curword > 0){
+            cur_pos += m_base;
+            // insert the input bit position to a normal word
+            if (cur_pos >= number){
+                // use | rather than + to allow duplicated numbers insertion
+                curword |= (T)1 << ((get_pos_word(number)) - 1);
+                if ((~m_cw_zero_mask) == curword){
+                    merge_norm_to_comp(curword, i);
+                }
+                return *this;
+            }
+        }else if (curword < 0){
+            // get the number of words for a composite word
+            // each word contains m_base bits
+            num_words = BM_NUMWORDS_IN_COMP(curword);
+            int64_t temp = num_words * m_base;
+            cur_pos += temp;
+            if (cur_pos >= number){
+                // if the inserting position is in a composite word with 1s
+                // then that's a duplicated number
+                if (BM_COMPWORD_ZERO(curword)){
+                    insert_compword(number - (cur_pos - temp), num_words, i);
+                }
+                return *this;
+            }
+        }
+    }
+
+    // reach the end of the bitmap
+    append(number - cur_pos);
+
+    return *this;
+}
+
+
+/**
+ * @brief get the maximum number represented by the bitmap
+ */
+template <typename T>
+inline
+int64_t
+Bitmap<T>::max_number() const{
+    int64_t res = 0;
+    int i = 1;
+    T word = 0;
+    for (; i < m_size - 1; ++i){
+        word = m_bitmap[i];
+        res += (word < 0 ? BM_NUMBITS_IN_COMP(word) : 31);
+    }
+
+    word = m_bitmap[i];
+    if (word < 0){
+        res += BM_NUMBITS_IN_COMP(word);
+    }else{
+        res += 31;
+        T mask = m_wordcnt_mask + 1;
+        while (0 == (word & mask)){
+            --res;
+            mask >>= 1;
+        }
+    }
+    return res;
+}
+
+
+/**
+ * @brief remove the specified number from the bitmap
+ */
+template <typename T>
+inline
+ArrayType*
+Bitmap<T>::reset(int64_t number){
+    if (number > 0 && number <= max_number()){
+        return Bitmap(4,4).insert(number).op_xor(*this);
+    }
+
+    return m_bmArray;
+
+}
+
+/**
+ * @brief bitwise operation on a normal word and a composite word
+ * @param norm      the normal word
+ * @param comp      the composite word
+ * @param i         the index of the normal word in its bitmap
+ * @param j         the index of the composite word in its bitmap
+ * @param lhs       the bitmap array for the normal word
+ * @param rhs       the bitmap array for the composite word
+ * @param op        the function pointer for the bitwise operation
+ *
+ * @ rturn the result of applying 'op' on the normal word and the composite word
+ */
+template <typename T>
+inline
+T
+Bitmap<T>::bitwise_norm_comp_words(T& norm, T& comp, int& i, int& j,
+            T* lhs, T* rhs, bitwise_op op) const{
+    T temp = (this->*op)(norm, comp);
+    --comp;
+    comp = BM_NUMWORDS_IN_COMP(comp) > 0 ? comp : rhs[++j];
+    norm = lhs[++i];
+    return temp;
+}
+
+
+/**
+ * @brief bitwise operation on two composite words
+ *
+ * @param lword     the left word
+ * @param rword     the right word
+ * @param i         the index of the left word in its bitmap
+ * @param j         the index of the right word in its bitmap
+ * @param lhs       the bitmap array for the left word
+ * @param rhs       the bitmap array for the right word
+ *
+ * @return the number of overlaped words for the two composite words
+ */
+template <typename T>
+inline
+T
+Bitmap<T>::bitwise_comp_comp_words(T& lword, T& rword, int& i, int& j,
+            T* lhs, T* rhs) const{
+    T l_num_words = BM_NUMWORDS_IN_COMP(lword);
+    T r_num_words = BM_NUMWORDS_IN_COMP(rword);
+    // left composite word contains more normal words
+    if (l_num_words > r_num_words){
+        lword -= r_num_words;
+        rword = rhs[++j];
+        return r_num_words;
+    }
+    // right composite word contains more normal words
+    if (r_num_words > l_num_words){
+        rword -= l_num_words;
+        lword = lhs[++i];
+        return l_num_words;
+    }
+    // left and right composite word have the same number of normal words
+    lword = lhs[++i];
+    rword = rhs[++j];
+    return l_num_words;
+}
+
+
+/**
+ * @brief the entry function for doing the bitwise operations,
+ *        such as |, & and ^, etc.
+ *
+ * @param rhs       the bitmap
+ * @param op        the function used to do the real operation, such as | and &
+ * @param postproc  the function used to post-processing the bitmap
+ *
+ * @return the result of "this" OP "rhs", where OP can be |, & and ^.
+ */
+template <typename T>
+inline
+ArrayType*
+Bitmap<T>::bitwise_proc
+(
+    const Bitmap<T>& rhs,
+    bitwise_op op,
+    bitwise_postproc postproc
+) const{
+    int i = 1;
+    int j = 1;
+    int k = 1;
+    T temp;
+    T pre_word = 0;
+    T lword = m_bitmap[i];
+    T rword = rhs.m_bitmap[j];
+    int capacity = m_size + rhs.m_size;
+    T* result = new T[capacity];
+
+    for (; i < m_size && j < rhs.m_size; ++k){
+        // the two words have the same sign
+        if ((lword ^ rword) >= 0){
+            temp = (this->*op)(lword, rword);
+            if (lword < 0){
+                temp = (temp & m_cw_one_mask ) | bitwise_comp_comp_words
+                    (lword, rword, i, j, m_bitmap, rhs.m_bitmap);
+            }else{
+                lword = m_bitmap[++i];
+                rword = rhs.m_bitmap[++j];
+            }
+        }else{
+            temp = lword > 0 ?
+                bitwise_norm_comp_words
+                    (lword, rword, i, j, m_bitmap, rhs.m_bitmap, op) :
+                bitwise_norm_comp_words
+                    (rword, lword, j, i, rhs.m_bitmap, m_bitmap, op);
+        }
+
+        // merge if needed
+        if (k >= 2 && BM_SAME_SIGN(temp, pre_word)){
+            pre_word += BM_NUMWORDS_IN_COMP(temp);
+            result[--k] = pre_word;
+        }else{
+            result[k] = temp;
+            pre_word = temp;
+        }
+    }
+    // post-processing
+    k = (this->*postproc)(result, k, *this, i, lword, pre_word);
+    k = (this->*postproc)(result, k, rhs, j, rword, pre_word);
+
+    // if the bitmap only has one word, and the word is a composite word with all
+    // values are 0, then trim it
+    k = (2 == k) && ((pre_word & m_cw_one_mask) == m_cw_zero_mask) ? 1 : k;
+
+    madlib_assert(k <= capacity,
+        std::logic_error
+        ("the real size of the bitmap should be no greater than its capacity"));
+
+    result[0] = (T)k;
+
+    if (1 == k){
+        return NULL;
+    }
+
+    ArrayType* arr = alloc_array(result, k);
+    delete[] result;
+    return arr;
+}
+
+
+/**
+ * @brief the bitwise xor operation on two words
+ *
+ * @param lhs   the left word
+ * @param rhs   the right word
+ *
+ * @return return the xor result if one of the two words is normal word
+ *         return the sign of xor result if the two words are composite.
+ */
+template <typename T>
+inline
+T
+Bitmap<T>::bitwise_xor
+(
+    T lhs,
+    T rhs
+) const{
+    T res = 0;
+    if (lhs > 0 && rhs > 0){
+        res = (lhs ^ rhs) & (~m_cw_zero_mask);
+        if (0 == res){
+            res = m_cw_zero_mask | 1;
+        }else if ((~m_cw_zero_mask) == res){
+            res = m_cw_one_mask | 1;
+        }
+    }else if (lhs < 0 && rhs > 0){
+        res = BM_COMPWORD_ONE(lhs) ? (~rhs) & (~m_cw_zero_mask) : rhs;
+    }else if (lhs > 0 && rhs < 0){
+        res = BM_COMPWORD_ONE(rhs) ? (~lhs) & (~m_cw_zero_mask) : lhs;
+    }else{
+        res = (0 == ((lhs ^ rhs) & (m_wordcnt_mask + 1))) ?
+                m_cw_zero_mask : m_cw_one_mask;
+    }
+
+    return res;
+}
+
+
+/**
+ * @brief the post-processing for the XOR operation. Here, we need to concat
+ *        the remainder bitmap elements to the result
+ *
+ * @param result    the array for keeping the 'or' result of two bitmaps
+ * @param k         the subscript if we insert new element to the result array
+ * @param bitmap    the bitmap that need to merge to the result array
+ * @param i         the index of the current word in the bitmap array
+ * @param curword   the current processing word in the bitmap array
+ * @param pre_word  the previous word in the bitmap array, compared with curword
+ *
+ * @return the number of elements in the result array
+ */
+template <typename T>
+inline
+int
+Bitmap<T>::xor_postproc
+(
+    T* result,
+    int k,
+    const Bitmap<T>& bitmap,
+    int i,
+    T curword,
+    T pre_word
+) const{
+    // value | 0 == value ^ 0;
+    return or_postproc(result, k, bitmap, i, curword, pre_word);
+}
+
+
+/**
+ * @brief implement the operator ^
+ *
+ * @param rhs   the bitmap
+ *
+ * @return the result of "this" ^ "rhs"
+ *
+ */
+template <typename T>
+inline
+ArrayType*
+Bitmap<T>::op_xor (const Bitmap<T>& rhs) const{
+    return bitwise_proc(rhs, &Bitmap<T>::bitwise_xor, &Bitmap<T>::xor_postproc);
+}
+
+
+/**
+ * @brief override the operator ^
+ *
+ * @param rhs   the bitmap
+ *
+ * @return the result of "this" ^ "rhs"
+ *
+ */
+template <typename T>
+inline
+Bitmap<T>
+Bitmap<T>::operator ^ (const Bitmap<T>& rhs) const{
+    ArrayType* res = bitwise_proc
+            (rhs, &Bitmap<T>::bitwise_xor, &Bitmap<T>::xor_postproc);
+    return res ? Bitmap(res, *this) : EMTYP_BITMAP;
+}
+
+
+/**
+ * @brief the bitwise or operation on two words.
+ *
+ * @param lhs   the left word
+ * @param rhs   the right word
+ *
+ * @return lhs | rhs if one of the two words is a normal word.
+ *         if both of them are composite words, return the sign of lhs | rhs.
+ */
+template <typename T>
+inline
+T
+Bitmap<T>::bitwise_or
+(
+    T lhs,
+    T rhs
+)  const{
+    T res = 0;
+    if ((lhs ^ rhs) >= 0){
+        res = lhs | rhs;
+    }else if (lhs < 0){
+        res = BM_COMPWORD_ONE(lhs) ? m_cw_one_mask | 1: rhs;
+    }else {
+        res = BM_COMPWORD_ONE(rhs) ? m_cw_one_mask | 1: lhs;
+    }
+
+    // if all the bits of the result are 1, then use a composite word
+    // to represent it
+    return res == (~m_cw_zero_mask) ? m_cw_one_mask | 1 : res;
+}
+
+
+/**
+ * @brief the post-processing for the OR operation. Here, we need to concat
+ *        the remainder bitmap elements to the result
+ *
+ * @param result    the array for keeping the 'or' result of two bitmaps
+ * @param k         the subscript if we insert new element to the result array
+ * @param bitmap    the bitmap that need to merge to the result array
+ * @param i         the index of the current word in the bitmap array
+ * @param curword   the current processing word in the bitmap array
+ * @param pre_word  the previous word in the bitmap array, compared with curword
+ *
+ * @return the number of elements in the result array
+ */
+template <typename T>
+inline
+int
+Bitmap<T>::or_postproc
+(
+    T* result,
+    int k,
+    const Bitmap<T>& bitmap,
+    int i,
+    T curword,
+    T pre_word
+)  const{
+    for (; i < bitmap.m_size; ++k){
+        T temp = (curword < 0) ? curword :
+                    ((curword == (~m_cw_zero_mask)) ?
+                    (m_cw_one_mask | 1) : curword);
+        if (k >= 2 && BM_SAME_SIGN(temp, pre_word)){
+            int64_t n1 = BM_NUMWORDS_IN_COMP(temp);
+            int64_t n2 = BM_NUMWORDS_IN_COMP(pre_word);
+            if (n1 + n2 > (int64_t)m_wordcnt_mask){
+                result[k - 1] = (pre_word & m_cw_one_mask) | m_wordcnt_mask;
+                pre_word = (pre_word & m_cw_one_mask) | (n1 + n2 - m_wordcnt_mask);
+                result[k] = pre_word;
+            }else{
+                pre_word += n1;
+                result[--k] = pre_word;
+            }
+        }else{
+            result[k] = curword;
+            pre_word = curword;
+        }
+        curword = bitmap.m_bitmap[++i];
+    }
+
+    return k;
+}
+
+
+/**
+ * @brief implement the operator |
+ *
+ * @param rhs   the bitmap
+ *
+ * @return the result of "this" | "rhs"
+ *
+ */
+template <typename T>
+inline
+ArrayType*
+Bitmap<T>::op_or (const Bitmap<T>& rhs) const{
+    return bitwise_proc(rhs, &Bitmap<T>::bitwise_or, &Bitmap<T>::or_postproc);
+}
+
+
+/**
+ * @brief override the operator |
+ *
+ * @param rhs   the bitmap
+ *
+ * @return the result of "this" | "rhs"
+ *
+ */
+template <typename T>
+inline
+Bitmap<T>
+Bitmap<T>::operator | (const Bitmap<T>& rhs) const{
+    ArrayType* res = bitwise_proc
+            (rhs, &Bitmap<T>::bitwise_or, &Bitmap<T>::or_postproc);
+    return res ? Bitmap(res, *this) : EMTYP_BITMAP;
+}
+
+
+/**
+ * @brief the bitwise and operation on two words
+ *
+ * @param lhs   the left word
+ * @param rhs   the right word
+ *
+ * @return lhs & rhs
+ */
+template <typename T>
+inline
+T
+Bitmap<T>::bitwise_and
+(
+    T lhs,
+    T rhs
+) const{
+    T res = 0;
+    if ((lhs ^ rhs) >= 0){
+        res = lhs & rhs;
+    }else if (lhs < 0 && rhs > 0){
+        res = BM_COMPWORD_ONE(lhs) ? rhs : m_cw_zero_mask | 1;
+    }else {
+        res = BM_COMPWORD_ONE(rhs) ? lhs : m_cw_zero_mask | 1;
+    }
+
+    // if all the bits of the result are 0, then use a composite word
+    // to represent it
+    return (0 == res) ? (m_cw_zero_mask | 1) : res;
+}
+
+
+/**
+ * @brief implement the operator &
+ *
+ * @param rhs   the bitmap
+ *
+ * @return the result of "this" & "rhs"
+ *
+ */
+template <typename T>
+inline
+ArrayType*
+Bitmap<T>::op_and (const Bitmap<T>& rhs) const{
+    return bitwise_proc(rhs, &Bitmap<T>::bitwise_and, &Bitmap<T>::and_postproc);
+}
+
+
+/**
+ * @brief override the operator &
+ *
+ * @param rhs   the bitmap
+ *
+ * @return the result of "this" & "rhs"
+ *
+ */
+template <typename T>
+inline
+Bitmap<T>
+Bitmap<T>::operator & (const Bitmap<T>& rhs) const{
+    ArrayType* res = bitwise_proc
+            (rhs, &Bitmap<T>::bitwise_and, &Bitmap<T>::and_postproc);
+    return res ? Bitmap(res, *this) : EMTYP_BITMAP;
+}
+
+
+/**
+ * @brief implement the operator ~
+ *
+ * @return the result of ~"this"
+ *
+ */
+template <typename T>
+inline
+ArrayType*
+Bitmap<T>::op_not () const{
+    T* result = new T[m_size];
+    T curword = 0;
+    int k = 1;
+    for (int i = 1; i < m_size; ++i){
+        curword = m_bitmap[i];
+        result[i] = (curword > 0) ?  (~m_cw_zero_mask) & (~curword) :
+                        BM_COMPWORD_SWAP(curword);
+    }
+
+    k = m_size - 1;
+    // If the highest bits of the last word are zeros, then those bits should
+    // not be reverted, since they are zeros without representing any numbers
+    // For example, ~0x00000FFF should be 0x00000000, and
+    // ~0x000030F0 should be 0x00000F0F
+    if (curword > 0){
+        if (1 == get_nonzero_cnt(curword + 1)){
+            --k;
+        }else{
+            T& lastword = result[k];
+            T mask = BM_CW_ONE_MASK ^ BM_CW_ZERO_MASK;
+            while ((lastword & mask) > 0){
+                lastword ^= mask;
+                mask >>= 1;
+            }
+        }
+    }
+    // trim the word with 0s
+    while((k > 0) && (result[k] < 0) && BM_COMPWORD_ZERO(result[k])){
+        --k;
+    }
+    if (0 == k)
+        return NULL;
+
+    result[0] = k + 1;
+    ArrayType* arr = alloc_array(result, k + 1);
+    delete[] result;
+    return arr;
+}
+
+
+/**
+ * @brief override the operator ~
+ *
+ * @param rhs   the bitmap
+ *
+ * @return the result of ~"this"
+ *
+ */
+template <typename T>
+inline
+Bitmap<T> Bitmap<T>::operator ~() const{
+    return Bitmap(op_not(), *this);
+}
+
+
+template <typename T>
+inline
+int32_t Bitmap<T>::operator [](size_t index) const{
+    int64_t curpos = 0;
+    int64_t numbits = 0;
+    for (int i = 1; i < m_size; ++i){
+        T word = m_bitmap[i];
+         numbits = (word > 0 ? 31 : BM_NUMBITS_IN_COMP(word));
+         curpos += numbits;
+        if (index <= curpos){
+            return BM_BIT_TEST(word, index - (curpos - numbits));
+        }
+    }
+    return 0;
+}
+/**
+ * @brief get the number of nonzero bits
+ *
+ * @return the nonzero count
+ */
+template <typename T>
+inline
+int64_t
+Bitmap<T>::nonzero_count() const{
+    int64_t   res = 0;
+    for (int i = 1; i < m_size; ++i){
+        if (m_bitmap[i] > 0){
+            res += get_nonzero_cnt(m_bitmap[i]);
+        }else{
+            // this is a composite word
+            res += (0 == (m_bitmap[i] & (m_wordcnt_mask + 1))) ?
+                    0 : (m_bitmap[i] & m_wordcnt_mask) * m_base;
+        }
+    }
+
+    return res;
+}
+
+
+/**
+ * @brief get the positions of the non-zero bits. The position starts from 1.
+ *
+ * @param result    the array used to keep the positions
+ *
+ * @return the array containing the positions whose bits are 1.
+ */
+template <typename T>
+inline
+int64_t
+Bitmap<T>::nonzero_positions(int64_t* result) const{
+    madlib_assert(result != NULL,
+            std::invalid_argument("the positions array must not be NULL"));
+    int64_t j = 0;
+    int64_t k = 1;
+    int64_t begin_pos = 1;
+    for (int i = 1; i < m_size; ++i){
+        k = begin_pos;
+        T word = m_bitmap[i];
+        if (word > 0){
+            do{
+                if (1 == (word & 0x01))
+                    result[j++] = k;
+                word >>= 1;
+                ++k;
+            }while (word > 0);
+            begin_pos += m_base;
+        }else{
+            if ((word & (m_wordcnt_mask + 1)) > 0){
+                int64_t n = (word & m_wordcnt_mask) * (int64_t)m_base;
+                for (; n > 0 ; --n){
+                    result[j++] = k++;
+                }
+            }
+            begin_pos += BM_NUMBITS_IN_COMP(word);
+        }
+    }
+
+    return j;
+}
+
+
+/**
+ * @brief get the positions of the non-zero bits. The position starts from 1.
+ *
+ * @return the array contains the positions
+ *
+ */
+template <typename T>
+inline
+ArrayType*
+Bitmap<T>::nonzero_positions() const{
+    int64_t* result = NULL;
+    int size = nonzero_count();
+    ArrayType* res_arr = alloc_array<int64_t>(result, size);
+    nonzero_positions(result);
+
+    return res_arr;
+}
+
+
+/**
+ * @brief allocate a new space for the string, the old space will be free
+ *
+ * @param oldstr    the old string
+ * @param len       the length of the old string
+ */
+template <typename T>
+inline
+char*
+Bitmap<T>::to_string_realloc
+(
+    char* oldstr,
+    int64_t& len
+) const{
+    // here, we shouldn't align the size, mustn't use BM_ALIGN_ALLOC0
+    len += MAXBITSOFINT64 * 16;
+    char* newstr = (char*)BM_ALLOC0(len* sizeof(char));
+    if (NULL != oldstr){
+        memcpy(newstr, oldstr, len * sizeof(char));
+        BM_FREE0(oldstr);
+        oldstr = NULL;
+    }
+
+    return newstr;
+}
+
+
+/**
+ * @brief construct a string for a series
+ *
+ * @param pstr      the string used to keep the input numbers
+ * @param totallen  the total length of the pstr
+ * @param curlen    the current length of the pstr
+ * @param cont_beg  the begin number for the series
+ * @param cont_cnt  the count of numbers in the series.
+ *
+ */
+template <typename T>
+inline
+char*
+Bitmap<T>::to_string_internal
+(
+    char* pstr,
+    int64_t& totallen,
+    int64_t& curlen,
+    int64_t& cont_beg,
+    int64_t& cont_cnt
+) const{
+    if (0 == cont_cnt)
+        return pstr;
+
+    int64_t len_beg = 0;
+    int64_t len_end = 0;
+    char str_beg[MAXBITSOFINT64 + 1] = {'\0'};
+    char str_end[MAXBITSOFINT64 + 1] = {'\0'};
+
+    if (cont_cnt >= 2){
+        len_beg = int64_to_string(str_beg, cont_beg);
+        len_end = int64_to_string(str_end, cont_beg + cont_cnt - 1);
+        if (len_beg + len_end + curlen + 3 > totallen){
+            pstr = to_string_realloc(pstr, curlen);
+        }
+        memcpy(pstr + curlen, str_beg, len_beg * sizeof(char));
+        curlen += len_beg;
+        *(pstr + curlen) = (2 == cont_cnt) ? ',' : '~';
+        ++curlen;
+        memcpy(pstr + curlen, str_end, len_end * sizeof(char));
+        curlen += len_end;
+    }else{
+        len_beg = int64_to_string(str_beg, cont_beg);
+        if (len_beg + curlen + 2 > totallen){
+            pstr = to_string_realloc(pstr, curlen);
+        }
+        memcpy(pstr + curlen, str_beg, len_beg * sizeof(char));
+        curlen += len_beg;
+    }
+
+    *(pstr + curlen) = ',';
+    ++curlen;
+    *(pstr + curlen) = '\0';
+    cont_cnt = 0;
+    cont_beg = 0;
+
+    return pstr;
+}
+
+
+/**
+ * @brief convert the bitmap to a readable format.
+ *        If more than 2 elements are continuous, then we use '~' to concat
+ *        the begin and the end of the continuous numbers. Otherwise, we will
+ *        use ',' to concat them.
+ *        e.g. assume the bitmap is '1,2,3,5,6,8,10,11,12,13'::bitmap, then
+ *        the output of to_string is '1~3,5,6,8,10~13'
+ *
+ * @return the readable string representation for the bitmap.
+ */
+template <typename T>
+inline
+char*
+Bitmap<T>::to_string() const{
+    int64_t k = 1;
+    int64_t begin_pos = 1;
+    int64_t cont_cnt = 0;
+    int64_t cont_begin = 0;
+    int64_t totallen = 0;
+    int64_t curlen = 0;
+    char* res = to_string_realloc(NULL, totallen);
+    for (int i = 1; i < m_size; ++i){
+        k = begin_pos;
+        T word = m_bitmap[i];
+        // a normal word
+        if (word > 0){
+            do{
+                if (1 == (word & 0x01)){
+                    ++cont_cnt;
+                    cont_begin = cont_begin > 0 ? cont_begin : k;
+                }else{
+                    res = to_string_internal
+                        (res, totallen, curlen, cont_begin, cont_cnt);
+                }
+                word >>= 1;
+                ++k;
+            }while (word > 0);
+
+            if (0 == (m_bitmap[i] & (m_wordcnt_mask + 1))){
+                res = to_string_internal
+                    (res, totallen, curlen, cont_begin, cont_cnt);
+            }
+            begin_pos += m_base;
+        }else{
+            int64_t numbits = BM_NUMBITS_IN_COMP(word);
+            if (BM_COMPWORD_ONE(word)){
+                cont_begin = cont_begin > 0 ? cont_begin : k;
+                cont_cnt += numbits;
+            }else{
+                res = to_string_internal
+                        (res, totallen, curlen, cont_begin, cont_cnt);
+            }
+            begin_pos += numbits;
+        }
+    }
+
+    if (cont_cnt > 0){
+        res = to_string_internal
+                (res, totallen, curlen, cont_begin, cont_cnt);
+    }
+
+    *(res + curlen - 1) = '\0';
+
+    return res;
+}
+
+
+/**
+ * @brief convert the bitmap to varbit
+ *
+ * @return the varbit representation for the bitmap
+ */
+template <typename T>
+inline
+VarBit*
+Bitmap<T>::to_varbit() const{
+    int64_t size = nonzero_count();
+    int64_t* pos = new int64_t[size];
+    nonzero_positions(pos);
+
+    // get the varbit related information
+    int64_t bitlen = pos[size - 1];
+    int64_t alignlen = ((bitlen + 7) >> 3) << 3;
+    int64_t ignorebits = alignlen - bitlen;
+    int64_t len = VARBITTOTALLEN(bitlen);
+    VarBit* result = (VarBit*)BM_ALIGN_ALLOC0(len);
+    SET_VARSIZE(result, len);
+    VARBITLEN(result) = bitlen;
+    bits8* pres = VARBITS(result);
+    int64_t arrlen = (alignlen >> 3);
+
+    // set the varbit
+    for (int i = 0; i < size; ++i){
+        int64_t curpos = pos[i] + ignorebits;
+        int64_t curindex = arrlen - ((curpos + 7) >> 3);
+        curpos &= 0x07;
+        curpos = (0 == curpos) ? 7 : curpos - 1;
+        *(pres + curindex) += ((bits8)1 << curpos);
+    }
+    return result;
+}
+
+
+/**
+ * @brief transform the bitmap to an ArrayHandle instance
+ *
+ * @param use_capacity  true if we don't trim the 0 elements
+ *
+ * @param the ArrayHandle instance for the given bitmap.
+ */
+template <typename T>
+inline
+ArrayType*
+Bitmap<T>::to_ArrayType
+(
+    bool use_capacity /* = true */
+) const{
+    if (use_capacity || (m_size == m_capacity))
+        return m_bmArray;
+
+    if (empty())
+        return NULL;
+
+    // do not change m_bitmap and m_bmArray
+    return alloc_array(m_bitmap, m_size);
+}
+
+} // namespace bitmap
+} // namespace modules
+} // namespace madlib
+
+#endif

--- a/src/modules/bitmap/Bitmap_proto.hpp
+++ b/src/modules/bitmap/Bitmap_proto.hpp
@@ -1,0 +1,420 @@
+#ifndef MADLIB_MODULES_BITMAP_BITMAP_PROTO_HPP
+#define MADLIB_MODULES_BITMAP_BITMAP_PROTO_HPP
+
+#include <dbconnector/dbconnector.hpp>
+
+
+namespace madlib {
+namespace modules {
+namespace bitmap {
+
+using madlib::dbconnector::postgres::madlib_get_typlenbyvalalign;
+
+// the public interfaces for bitmap
+#define RETURN_BITMAP_INTERNAL(val, T) \
+            return AnyType(ArrayHandle<T>(val), false, false)
+#define RETURN_BITMAP_NULL_INTERNAL(val, T) \
+            const ArrayType* res = val; \
+            return NULL != res ? AnyType(ArrayHandle<T>(res), false, false) : AnyType()
+#define RETURN_ARRAY(val, T) \
+            return AnyType(ArrayHandle<T>(val), false, false)
+#define RETURN_BASE(val) \
+            return AnyType(val)
+#define GETARG_MUTABLE_BITMAP_INTERNAL(arg, T) \
+            ((arg).getAs< MutableArrayHandle<T> >(false, false))
+#define GETARG_CLONED_BITMAP_INTERNAL(arg, T) \
+            ((arg).getAs< MutableArrayHandle<T> >(false, true))
+#define GETARG_IMMUTABLE_BITMAP_INTERNAL(arg, T) \
+            ((arg).getAs< ArrayHandle<T> >(false, false))
+
+// return
+#define RETURN_BITMAP(val)             RETURN_BITMAP_INTERNAL(val, int32_t)
+#define RETURN_BITMAP_NULL(val)        RETURN_BITMAP_NULL_INTERNAL(val, int32_t)
+#define RETURN_INT4_ARRAY(val)         RETURN_ARRAY(val, int32_t)
+#define RETURN_INT8_ARRAY(val)         RETURN_ARRAY(val, int64_t)
+
+// get arguments
+#define GETARG_MUTABLE_BITMAP(arg)     GETARG_MUTABLE_BITMAP_INTERNAL(arg, int32_t)
+#define GETARG_CLONED_BITMAP(arg)      GETARG_CLONED_BITMAP_INTERNAL(arg, int32_t)
+#define GETARG_IMMUTABLE_BITMAP(arg)   GETARG_IMMUTABLE_BITMAP_INTERNAL(arg, int32_t)
+
+// internal defines
+#define INT64FORMAT     "%lld"
+#define MAXBITSOFINT64  25
+#define BYTESIZE        8
+// the nonzero positions array may be extremely large
+// here we limit it to 32MB
+#define BM_MAX_BITS     (1<<25)
+
+#define DEFAULT_SIZE_PER_ADD    16
+#define EMTYP_BITMAP            Bitmap(1, DEFAULT_SIZE_PER_ADD)
+
+#define BM_BASE             (sizeof(T) * BYTESIZE - 1)
+#define BM_WORDCNT_MASK     (((T)1 << (BM_BASE - 1)) - 1)
+#define BM_CW_ZERO_MASK     ((T)1 << BM_BASE)
+#define BM_CW_ONE_MASK      ((T)3 << (BM_BASE - 1))
+
+// the following macros will be used to calculate the number of 1s in an integer
+#define BM_POW(c, T)        ((T)1<<(c))
+#define BM_MASK(c, T)       (((T)-1) / (BM_POW(BM_POW(c, T), T) + 1))
+#define BM_ROUND(n, c, T)   (((n) & BM_MASK(c, T)) + ((n) >> BM_POW(c, T) & BM_MASK(c, T)))
+
+// align the 'val' with 'align' length
+#define BM_ALIGN(val, align)    ((((val) + (align) - 1) / (align)) * (align))
+
+// does the composite word represent continuous 1s
+#define BM_COMPWORD_ONE(val)    (((val) & (m_wordcnt_mask + 1)) > 0)
+// does the composite word represent continuous 0s
+#define BM_COMPWORD_ZERO(val)   (((val) & (m_wordcnt_mask + 1)) == 0)
+// change a composite word with 1s/0s to a composite word with 0s/1s
+#define BM_COMPWORD_SWAP(val) \
+    BM_NUMWORDS_IN_COMP(val) | (((val) & m_cw_one_mask) ^ (m_wordcnt_mask + 1))
+
+// the two composite words are the same sign?
+#define BM_SAME_SIGN(lhs, rhs) (((lhs) < 0) && ((rhs) < 0) && \
+                               (0 == (((lhs) ^ (rhs)) & (m_wordcnt_mask + 1))))
+
+// get the number of words for representing the input number
+#define BM_NUMWORDS_FOR_BITS(val)   (((val) + m_base - 1) / m_base)
+// get the number of words in the composite word
+#define BM_NUMWORDS_IN_COMP(val)    ((val) & m_wordcnt_mask)
+#define BM_NUMBITS_IN_COMP(val)     BM_NUMWORDS_IN_COMP(val) * (int64_t)m_base
+#define BM_BIT_TEST(val, bit)  \
+         ((val) > 0 ?  (((val) & (1 << ((bit) - 1))) > 0) : BM_COMPWORD_ONE(val))
+
+// the maximum value for a composite word with continuous 1s/0s
+#define BM_COMP_ONE_MAX(val)   (val == ((T)-1))
+#define BM_COMP_ZERO_MAX(val)  (val == (m_wordcnt_mask | m_cw_zero_mask))
+
+// get the maximum 0s or 1s can be represented by a composite word
+// for bitmap4, its 0x3F FF FF FF.
+#define BM_MAXBITS_IN_COMP ((int64_t)1 << (m_base - 1)) - 1
+
+// the wrapper for palloc0, this function will not align the 'size'
+#define BM_ALLOC0(size) palloc0(size)
+#define BM_FREE0(ptr)   pfree(ptr);
+
+// the madlib allocation function will align the 'size' to 16
+#define BM_ALIGN_ALLOC0(size) madlib::defaultAllocator().allocate<\
+        madlib::dbal::FunctionContext, \
+        madlib::dbal::DoZero, \
+        madlib::dbal::ThrowBadAlloc>(size)
+
+// wrapper definition for ArrayType related functions
+#define BM_ARR_DATA_PTR(val, T) reinterpret_cast<T*>(ARR_DATA_PTR(val))
+#define BM_ARRAY_LENGTH(val) ArrayGetNItems(ARR_NDIM(val), ARR_DIMS(val))
+#define BM_CONSTRUCT_ARRAY(result, size) \
+    construct_array( result, size, m_typoid, m_typlen, m_typbyval, m_typalign);
+#define BM_CONSTRUCT_ARRAY_TYPE(result, size, typoid, typlen, typbyval, typalign) \
+    construct_array( result, size, typoid, typlen, typbyval, typalign);
+
+#define BM_CHECK_ARRAY_SIZE(array, size)     \
+        madlib_assert((NULL != (array)) && (size == (array)[0]), \
+        std::invalid_argument("invalid bitmap"));
+
+/**
+ * the class for building and manipulating the bitmap.
+ * We use an array as the underlying implementation for the bitmap. The first
+ * element in the array keeps the real size of that array. The reasons why we
+ * keep the real size of the array are:
+ *  1) As the capacity of the array is always greater than the real size,
+ *  we can get the real size of the array using the first element rather than
+ *  traverse the whole array to get the real size;
+ *  2) one addition element is small compared to the whole Array.
+ *
+ * the bitmap array can be dynamically reallocated. If the required size of the
+ * bitmap is greater than the capacity of the bitmap, then we will allocate a
+ * new memory for the new bitmap and copy the old bitmap elements to the new one.
+ * And we define a parameter "size_per_add" to indicate the number of elements
+ * will be added to the bitmap array.
+ *
+ */
+// T* is the type of the underlying storage for the bitmap
+template <typename T>
+class Bitmap{
+    // function pointers for bitwise operation
+    typedef T (Bitmap<T>::*bitwise_op)(T, T) const;
+    typedef int (Bitmap<T>::*bitwise_postproc)(T*, int, const Bitmap<T>&, int, T, T) const;
+
+public:
+    //ctor
+    Bitmap(int capacity, int size_per_add);
+
+    //ctor
+    Bitmap(ArrayType* arr, Bitmap& rhs);
+
+    //ctor
+    Bitmap(ArrayHandle<T> handle, int size_per_add = DEFAULT_SIZE_PER_ADD);
+
+    //ctor
+    Bitmap(Bitmap& rhs);
+
+    // construct a bitmap from the input string
+    // the format of input string looks like "1,3,19,20".
+    // we use comma to separate the numbers
+    Bitmap(char* rhs);
+
+    // construct a bitmap from the varbit
+    Bitmap(VarBit* bits);
+
+    // if the bitmap was reallocated, the flag will be set to true
+    inline bool updated() const{
+        return m_bitmap_updated;
+    }
+
+    // is the bitmap full
+    inline bool full() const{
+        return m_size == m_capacity;
+    }
+
+    inline bool empty() const{
+        return 1 == m_size;
+    }
+
+    // insert the specified number to the bitmap
+    inline Bitmap& insert(int64_t number);
+
+    // set the specified bit to 0
+    inline ArrayType* reset(int64_t number);
+
+    // transform the bitmap to an ArrayType* instance
+    inline ArrayType* to_ArrayType(bool use_capacity = true) const;
+
+    // override bitwise operators
+    inline Bitmap operator | (const Bitmap& rhs) const;
+    inline Bitmap operator & (const Bitmap& rhs) const;
+    inline Bitmap operator ~() const;
+    inline Bitmap operator ^(const Bitmap& rhs) const;
+
+    // override operator []
+    inline int32_t operator [](size_t index) const;
+
+    // to avoid the overhead of constructing bitmap object and ArrayHandle object,
+    // the functions start with op_ will return ArrayType*
+    inline ArrayType* op_or(const Bitmap& rhs) const;
+    inline ArrayType* op_and(const Bitmap& rhs) const;
+    inline ArrayType* op_xor(const Bitmap& rhs) const;
+    inline ArrayType* op_not() const;
+
+    // convert the bitmap to a readable format
+    inline char* to_string() const;
+
+    // convert the bitmap to varbit
+    inline VarBit* to_varbit() const;
+
+    // get the positions of the non-zero bits. The position starts from 1
+    inline ArrayType* nonzero_positions() const;
+
+    // get the number of nonzero bits
+    inline int64_t nonzero_count() const;
+
+protected:
+    // insert the specified number to the composite word
+    inline void insert_compword(int64_t number, int64_t num_words, int index);
+
+    // breakup the composite word, and insert the number to it
+    inline void breakup_compword (T* newbitmap, int index,
+            int pos_in_word, int word_pos, int num_words);
+
+    // append a number to the bitmap
+    inline void append(int64_t number);
+
+    // merge a normal word to a composite word
+    inline void merge_norm_to_comp(T& curword, int index);
+
+    // the entry function for doing the bitwise operations,
+    // such as | and &, etc.
+    inline ArrayType* bitwise_proc(const Bitmap<T>& rhs, bitwise_op op,
+            bitwise_postproc postproc) const;
+
+    // bitwise operation on a normal word and a composite word
+    inline T bitwise_norm_comp_words(T& norm, T& comp, int& i, int& j,
+                    T* lhs, T* rhs, bitwise_op op) const;
+
+    // bitwise operation on two composite words
+    inline T bitwise_comp_comp_words(T& lword, T& rword, int& i, int& j,
+                    T* lhs, T* rhs) const;
+
+    // lhs | rhs. If both lhs and rhs are composite words, then return
+    // the sign of the result
+    inline T bitwise_or(T lhs, T rhs) const;
+    // the post-processing for the OR operation. the remainder bitmap elements
+    // will do the | operation with zero
+    inline int or_postproc(T* result, int k, const Bitmap<T>& bitmap,
+                            int i, T curword, T pre_word) const;
+
+    // lhs & rhs. If both lhs and rhs are composite words, then return
+    // the sign of the result
+    inline T bitwise_and(T lhs, T rhs) const;
+    // the post-processing for the AND operation. Here, we do nothing,
+    // since the result of any words & zero is zero.
+    inline int and_postproc(T*, int k, const Bitmap<T>&, int, T, T) const{
+        return k;
+    }
+
+    // lhs ^ rhs. If both lhs and rhs are composite words, then return
+    // the sign of the result
+    inline T bitwise_xor(T lhs, T rhs) const;
+    // the post-processing for the AND operation. the remainder bitmap elements
+    // will do the ^ operation with zero
+    inline int xor_postproc(T*, int k, const Bitmap<T>&, int, T, T) const;
+
+    // get the number of 1s
+    inline int64_t get_nonzero_cnt(int32_t value) const{
+        uint32_t res = value;
+        res = BM_ROUND(res, 0, uint32_t);
+        res = BM_ROUND(res, 1, uint32_t);
+        res = BM_ROUND(res, 2, uint32_t);
+        res = BM_ROUND(res, 3, uint32_t);
+        res = BM_ROUND(res, 4, uint32);
+
+        return static_cast<int64_t>(res);
+    }
+
+    // get the number of 1s
+    inline int64_t get_nonzero_cnt(int64_t value) const{
+        uint64 res = value;
+        res = BM_ROUND(res, 0, uint64);
+        res = BM_ROUND(res, 1, uint64);
+        res = BM_ROUND(res, 2, uint64);
+        res = BM_ROUND(res, 3, uint64);
+        res = BM_ROUND(res, 4, uint64);
+        res = BM_ROUND(res, 5, uint64);
+
+        return static_cast<T>(res);
+    }
+
+    // get an array containing the positions of the nonzero bits
+    // the input parameter should not be null
+    inline int64_t nonzero_positions(int64_t* result) const;
+
+    // get an array containing the positions of the nonzero bits
+    // the function will allocate memory for holding the positions
+    // the size of the array is passed by reference, the returned value
+    // is the nonzero positions
+    inline int64_t* nonzero_positions(int64_t& size) const;
+
+    // retrieve the max number stored in the bitmap
+    inline int64_t max_number() const;
+
+    // allocate a new array with ArrayType encapsulated
+    // X is the type of the array, we need to search the type
+    // related information from cache.
+    template <typename X>
+    inline ArrayType* alloc_array(X*& res, int size) const{
+        Oid typoid = get_Oid((X)0);
+        int16 typlen;
+        bool typbyval;
+        char typalign;
+
+        madlib_get_typlenbyvalalign
+                    (typoid, &typlen, &typbyval, &typalign);
+
+        ArrayType* arr = BM_CONSTRUCT_ARRAY_TYPE(
+                (Datum*)NULL, size, typoid, typlen, typbyval, typalign);
+        res = BM_ARR_DATA_PTR(arr, X);
+
+        return arr;
+    }
+
+    // allocate an array to keep the elements in 'oldarr'
+    // the number of those elements is 'size'. The type of
+    // the array is T.
+    inline ArrayType* alloc_array(T* oldarr, int size) const{
+        ArrayType* res = BM_CONSTRUCT_ARRAY((Datum*)NULL, size);
+        memcpy(BM_ARR_DATA_PTR(res, T), oldarr, size * sizeof(T));
+
+        return res;
+    }
+
+    // allocate a new bitmap, all elements are zeros
+    inline T* alloc_bitmap(int size){
+        m_bmArray = BM_CONSTRUCT_ARRAY((Datum*)NULL, size);
+        return BM_ARR_DATA_PTR(m_bmArray, T);
+    }
+
+    // allocate a new bitmap, and copy the oldbitmap to the new bitmap
+    inline T* alloc_bitmap(int newsize, T* oldbitmap, int oldsize){
+        T* result = alloc_bitmap(newsize);
+        memcpy(result, oldbitmap, oldsize * sizeof(T));
+
+        return result;
+    }
+
+
+    // get the inserting position for the input number.
+    // The result is in range of [1, m_base]
+    inline int get_pos_word(int64_t number) const{
+        int pos = number % m_base;
+        return 0 == pos  ? m_base : pos;
+    }
+
+    // transform the specified value to a Datum
+    inline Datum get_Datum(int32_t elem) const{
+        return Int32GetDatum(elem);
+    }
+
+    // transform the specified value to a Datum
+    inline Datum get_Datum(int64_t elem) const{
+        return Int64GetDatum(elem);
+    }
+
+    // get the OID for int32
+    inline Oid get_Oid(int32_t) const{
+        return INT4OID;
+    }
+
+    // get the OID for int64_t
+    inline Oid get_Oid(int64_t) const{
+        return INT8OID;
+    }
+
+    // set the type related information to the member variables
+    inline void set_typInfo(){
+        m_typoid = get_Oid((T)0);
+        madlib_get_typlenbyvalalign
+            (m_typoid, &m_typlen, &m_typbyval, &m_typalign);
+    }
+
+    char* to_string_realloc(char* oldstr, int64_t& len) const;
+    char* to_string_internal(char* pstr, int64_t& totallen, int64_t& curlen,
+            int64_t& cont_beg, int64_t& cont_cnt) const;
+
+    // convert int64 number to a string
+    int int64_to_string (char* result, int64_t value) const{
+        int len = 0;
+        if ((len = snprintf(result, MAXBITSOFINT64, INT64FORMAT, value)) < 0)
+            throw std::invalid_argument("the input value is not int8 number");
+        result[len] = '\0';
+
+        return len;
+    }
+
+private:
+    // the bitmap array related info
+    ArrayType* m_bmArray;
+    T* m_bitmap;
+    int m_size;
+    int m_capacity;
+    int m_size_per_add;
+    bool m_bitmap_updated;
+
+    // const variables
+    const int m_base;
+    const T m_wordcnt_mask;
+    const T m_cw_zero_mask;
+    const T m_cw_one_mask;
+
+    // type information
+    Oid m_typoid;
+    int16 m_typlen;
+    bool m_typbyval;
+    char m_typalign;
+
+}; // class bitmap
+
+} // namespace bitmap
+} // namespace modules
+} // namespace madlib
+
+#endif

--- a/src/modules/bitmap/bitmap.cpp
+++ b/src/modules/bitmap/bitmap.cpp
@@ -1,0 +1,238 @@
+#include <dbconnector/dbconnector.hpp>
+
+#include "BitmapUtil.hpp"
+#include "bitmap.hpp"
+
+namespace madlib {
+namespace modules {
+namespace bitmap {
+
+/**
+ * @brief the step function for the bitmap_agg.
+ */
+AnyType
+bitmap_agg_sfunc::run(AnyType &args){
+    RETURN_BITMAP(BitmapUtil::bitmap_agg_sfunc<int32_t>(args));
+}
+
+/**
+ * @brief the pre-function for the bitmap_agg.
+ */
+AnyType
+bitmap_agg_pfunc::run(AnyType &args){
+    RETURN_BITMAP_NULL(BitmapUtil::bitmap_agg_pfunc<int32_t>(args));
+}
+
+
+/**
+ * @brief the operator "AND" implementation
+ */
+AnyType
+bitmap_and::run(AnyType &args){
+    RETURN_BITMAP_NULL(BitmapUtil::bitmap_and<int32_t>(args));
+}
+
+
+/**
+ * @brief the operator "OR" implementation
+ */
+AnyType
+bitmap_or::run(AnyType &args){
+    RETURN_BITMAP(BitmapUtil::bitmap_or<int32_t>(args));
+}
+
+
+/**
+ * @brief the operator "XOR" implementation
+ */
+AnyType
+bitmap_xor::run(AnyType &args){
+    RETURN_BITMAP_NULL(BitmapUtil::bitmap_xor<int32_t>(args));
+}
+
+
+/**
+ * @brief the operator "NOT" implementation
+ */
+AnyType
+bitmap_not::run(AnyType &args){
+    RETURN_BITMAP_NULL(BitmapUtil::bitmap_not<int32_t>(args));
+}
+
+
+/**
+ * @brief set the specified bit to 1/0
+ */
+AnyType
+bitmap_set::run(AnyType &args){
+    RETURN_BITMAP(BitmapUtil::bitmap_set<int32_t>(args));
+}
+
+
+/**
+ * @brief test whether the specified bit is 1
+ */
+AnyType
+bitmap_test::run(AnyType &args){
+    RETURN_BASE(BitmapUtil::bitmap_test<int32_t>(args));
+}
+
+/**
+ * @brief get the number of bits whose value is 1.
+ */
+AnyType
+bitmap_nonzero_count::run(AnyType &args){
+    RETURN_BASE(BitmapUtil::bitmap_nonzero_count<int32_t>(args));
+}
+
+
+/**
+ * @brief get the positions of the non-zero bits.
+ * @note the position start from 1.
+ */
+AnyType
+bitmap_nonzero_positions::run(AnyType &args){
+    RETURN_INT8_ARRAY(BitmapUtil::bitmap_nonzero_positions<int32_t>(args));
+}
+
+
+/**
+ * @brief get the bitmap representation for the int64 array
+ */
+AnyType
+bitmap_from_int8array::run(AnyType &args){
+    RETURN_BITMAP_NULL((BitmapUtil::bitmap_from_array<int32_t, int64_t>(args)));
+}
+
+
+/**
+ * @brief get the bitmap representation for the int32 array
+ */
+AnyType
+bitmap_from_int4array::run(AnyType &args){
+    RETURN_BITMAP_NULL((BitmapUtil::bitmap_from_array<int32_t, int32_t>(args)));
+}
+
+
+/**
+ * @brief get the bitmap representation for the varbit
+ */
+AnyType
+bitmap_from_varbit::run(AnyType &args){
+    RETURN_BITMAP_NULL((BitmapUtil::bitmap_from_varbit<int32_t>(args)));
+}
+
+
+/**
+ * @brief the in function for the bitmap
+ */
+AnyType
+bitmap_in::run(AnyType &args){
+    RETURN_BITMAP(BitmapUtil::bitmap_in<int32_t>(args));
+}
+
+
+/**
+ * @brief the out function for the bitmap
+ */
+AnyType
+bitmap_out::run(AnyType &args){
+    RETURN_BASE(BitmapUtil::bitmap_out<int32_t>(args));
+}
+
+
+/**
+ * @brief cast the specified varbit to the bitmap representation
+ */
+AnyType
+bitmap_return_varbit::run(AnyType &args){
+    RETURN_BASE(BitmapUtil::bitmap_return_varbit<int32_t>(args));
+}
+
+
+/**
+ * @brief return the internal representation (array) of the bitmap
+ */
+AnyType
+bitmap_return_array::run(AnyType &args){
+    RETURN_INT4_ARRAY(BitmapUtil::bitmap_return_array<int32_t>(args));
+}
+
+
+void*
+bitmap_unnest::SRF_init(AnyType &args) {
+    return BitmapUtil::bitmap_unnest_init<int32_t>(args);
+}
+
+AnyType
+bitmap_unnest::SRF_next(void *user_fctx, bool *is_last_call) {
+    int64_t res = BitmapUtil::bitmap_unnest_next<int32_t>(user_fctx, is_last_call);
+    return -1 == res ? AnyType() : AnyType(res);
+}
+
+
+/**
+ * @brief the implementation of operator =
+ */
+AnyType
+bitmap_eq::run(AnyType &args){
+    RETURN_BASE(BitmapUtil::bitmap_eq<int32_t>(args));
+}
+
+
+/**
+ * @brief the implementation of operator !=
+ */
+AnyType
+bitmap_neq::run(AnyType &args){
+    RETURN_BASE(!BitmapUtil::bitmap_eq<int32_t>(args));
+}
+
+
+/**
+ * @brief the implementation of operator >
+ */
+AnyType
+bitmap_gt::run(AnyType &args){
+    RETURN_BASE(BitmapUtil::bitmap_gt<int32_t>(args));
+}
+
+
+/**
+ * @brief the implementation of operator <
+ */
+AnyType
+bitmap_lt::run(AnyType &args){
+    RETURN_BASE(!BitmapUtil::bitmap_ge<int32_t>(args));
+}
+
+
+/**
+ * @brief the implementation of operator >=
+ */
+AnyType
+bitmap_ge::run(AnyType &args){
+    RETURN_BASE(BitmapUtil::bitmap_ge<int32_t>(args));
+}
+
+
+/**
+ * @brief the implementation of operator <=
+ */
+AnyType
+bitmap_le::run(AnyType &args){
+    RETURN_BASE(!BitmapUtil::bitmap_gt<int32_t>(args));
+}
+
+
+/**
+ * @brief compare the two bitmaps
+ */
+AnyType
+bitmap_cmp::run(AnyType &args){
+    RETURN_BASE(BitmapUtil::bitmap_cmp<int32_t>(args));
+}
+
+} // bitmap
+} // modules
+} // madlib

--- a/src/modules/bitmap/bitmap.hpp
+++ b/src/modules/bitmap/bitmap.hpp
@@ -1,0 +1,36 @@
+/* ----------------------------------------------------------------------- *//**
+ *
+ * @file bitmap.hpp
+ *
+ * The functions' declarations for the plc functions in bitmap.sql_in
+ *
+ *//* ----------------------------------------------------------------------- */
+
+
+DECLARE_UDF(bitmap, bitmap_agg_sfunc)
+DECLARE_UDF(bitmap, bitmap_agg_pfunc)
+DECLARE_UDF(bitmap, bitmap_and)
+DECLARE_UDF(bitmap, bitmap_or)
+DECLARE_UDF(bitmap, bitmap_xor)
+DECLARE_UDF(bitmap, bitmap_not)
+DECLARE_UDF(bitmap, bitmap_set)
+DECLARE_UDF(bitmap, bitmap_test)
+DECLARE_UDF(bitmap, bitmap_out)
+DECLARE_UDF(bitmap, bitmap_in)
+DECLARE_UDF(bitmap, bitmap_return_array)
+DECLARE_UDF(bitmap, bitmap_return_varbit)
+DECLARE_UDF(bitmap, bitmap_nonzero_count)
+DECLARE_UDF(bitmap, bitmap_nonzero_positions)
+DECLARE_UDF(bitmap, bitmap_from_int8array)
+DECLARE_UDF(bitmap, bitmap_from_int4array)
+DECLARE_UDF(bitmap, bitmap_from_varbit)
+DECLARE_UDF(bitmap, bitmap_eq)
+DECLARE_UDF(bitmap, bitmap_neq)
+DECLARE_UDF(bitmap, bitmap_le)
+DECLARE_UDF(bitmap, bitmap_ge)
+DECLARE_UDF(bitmap, bitmap_lt)
+DECLARE_UDF(bitmap, bitmap_gt)
+DECLARE_UDF(bitmap, bitmap_cmp)
+DECLARE_SR_UDF(bitmap, bitmap_unnest)
+
+

--- a/src/modules/declarations.hpp
+++ b/src/modules/declarations.hpp
@@ -14,3 +14,6 @@
 #include "convex/convex.hpp"
 #include "crf/linear_crf.hpp"
 #include "assoc_rules/assoc_rules.hpp"
+#include "bitmap/bitmap.hpp"
+
+

--- a/src/ports/greenplum/dbconnector/dbconnector.hpp
+++ b/src/ports/greenplum/dbconnector/dbconnector.hpp
@@ -23,6 +23,7 @@ extern "C" {
     #include <utils/array.h>
     #include <utils/builtins.h>    // needed for format_procedure()
     #include <utils/datum.h>
+    #include <utils/varbit.h>
     #include <utils/lsyscache.h>   // for type lookup, e.g., type_is_rowtype
     #include <utils/memutils.h>
     #include <utils/syscache.h>    // for direct access to catalog, e.g., SearchSysCache()

--- a/src/ports/postgres/dbconnector/AnyType_proto.hpp
+++ b/src/ports/postgres/dbconnector/AnyType_proto.hpp
@@ -33,8 +33,15 @@ class AnyType {
 public:
     AnyType();
     template <typename T> AnyType(const T& inValue,
-        bool inForceLazyConversionToDatum = false);
-    template <typename T> T getAs() const;
+        bool inForceLazyConversionToDatum = false,
+        bool isCheckType = true);
+
+    // Set isCheckType to false, if you don't want to check the type of this instance.
+    // Set isCloneMutable to false, if you don't want to copy the mutable TypeTraits,
+    // for example, in the aggregate step/pre/final function, we always get the state by
+    // setting isCloneMutable to false.
+    template <typename T> T getAs(bool isCheckType = true, bool isCloneMutable = true) const;
+
     AnyType operator[](uint16_t inID) const;
     uint16_t numFields() const;
     bool isNull() const;

--- a/src/ports/postgres/dbconnector/Compatibility.hpp
+++ b/src/ports/postgres/dbconnector/Compatibility.hpp
@@ -20,6 +20,10 @@ namespace {
     #define FLOAT8ARRAYOID 1022
 #endif
 
+#ifndef INT8ARRAYOID
+    #define INT8ARRAYOID 1016
+#endif
+
 #ifndef PG_GET_COLLATION
 // See madlib_InitFunctionCallInfoData()
 #define PG_GET_COLLATION()	InvalidOid

--- a/src/ports/postgres/dbconnector/SystemInformation_impl.hpp
+++ b/src/ports/postgres/dbconnector/SystemInformation_impl.hpp
@@ -435,14 +435,13 @@ FunctionInformation::getReturnType(FunctionCallInfo fcinfo) {
             "FunctionInformation::getReturnType()."));
 
     Oid returnType = rettype;
-    if (rettype != RECORDOID &&
+    if (rettype != RECORDOID && rettype != CSTRINGOID &&
         mSysInfo->typeInformation(rettype)->type == TYPTYPE_PSEUDO) {
         // The function is polymorphic, and the result type thus depends on the
         // expression parse tree. Note that the condition in the if-clause is
         // sufficient condition for cachedFuncInfo->polymorphic, but not a
         // necessary condition. (A function could have input arguments with
         // pseudo types, but a fixed return type.)
-
         madlib_assert(polymorphic,
             std::logic_error("Logical error: Function returns non-record "
                 "pseudo type but is not polymorphic."));

--- a/src/ports/postgres/dbconnector/TypeTraits_impl.hpp
+++ b/src/ports/postgres/dbconnector/TypeTraits_impl.hpp
@@ -220,17 +220,45 @@ struct TypeTraits<bool> {
     WITH_TO_CXX_CONVERSION( DatumGetBool(value) );
 };
 
+
 template <>
-struct TypeTraits<char*> {
-    typedef char* value_type;
+struct TypeTraits<text*> {
+    typedef text* value_type;
 
     WITH_OID( TEXTOID );
     WITH_TYPE_CLASS( dbal::SimpleType );
     WITH_MUTABILITY( dbal::Immutable );
     WITH_DEFAULT_EXTENDED_TRAITS;
-    WITH_TO_PG_CONVERSION(PointerGetDatum(cstring_to_text(value)));
-    WITH_TO_CXX_CONVERSION(text_to_cstring(DatumGetTextPP(value)));
+    WITH_TO_PG_CONVERSION(PointerGetDatum(value));
+    WITH_TO_CXX_CONVERSION(DatumGetTextPP(value));
 };
+
+
+template <>
+struct TypeTraits<char*> {
+    typedef char* value_type;
+
+    WITH_OID( CSTRINGOID );
+    WITH_TYPE_CLASS( dbal::SimpleType );
+    WITH_MUTABILITY( dbal::Immutable );
+    WITH_DEFAULT_EXTENDED_TRAITS;
+    WITH_TO_PG_CONVERSION(CStringGetDatum(value));
+    WITH_TO_CXX_CONVERSION(DatumGetCString(value));
+};
+
+
+template <>
+struct TypeTraits<VarBit*> {
+    typedef VarBit* value_type;
+
+    WITH_OID( VARBITOID );
+    WITH_TYPE_CLASS( dbal::SimpleType );
+    WITH_MUTABILITY( dbal::Immutable );
+    WITH_DEFAULT_EXTENDED_TRAITS;
+    WITH_TO_PG_CONVERSION(VarBitPGetDatum(value));
+    WITH_TO_CXX_CONVERSION(DatumGetVarBitP(value));
+};
+
 
 template <>
 struct TypeTraits<ByteString> : public TypeTraitsBase<ByteString> {
@@ -280,6 +308,30 @@ template <>
 struct TypeTraits<MutableArrayHandle<int32_t> >
   : public TypeTraitsBase<MutableArrayHandle<int32_t> > {
     enum { oid = INT4ARRAYOID };
+    enum { isMutable = dbal::Mutable };
+    enum { typeClass = dbal::ArrayType };
+    WITH_TO_PG_CONVERSION( PointerGetDatum(value.array()) );
+    WITH_TO_CXX_CONVERSION(
+        needMutableClone
+          ? madlib_DatumGetArrayTypePCopy(value)
+          : madlib_DatumGetArrayTypeP(value)
+    );
+};
+
+template <>
+struct TypeTraits<ArrayHandle<int64_t> >
+  : public TypeTraitsBase<ArrayHandle<int64_t> > {
+    enum { oid = INT8ARRAYOID };
+    enum { isMutable = dbal::Immutable };
+    enum { typeClass = dbal::ArrayType };
+    WITH_TO_PG_CONVERSION( PointerGetDatum(value.array()) );
+    WITH_TO_CXX_CONVERSION( madlib_DatumGetArrayTypeP(value) );
+};
+
+template <>
+struct TypeTraits<MutableArrayHandle<int64_t> >
+  : public TypeTraitsBase<MutableArrayHandle<int64_t> > {
+    enum { oid = INT8ARRAYOID };
     enum { isMutable = dbal::Mutable };
     enum { typeClass = dbal::ArrayType };
     WITH_TO_PG_CONVERSION( PointerGetDatum(value.array()) );

--- a/src/ports/postgres/dbconnector/dbconnector.hpp
+++ b/src/ports/postgres/dbconnector/dbconnector.hpp
@@ -29,6 +29,7 @@ extern "C" {
     #include <utils/memutils.h>
     #include <utils/syscache.h>    // for direct access to catalog, e.g., SearchSysCache()
     #include <utils/typcache.h>    // type conversion, e.g., lookup_rowtype_tupdesc
+    #include <utils/varbit.h>
     #include "../../../../methods/svec/src/pg_gp/sparse_vector.h" // Legacy sparse vectors
 } // extern "C"
 

--- a/src/ports/postgres/modules/bitmap/bitmap.sql_in
+++ b/src/ports/postgres/modules/bitmap/bitmap.sql_in
@@ -29,7 +29,7 @@ like this one:
 1,2,3, 10000000, 32~3100000.
 \endcode
 
-If we use an array to keep them, it would occupy more than 24MB of memory/disk 
+If we use an array to keep them, it would occupy more than 90MB of memory/disk 
 space. Using a traditional bitmap where each bit represents one number, we would 
 still need more than 9MB space for those integers.
 

--- a/src/ports/postgres/modules/bitmap/bitmap.sql_in
+++ b/src/ports/postgres/modules/bitmap/bitmap.sql_in
@@ -1,0 +1,818 @@
+/* ----------------------------------------------------------------------- *//** 
+ *
+ * @file bitmap.sql_in
+ *
+ * @brief SQL type definitions and functions for bitmap data type
+ *        <tt>bitmap</tt>
+ *
+ * @sa For an introduction to the bitmap implementation, see the module
+ *     description \ref grp_bitmap.
+ *
+ *//* ----------------------------------------------------------------------- */
+
+
+/**
+@addtogroup grp_bitmap
+
+@about
+
+Many data mining algorithms need to deal with a set of integers. For example 
+Apriori takes as input the IDs of the transactions that contain a specific item. 
+Using an array to keep these IDs leads to large storage overhead and low efficiency 
+in processing. We will need a more compact and efficient representation of these 
+numbers. MADLIB_SCHEMA.bitmap is a UDT that serves this purpose. 
+
+For example, a set of integers (say I), which can be ordered or unordered, 
+like this one: 
+
+\code
+1,2,3, 10000000, 32~3100000.
+\endcode
+
+If we use an array to keep them, it would occupy more than 24MB of memory/disk 
+space. Using a traditional bitmap where each bit represents one number, we would 
+still need more than 9MB space for those integers.
+
+Therefore, we need a compact bitmap to represent a large number of integers. We
+assume these numbers are 1 based rather than 0 based. MADLIB_SCHEMA.bitmap is 
+such a compact bitmap implementation that uses an INT4 array to keep the bitmap 
+image. We denote the bitmap image as B(\f$n+1,w_1,w_2,...w_n\f$), where 
+\f$w_i\f$ (1<=i<=n) is 32-bit word. There are two types of words: 
+-# Normal Word (NW), whose highest bit is 0. The nonzero bits in the rest 31 
+   bits are used to represent numbers that appear in the input.
+
+-# Composite Word (CW), whose highest bit is 1. If:
+    -# the second highest bit is 1, then it represents (w & 0x3FFFFFFF) * 31 
+       number of 1s.
+    -# the second highest bit is 0, then it represents (w & 0x3FFFFFFF) * 31 
+       number of 0s.
+Obviously, the integer value for an NW is positive, while for a CW, it's negative.
+Given the bitmap image B(\f$n+1,w_1,w_2,...w_n\f$), we can know that 
+the base (\f$p_i\f$) of the numbers represented by \f$w_i\f$ is:
+-# if i = 1, then \f$p_i\f$ = 1.
+-# if i > 1, then \f$p_i = \sum_{j=1}^{i-1}(w_j > 0 ? 32 : (w_j & 0x3FFFFFFF) * 31)\f$.
+
+For example, the aforementioned integer set I would be encoded as the 
+following array: 
+\code
+array[0x00000005, 0x00000007, 0xC001869F, 0x80036574, 0x00080000]
+\endcode
+
+Where:
+-# E[0], i.e. 0x00000005, is the total length of the array. 
+
+-# E[1], i.e. 0x00000007, is a normal word. Its base is 1. As the lowest 3 bits 
+are all ones, we know that I has 1,2,3 in it. 
+
+-# E[2], i.e. 0xC001869F, is a composite word. Its base is 32.
+It represents 0x0001869F * 31 number of 1s. That means the integers from 32 to 
+(0x0001869F * 31 + 32) - 1, i.e. 3100000, are in I
+
+-# E[3], i.e. 0x80036574, is a composite word. Its base is 3100001.
+It represents 0x00036574 * 31 number of 0s. That means no integers in range of 
+[3100001, (0x00036574 * 31 + 3100001) - 1], which is [3100001, 9999979].
+
+-# E[4], i.e. 0x00080000, is a normal word. Its base is 9999980.
+As the 20th bit is 1, we know that (9999980 + 20), i.e. 10000000 is in I.
+
+Obviously, for a sparse integer array like I we only need 5 words to represent 
+it as a bitmap. The savings in storage is huge. And the bitmap operations, such 
+as | and &, can be very efficient.
+    
+@usage
+
+    A bitmap can be constructed as follows:
+    <pre>
+    SELECT 'x1,x2,x3,...,xk'::MADLIB_SCHEMA.bitmap;
+    </pre>
+    where x1,x2,x3,...,xk are integers.
+    
+    Or, it can also be built from an integer array:
+    <pre>
+    SELECT ('{x1,x2,x3,...xk}'::INT[])::MADLIB_SCHEMA.bitmap;
+    </pre>
+    
+    Or, it can be aggregated from a column with integer type of a table:
+    <pre>
+    SELECT MADLIB_SCHEMA.bitmap_agg(tid) FROM trans_table;
+    </pre>
+    where tid is the column with integer type.
+    
+    Syntax reference can be found in bitmap.sql_in.
+
+    Users need to add MADLIB_SCHEMA to their search_path to use the bitmap 
+    operators defined in the module.
+
+@examp
+
+Here, we will give examples for the functions that we provided in this version.
+
+The following three examples show how to build a bitmap:
+
+Building the bitmap from a cstring:
+\code
+sql> SELECT '1,2,3'::MADLIB_SCHEMA.bitmap AS bitmap
+ bitmap  
+---------
+ 1~3
+\endcode
+
+Building the bitmap from an integer array. NULLs are not allowed. The duplicated 
+numbers in the array will be ignored.
+\code
+sql> SELECT array[1,2,3]::MADLIB_SCHEMA.bitmap AS bitmap
+ bitmap  
+---------
+ 1~3
+\endcode
+
+Building the bitmap by aggregating integers from a column of a table. NULLs are 
+not allowed. The duplicated numbers in the column will be ignored.
+\code
+sql> CREATE TEMP TABLE t1(id) AS SELECT generate_series(32, 62) UNION ALL
+                                 SELECT unnest(array[1,2,3,4];
+sql> SELECT MADLIB_SCHEMA.bitmap_agg(id) AS bitmap FROM t1;
+ bitmap  
+---------
+ 1~4,32~62
+\endcode
+
+The following two examples show how we use the bitwise operations: | and &.
+\code
+sql> SELECT '1,2,3'::MADLIB_SCHEMA.bitmap | '4,3,2'::MADLIB_SCHEMA.bitmap AS bitmap_or
+ bitmap_or  
+---------
+ 1~4
+\endcode
+
+\code
+sql> SELECT '1,2,3'::MADLIB_SCHEMA.bitmap & '4,3,2'::MADLIB_SCHEMA.bitmap AS bitmap_and
+ bitmap_and  
+---------
+ 2,3
+\endcode
+
+
+The following two examples show the CASTs for the bitmap:
+\code
+sql> SELECT '1,2,3'::MADLIB_SCHEMA.bitmap::INT[] AS intcast
+ intcast
+---------
+ {2,7}
+\endcode
+
+\code
+sql> SELECT '1,2,3,32'::MADLIB_SCHEMA.bitmap::varbit AS varbitcast
+            varbitcast             
+-----------------------------------
+ 10000000000000000000000000000111
+\endcode
+
+
+@sa File bitmap.sql_in documenting the SQL functions.
+
+*/
+
+
+m4_include(`SQLCommon.m4')
+
+CREATE TYPE MADLIB_SCHEMA.bitmap;
+
+/*
+ * @brief the 'in' function for the bitmap data type
+ *
+ * @param args[0]   the input string, which must be split by a comma.
+ *
+ * @return the bitmap representing the input string
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_in(cstring)
+RETURNS MADLIB_SCHEMA.bitmap
+AS 'MODULE_PATHNAME'
+LANGUAGE C IMMUTABLE STRICT;
+
+
+/*
+ * @brief the 'out' function for the bitmap data type.
+ *
+ * @param args[0]   the bitmap
+ *
+ * @return the string representing the bitmap.
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_out(MADLIB_SCHEMA.bitmap)
+RETURNS cstring
+AS 'MODULE_PATHNAME'
+LANGUAGE C IMMUTABLE STRICT;
+
+
+CREATE TYPE MADLIB_SCHEMA.bitmap (
+   internallength = VARIABLE, 
+   input = MADLIB_SCHEMA.bitmap_in,
+   output = MADLIB_SCHEMA.bitmap_out,
+   storage = EXTENDED,
+   alignment = int4
+);
+
+
+/*
+ * @brief the step function for aggregating the input numbers to
+ *        a compressed bitmap.
+ *
+ * @param args[0]   the array indicating the state
+ * @param args[1]   the input number
+ * @param args[2]   the number of empty elements will be dynamically
+ *                  added to the state array. The default values is 16.
+ *
+ * @return an array indicating the state after inserting the input number.
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_agg_sfunc
+(
+    MADLIB_SCHEMA.bitmap,
+    INT8,
+    INT4
+)
+RETURNS MADLIB_SCHEMA.bitmap
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE;
+
+
+/*
+ * @brief the step function for aggregating the input numbers to
+ * a compressed bitmap.
+ *
+ * @param args[0]   The array indicating the state
+ * @param args[1]   the input number
+ *
+ * @return an array indicating the state after inserting the input number.
+ * @note the default value for the second parameter is 16
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_agg_sfunc
+(
+    MADLIB_SCHEMA.bitmap,
+    INT8
+)
+RETURNS MADLIB_SCHEMA.bitmap
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE;
+
+
+/*
+ * @brief the pre-function for the bitmap aggregation.
+ *
+ * @param args[0]   the first state
+ * @param args[1]   the second state
+ *
+ * @return an array of merging the first state and the second state.
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_agg_pfunc
+(
+    MADLIB_SCHEMA.bitmap,
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS MADLIB_SCHEMA.bitmap
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE;
+
+
+CREATE AGGREGATE MADLIB_SCHEMA.bitmap_agg
+(
+    INT8,
+    INT4
+)
+(
+    SFUNC=MADLIB_SCHEMA.bitmap_agg_sfunc,
+    STYPE=MADLIB_SCHEMA.bitmap
+    m4_ifdef(`__GREENPLUM__',`,prefunc=MADLIB_SCHEMA.bitmap_agg_pfunc')
+);
+
+
+CREATE AGGREGATE MADLIB_SCHEMA.bitmap_agg
+(
+    INT8
+)
+(
+    SFUNC=MADLIB_SCHEMA.bitmap_agg_sfunc,
+    STYPE=MADLIB_SCHEMA.bitmap
+    m4_ifdef(`__GREENPLUM__',`,prefunc=MADLIB_SCHEMA.bitmap_agg_pfunc')
+);
+
+
+/*
+ * @brief The implementation of AND operation.
+ *
+ * @param args[0]   the first bitmap
+ * @param args[1]   the second bitmap
+ *
+ * @return the result of args[0] AND args[1].
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_and
+(
+    MADLIB_SCHEMA.bitmap,
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS MADLIB_SCHEMA.bitmap
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief The implementation of OR operation.
+ *
+ * @param args[0]   the first bitmap
+ * @param args[1]   the second bitmap
+ *
+ * @return the result of args[0] OR args[1].
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_or
+(
+    MADLIB_SCHEMA.bitmap,
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS MADLIB_SCHEMA.bitmap
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief The implementation of XOR operation.
+ *
+ * @param args[0]   the first bitmap
+ * @param args[1]   the second bitmap
+ *
+ * @return the result of args[0] XOR args[1].
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_xor
+(
+    MADLIB_SCHEMA.bitmap,
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS MADLIB_SCHEMA.bitmap
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief The implementation of NOT operation.
+ *
+ * @param args[0]   the bitmap
+ *
+ * @return the result of !args[0].
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_not
+(
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS MADLIB_SCHEMA.bitmap
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE STRICT;
+
+
+
+/*
+ * @brief set the value of the bit to 1/0
+ *
+ * @param args[0]   the bitmap 
+ * @param args[1]   the position of the bit
+ * @param args[2]   true for 1; false for 0
+ *
+ * @return the changed bitmap
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_set
+(
+    MADLIB_SCHEMA.bitmap,
+    INT8,
+    BOOL
+)
+RETURNS MADLIB_SCHEMA.bitmap
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE;
+
+
+/*
+ * @brief Test whether the specified bit is set
+ *
+ * @param args[0]   the bitmap
+ * @param args[1]   the specified bit to be tested
+ *
+ * @return True if the bit at specified bit in the bitmap is set,
+ *         otherwise, return False;
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_test
+(
+    MADLIB_SCHEMA.bitmap,
+    INT8
+)
+RETURNS BOOL
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE;
+
+
+/*
+ * @brief get the positions of the non-zero bits
+ *
+ * @param args[0]   the bitmap
+ *
+ * @return the array contains the positions of the non-zero bits.
+ * @note the position starts from 1.
+ *
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_nonzero_positions
+(
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS INT8[]
+AS 'MODULE_PATHNAME'
+LANGUAGE C 
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief get the number of bits whose value is 1.
+ *
+ * @param args[0]   the bitmap
+ *
+ * @return the count of non-zero bits in the bitmap.
+ *
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_nonzero_count
+(
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS INT8
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief get the array representation for the bitmap
+ *
+ * @param args[0]   the bitmap
+ *
+ * @return the array representation for the bitmap.
+ * @note the first element is the array size
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_return_array
+(
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS INT4[]
+AS 'MODULE_PATHNAME'
+LANGUAGE C 
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief get the varbit representation for the bitmap
+ *
+ * @param args[0]   the bitmap
+ *
+ * @return the varbit representation for the bitmap.
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_return_varbit
+(
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS VARBIT
+AS 'MODULE_PATHNAME'
+LANGUAGE C 
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief unnest the bitmap to a set of integers
+ *
+ * @param args[0]   the bitmap
+ *
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_unnest
+(
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS SETOF INT8
+AS 'MODULE_PATHNAME'
+LANGUAGE C 
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief get the bitmap representation for the array
+ *
+ * @param args[0]   the input array
+ *
+ * @return the bitmap representation for the array.
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_from_int8array
+(
+    INT8[]
+)
+RETURNS MADLIB_SCHEMA.bitmap
+AS 'MODULE_PATHNAME'
+LANGUAGE C 
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief get the bitmap representation for the array
+ *
+ * @param args[0]   the input array
+ *
+ * @return the bitmap representation for the array.
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_from_int4array
+(
+    INT4[]
+)
+RETURNS MADLIB_SCHEMA.bitmap
+AS 'MODULE_PATHNAME'
+LANGUAGE C 
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief get the bitmap representation for the varbit
+ *
+ * @param args[0]   the input varbit
+ *
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_from_varbit
+(
+    VARBIT
+)
+RETURNS MADLIB_SCHEMA.bitmap
+AS 'MODULE_PATHNAME'
+LANGUAGE C 
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief The implementation of = operation.
+ *
+ * @param args[0]   the first bitmap
+ * @param args[1]   the second bitmap
+ *
+ * @return the result of args[0] = args[1].
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_eq
+(
+    MADLIB_SCHEMA.bitmap,
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS BOOL
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief The implementation of <> operation.
+ *
+ * @param args[0]   the first bitmap
+ * @param args[1]   the second bitmap
+ *
+ * @return the result of args[0] <> args[1].
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_neq
+(
+    MADLIB_SCHEMA.bitmap,
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS BOOL
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief The implementation of > operation.
+ *
+ * @param args[0]   the first bitmap
+ * @param args[1]   the second bitmap
+ *
+ * @return the result of args[0] > args[1].
+ * @note it doesn't make sense to compare two bitmap. 
+ *       However, the btree index need this operation. 
+ *       Here, we just simple compare the two bitmaps
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_gt
+(
+    MADLIB_SCHEMA.bitmap,
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS BOOL
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief The implementation of < operation.
+ *
+ * @param args[0]   the first bitmap
+ * @param args[1]   the second bitmap
+ *
+ * @return the result of args[0] < args[1].
+ * @note it doesn't make sense to compare two bitmap. 
+ *       However, the btree index need this operation. 
+ *       Here, we just simple compare the two bitmaps
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_lt
+(
+    MADLIB_SCHEMA.bitmap,
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS BOOL
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief The implementation of >= operation.
+ *
+ * @param args[0]   the first bitmap
+ * @param args[1]   the second bitmap
+ *
+ * @return the result of args[0] >= args[1].
+ * @note it doesn't make sense to compare two bitmap. 
+ *       However, the btree index need this operation. 
+ *       Here, we just simple compare the two bitmaps
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_ge
+(
+    MADLIB_SCHEMA.bitmap,
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS BOOL
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief The implementation of <= operation.
+ *
+ * @param args[0]   the first bitmap
+ * @param args[1]   the second bitmap
+ *
+ * @return the result of args[0] <= args[1].
+ * @note it doesn't make sense to compare two bitmap. 
+ *       However, the btree index need this operation. 
+ *       Here, we just simple compare the two bitmaps
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_le
+(
+    MADLIB_SCHEMA.bitmap,
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS BOOL
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE STRICT;
+
+
+/*
+ * @brief compare two bitmaps
+ *
+ * @param args[0]   the first bitmap
+ * @param args[1]   the second bitmap
+ *
+ * @return 0 for equality; 1 for greater than; and -1 for less than.
+ * @note it doesn't make sense to compare two bitmap. 
+ *       However, the btree index need this operation. 
+ *       Here, we just simple compare the two bitmaps
+ */
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.bitmap_cmp
+(
+    MADLIB_SCHEMA.bitmap,
+    MADLIB_SCHEMA.bitmap
+)
+RETURNS INT
+AS 'MODULE_PATHNAME'
+LANGUAGE C
+IMMUTABLE STRICT;
+
+/* 
+ * Don't comment out commutator and negator for them, or
+ * the order by DESC will not work
+ */
+CREATE OPERATOR MADLIB_SCHEMA.< (
+    leftarg = MADLIB_SCHEMA.bitmap, rightarg = MADLIB_SCHEMA.bitmap,
+    procedure = MADLIB_SCHEMA.bitmap_lt,
+    --commutator = operator(MADLIB_SCHEMA.>) ,
+    --negator = operator(MADLIB_SCHEMA.>=) ,
+    restrict = scalarltsel, join = scalarltjoinsel
+);
+
+CREATE OPERATOR MADLIB_SCHEMA.<= (
+    leftarg = MADLIB_SCHEMA.bitmap, rightarg = MADLIB_SCHEMA.bitmap,
+    procedure = MADLIB_SCHEMA.bitmap_le,
+    --commutator = operator(MADLIB_SCHEMA.>=) ,
+    --negator = operator(MADLIB_SCHEMA.>) ,
+    restrict = scalarltsel, join = scalarltjoinsel
+);
+
+
+CREATE OPERATOR MADLIB_SCHEMA.> (
+    leftarg = MADLIB_SCHEMA.bitmap, rightarg = MADLIB_SCHEMA.bitmap,
+    procedure = MADLIB_SCHEMA.bitmap_gt,
+    --commutator = operator(MADLIB_SCHEMA.<) ,
+    --negator = operator(MADLIB_SCHEMA.<=) ,
+    restrict = scalargtsel, join = scalargtjoinsel
+);
+
+
+CREATE OPERATOR MADLIB_SCHEMA.>= (
+    leftarg = MADLIB_SCHEMA.bitmap, rightarg = MADLIB_SCHEMA.bitmap,
+    procedure = MADLIB_SCHEMA.bitmap_ge,
+    --commutator = operator(MADLIB_SCHEMA.<=) ,
+    --negator = operator(MADLIB_SCHEMA.<) ,
+    restrict = scalargtsel, join = scalargtjoinsel
+);
+
+
+CREATE OPERATOR MADLIB_SCHEMA.<> (
+    leftarg = MADLIB_SCHEMA.bitmap, rightarg = MADLIB_SCHEMA.bitmap,
+    procedure = MADLIB_SCHEMA.bitmap_neq,
+    --commutator = operator(MADLIB_SCHEMA.<>) ,
+    --negator = operator(MADLIB_SCHEMA.=) ,
+    restrict = eqsel, join = eqjoinsel
+);
+
+
+CREATE OPERATOR MADLIB_SCHEMA.= (
+    leftarg = MADLIB_SCHEMA.bitmap, rightarg = MADLIB_SCHEMA.bitmap,
+    procedure = MADLIB_SCHEMA.bitmap_eq,
+    commutator = operator(MADLIB_SCHEMA.=) ,
+    negator = operator(MADLIB_SCHEMA.<>) ,
+    restrict = eqsel, join = eqjoinsel,
+    HASHS,
+    MERGES,
+    SORT1 = operator(MADLIB_SCHEMA.<),
+    SORT2 = operator(MADLIB_SCHEMA.<),
+    LTCMP = operator(MADLIB_SCHEMA.<),
+    GTCMP = operator(MADLIB_SCHEMA.>)
+);
+
+
+/*
+ * define the btree index, so that we can use the type
+ * in GROUP BY clause
+ */
+CREATE OPERATOR CLASS MADLIB_SCHEMA.bitmap_index_btree
+DEFAULT FOR TYPE MADLIB_SCHEMA.bitmap USING btree AS
+OPERATOR        1       MADLIB_SCHEMA.< ,
+OPERATOR        2       MADLIB_SCHEMA.<= ,
+OPERATOR        3       MADLIB_SCHEMA.=,
+OPERATOR        4       MADLIB_SCHEMA.>= ,
+OPERATOR        5       MADLIB_SCHEMA.>,
+FUNCTION        1       MADLIB_SCHEMA.bitmap_cmp(MADLIB_SCHEMA.bitmap, MADLIB_SCHEMA.bitmap);
+
+
+CREATE OPERATOR MADLIB_SCHEMA.| (
+    leftarg = MADLIB_SCHEMA.bitmap, rightarg = MADLIB_SCHEMA.bitmap, 
+    procedure = MADLIB_SCHEMA.bitmap_or
+);
+
+CREATE OPERATOR MADLIB_SCHEMA.& (
+    leftarg = MADLIB_SCHEMA.bitmap, rightarg = MADLIB_SCHEMA.bitmap, 
+    procedure = MADLIB_SCHEMA.bitmap_and
+);
+
+CREATE OPERATOR MADLIB_SCHEMA.# (
+    leftarg = MADLIB_SCHEMA.bitmap, rightarg = MADLIB_SCHEMA.bitmap, 
+    procedure = MADLIB_SCHEMA.bitmap_xor
+);
+
+
+CREATE OPERATOR MADLIB_SCHEMA.~ (
+    rightarg = MADLIB_SCHEMA.bitmap, 
+    procedure = MADLIB_SCHEMA.bitmap_not
+);
+
+
+/*
+ * CASTs
+ */
+CREATE CAST (MADLIB_SCHEMA.bitmap AS INT4[]) 
+WITH FUNCTION MADLIB_SCHEMA.bitmap_return_array(MADLIB_SCHEMA.bitmap);
+
+CREATE CAST (INT8[] AS MADLIB_SCHEMA.bitmap) 
+WITH FUNCTION MADLIB_SCHEMA.bitmap_from_int8array(INT8[]);
+
+CREATE CAST (INT4[] AS MADLIB_SCHEMA.bitmap) 
+WITH FUNCTION MADLIB_SCHEMA.bitmap_from_int4array(INT4[]);
+
+CREATE CAST (MADLIB_SCHEMA.bitmap AS VARBIT) 
+WITH FUNCTION MADLIB_SCHEMA.bitmap_return_varbit(MADLIB_SCHEMA.bitmap);
+
+CREATE CAST (VARBIT AS MADLIB_SCHEMA.bitmap) 
+WITH FUNCTION MADLIB_SCHEMA.bitmap_from_varbit(VARBIT);

--- a/src/ports/postgres/modules/bitmap/test/bitmap.sql_in
+++ b/src/ports/postgres/modules/bitmap/test/bitmap.sql_in
@@ -1,0 +1,797 @@
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_assert
+    (
+    condition   BOOLEAN
+    ) 
+RETURNS void AS $$
+BEGIN
+    IF (NOT condition) THEN
+        RAISE EXCEPTION 'Install check failed.';
+    END IF;
+END
+$$ LANGUAGE PLPGSQL IMMUTABLE;
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_agg
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    result  BOOL;
+BEGIN
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT unnest(ARRAY[1,2,3,4,5,10008]) UNION SELECT generate_series(1000, 10000);';
+    
+    EXECUTE 'select textin(MADLIB_SCHEMA.bitmap_out(MADLIB_SCHEMA.bitmap_agg(id::BIGINT, 4))) = ''1~5,1000~10000,10008'' from t1' INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result);
+    
+    EXECUTE 'select textin(MADLIB_SCHEMA.bitmap_out(MADLIB_SCHEMA.bitmap_agg(id::BIGINT))) = ''1~5,1000~10000,10008'' from t1' INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result);
+    
+    EXECUTE 'select MADLIB_SCHEMA.bitmap_agg(id::BIGINT, 4)::INT[] = ARRAY[6,31,-2147483617,2147483520,-1073741535,33816575]::INT[] from t1' INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result);
+
+    EXECUTE 'select MADLIB_SCHEMA.bitmap_agg(id::BIGINT)::INT[] = ARRAY[6,31,-2147483617,2147483520,-1073741535,33816575]::INT[] from t1' INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result);
+    
+    EXECUTE 'select MADLIB_SCHEMA.bitmap_agg(id::BIGINT)::INT[] = MADLIB_SCHEMA.bitmap_agg(id::BIGINT, 4)::INT[] from t1' INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result);    
+            
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_unnest
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    data    TEXT[] := ARRAY['1,31,32,93,94', '1,2,3,4,5,6', '1,2,4,5,7,8,9,10,11', '1,2,100000'];
+    result  BOOL;
+BEGIN
+
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT unnest(ARRAY[1,2,3,4,5,10008]) UNION SELECT generate_series(1000, 2000);';
+    EXECUTE 'SELECT count(s.id) = count(t.id) FROM
+             (SELECT id FROM t1) s,
+             (SELECT id FROM 
+                (SELECT MADLIB_SCHEMA.bitmap_unnest(bm) as id FROM 
+                    (SELECT MADLIB_SCHEMA.bitmap_agg(id) as bm FROM t1) m) n ) t
+             WHERE s.id = t.id' INTO result;
+             
+    PERFORM MADLIB_SCHEMA.test_assert(result);
+
+    FOR i in 1..array_upper(data, 1) LOOP
+        EXECUTE 'select string_agg(id, '','') = ''' || data[i] || ''' FROM 
+                (SELECT MADLIB_SCHEMA.bitmap_unnest(''' || 
+                    data[i] || 
+                    '''::MADLIB_SCHEMA.bitmap) id ) t;' INTO result;
+        PERFORM MADLIB_SCHEMA.test_assert(result); 
+    END LOOP;
+    
+    EXECUTE 'select count(s.id) = count(t.id)
+             from 
+             (SELECT MADLIB_SCHEMA.bitmap_unnest(
+                    array(select generate_series(1E10::BIGINT,1E10::BIGINT + 5))::MADLIB_SCHEMA.bitmap) id) s,
+             (SELECT generate_series(1E10::BIGINT,1E10::BIGINT + 5) id) t
+             WHERE s.id = t.id' INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+    
+    EXECUTE 'select count(s.id) = count(t.id)
+             from 
+             (SELECT MADLIB_SCHEMA.bitmap_unnest(
+                    array(select generate_series(1E17::BIGINT,1E17::BIGINT + 5))::MADLIB_SCHEMA.bitmap) id) s,
+             (SELECT generate_series(1E17::BIGINT,1E17::BIGINT + 5) id) t
+             WHERE s.id = t.id' INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+    
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_in_out
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    data    TEXT[] := ARRAY['1,31,32,93,94', '1,2,3,4,5,6', '1,2,4,5,7,8,9,10,11', '1,2,100000'];
+    exp     TEXT[] := ARRAY['1,31,32,93,94', '1~6', '1,2,4,5,7~11', '1,2,100000'];
+    result  BOOL;
+    i       INT;
+BEGIN
+    FOR i in 1..array_upper(data, 1) LOOP
+        EXECUTE 'select textin(MADLIB_SCHEMA.bitmap_out(''' || data[i] || '''::MADLIB_SCHEMA.bitmap)) = ''' || exp[i] || ''';' INTO result;
+        PERFORM MADLIB_SCHEMA.test_assert(result); 
+    END LOOP;
+
+    select textin(MADLIB_SCHEMA.bitmap_out(
+            '1,1000, 1000000, 1000000000, 1000000000000'::MADLIB_SCHEMA.bitmap)) = 
+            '1,1000,1000000,1000000000,1000000000000' INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+    
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_or
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    data1    TEXT[] := ARRAY['1,31,32,93,94', '1,2,3,4,5,6', '1,2,4,5,7,8,9,10,11', '1,2,100000'];
+    data2    TEXT[] := ARRAY['1,31', '1,2,3,4,5,6,7', '1,2,3,4,5,6,7,8,9,10,11', '1'];
+    exp      TEXT[] := ARRAY['1,31,32,93,94', '1~7', '1~11', '1,2,100000'];
+    types    TEXT[] := ARRAY['bitmap'];
+    result   BOOL;
+    i        INT;
+    k        INT;
+    stmt     TEXT;
+BEGIN
+    FOR k in 1..array_upper(types, 1) LOOP
+        FOR i in 1..array_upper(data1, 1) LOOP
+            EXECUTE 'select textin(MADLIB_SCHEMA.' || types[k] || '_out(''' || 
+                    data1[i] || '''::MADLIB_SCHEMA.' || types[k] || ' | ''' || 
+                    data2[i] || '''::MADLIB_SCHEMA.' || types[k] || ')) = ''' || 
+                    exp[i] || ''';' INTO result;
+            PERFORM MADLIB_SCHEMA.test_assert(result); 
+        END LOOP;
+    END LOOP;
+
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT unnest(ARRAY[1,2,3,4,5,10008]::BIGINT[])';
+    EXECUTE 'DROP TABLE IF EXISTS t2';
+    EXECUTE 'CREATE TEMP TABLE t2(id) AS SELECT generate_series(1000, 10000)::BIGINT;';
+
+    FOR k in 1..array_upper(types, 1) LOOP    
+        stmt = 'SELECT textin(MADLIB_SCHEMA.' || types[k] || '_out(b1 | b2)) = 
+                ''1~5,1000~10000,10008'' FROM 
+                 (SELECT MADLIB_SCHEMA.' || types[k] || '_agg(id, 8) as b1 from t1) s, 
+                 (SELECT MADLIB_SCHEMA.' || types[k] || '_agg(id, 8) as b2 from t2) t';
+        EXECUTE stmt INTO result;
+        PERFORM MADLIB_SCHEMA.test_assert(result); 
+    END LOOP;
+
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT generate_series(1,20) UNION ALL
+            SELECT generate_series(32, 40) UNION ALL SELECT generate_series(63, 80)';
+    EXECUTE 'DROP TABLE IF EXISTS t2';
+    EXECUTE 'CREATE TEMP TABLE t2(id) AS SELECT generate_series(21, 31) UNION ALL
+            SELECT generate_series(41, 62) UNION ALL SELECT generate_series(81, 93)
+            UNION ALL SELECT generate_series(94, 1000)';
+    
+    FOR k in 1..array_upper(types, 1) LOOP    
+        stmt = 'SELECT textin(MADLIB_SCHEMA.' || types[k] || '_out(b1 | b2)) = 
+                ''1~1000'' FROM 
+                 (SELECT MADLIB_SCHEMA.' || types[k] || '_agg(id, 8) as b1 from t1) s, 
+                 (SELECT MADLIB_SCHEMA.' || types[k] || '_agg(id, 8) as b2 from t2) t';
+        EXECUTE stmt INTO result;
+        PERFORM MADLIB_SCHEMA.test_assert(result); 
+    END LOOP;
+
+    stmt = 'SELECT (b1 | b2)::INT4[] = ARRAY[3,-1073741792,255]::INT4[] FROM 
+             (SELECT MADLIB_SCHEMA.bitmap_agg(id, 8) as b1 from t1) s, 
+             (SELECT MADLIB_SCHEMA.bitmap_agg(id, 8) as b2 from t2) t';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+
+    stmt = 'select (array(select generate_series(1,100))::MADLIB_SCHEMA.bitmap | 
+            ''100000000000''::MADLIB_SCHEMA.bitmap)::INT[] = 
+            ''{8,-1073741821,127,-1073741825,-1073741825,-1073741825,-2142902670,
+            262144}''::INT[]';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+    
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_not
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    data1    TEXT[] := ARRAY['1,31,32,93,94', '1,2,3,4,6', '1,2,4,5,7,8,9,10,11', '1,2,1000000'];
+    exp      TEXT[] := ARRAY['2~30,33~92', '5', '3,6', '3~999999'];
+    result   BOOL;
+    i        INT;
+    stmt     TEXT;
+BEGIN
+    FOR i in 1..array_upper(data1, 1) LOOP
+        EXECUTE 'select textin(MADLIB_SCHEMA.bitmap_out(~''' || 
+                data1[i] || '''::MADLIB_SCHEMA.bitmap)) = ''' || 
+                exp[i] || ''';' INTO result;
+        PERFORM MADLIB_SCHEMA.test_assert(result); 
+    END LOOP;
+
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT unnest(ARRAY[1,2,3,4,5,10008]::BIGINT[])';
+
+    stmt = 'SELECT textin(
+                MADLIB_SCHEMA.bitmap_out(
+                    ~MADLIB_SCHEMA.bitmap_agg(id, 8)
+                )) = ''6~10007''  FROM t1';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT generate_series(1,20) UNION ALL
+            SELECT generate_series(32, 40) UNION ALL SELECT generate_series(63, 80)';
+    EXECUTE 'DROP TABLE IF EXISTS t2';
+    EXECUTE 'CREATE TEMP TABLE t2(id) AS SELECT generate_series(21, 31) UNION ALL
+            SELECT generate_series(41, 62) UNION ALL SELECT generate_series(81, 93)
+            UNION ALL SELECT generate_series(94, 1000)';
+    
+    stmt = 'SELECT b1 = (~b2) FROM 
+             (SELECT MADLIB_SCHEMA.bitmap_agg(id, 8) as b1 from t1) s, 
+             (SELECT MADLIB_SCHEMA.bitmap_agg(id, 8) as b2 from t2) t';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_xor
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    data1    TEXT[] := ARRAY['1,31,32,93,94', '1,2,3,4,5,6', '1,2,4,5,7,8,9,10,11', '1,2,10000000000'];
+    data2    TEXT[] := ARRAY['1,31', '1,2,3,4,5,6,7', '1,2,3,4,5,6,7,8,9,10,11', '1'];
+    exp      TEXT[] := ARRAY['32,93,94', '7', '3,6', '2,10000000000'];
+    result   BOOL;
+    i        INT;
+    stmt     TEXT;
+BEGIN
+    FOR i in 1..array_upper(data1, 1) LOOP
+        EXECUTE 'select textin(MADLIB_SCHEMA.bitmap_out(''' || 
+                data1[i] || '''::MADLIB_SCHEMA.bitmap # ''' || 
+                data2[i] || '''::MADLIB_SCHEMA.bitmap)) = ''' || 
+                exp[i] || ''';' INTO result;
+        PERFORM MADLIB_SCHEMA.test_assert(result); 
+    END LOOP;
+
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT unnest(ARRAY[1,2,3,4,5,10008]::BIGINT[])';
+    EXECUTE 'DROP TABLE IF EXISTS t2';
+    EXECUTE 'CREATE TEMP TABLE t2(id) AS SELECT generate_series(1000, 10000)::BIGINT;';
+
+    stmt = 'SELECT textin(MADLIB_SCHEMA.bitmap_out(b1 # b2)) = ''1~5,1000~10000,10008''  FROM 
+             (SELECT MADLIB_SCHEMA.bitmap_agg(id, 8) as b1 from t1) s, 
+             (SELECT MADLIB_SCHEMA.bitmap_agg(id, 8) as b2 from t2) t';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT generate_series(1,20) UNION ALL
+            SELECT generate_series(32, 40) UNION ALL SELECT generate_series(63, 80)';
+    EXECUTE 'DROP TABLE IF EXISTS t2';
+    EXECUTE 'CREATE TEMP TABLE t2(id) AS SELECT generate_series(21, 31) UNION ALL
+            SELECT generate_series(41, 62) UNION ALL SELECT generate_series(81, 93)
+            UNION ALL SELECT generate_series(94, 1000)';
+    
+    stmt = 'SELECT textin(MADLIB_SCHEMA.bitmap_out(b1 # b2)) = 
+            ''1~1000'' FROM 
+             (SELECT MADLIB_SCHEMA.bitmap_agg(id, 8) as b1 from t1) s, 
+             (SELECT MADLIB_SCHEMA.bitmap_agg(id, 8) as b2 from t2) t';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+
+    stmt = 'SELECT (b1 # b2)::INT4[] = ARRAY[3,-1073741792,255]::INT4[] FROM 
+             (SELECT MADLIB_SCHEMA.bitmap_agg(id, 8) as b1 from t1) s, 
+             (SELECT MADLIB_SCHEMA.bitmap_agg(id, 8) as b2 from t2) t';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+
+    stmt = 'select (array(select generate_series(1,100))::MADLIB_SCHEMA.bitmap # 
+            ''100000000000''::MADLIB_SCHEMA.bitmap)::INT[] = 
+            ''{8,-1073741821,127,-1073741825,-1073741825,-1073741825,-2142902670,
+            262144}''::INT[]';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+    
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_set_test
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    result   BOOL;
+    i        INT;
+    k        INT;
+    stmt     TEXT;
+BEGIN
+    stmt = 'SELECT textin(MADLIB_SCHEMA.bitmap_out(MADLIB_SCHEMA.bitmap_set(
+                array(select generate_series(1,100))::MADLIB_SCHEMA.bitmap, 1, true)))
+                = ''1~100''';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+
+    stmt = 'SELECT textin(MADLIB_SCHEMA.bitmap_out(MADLIB_SCHEMA.bitmap_set(
+                array(select generate_series(1,100))::MADLIB_SCHEMA.bitmap, 1000000000000, true)))
+                = ''1~100,1000000000000''';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+
+    stmt = 'SELECT textin(MADLIB_SCHEMA.bitmap_out(MADLIB_SCHEMA.bitmap_set(
+                array(select generate_series(1,100))::MADLIB_SCHEMA.bitmap, 101, true)))
+                = ''1~101''';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+
+    stmt = 'SELECT not MADLIB_SCHEMA.bitmap_test(
+        array(select generate_series(1,100))::MADLIB_SCHEMA.bitmap, 101)';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+
+    stmt = 'SELECT not MADLIB_SCHEMA.bitmap_test(
+        array(select generate_series(1,100))::MADLIB_SCHEMA.bitmap, 10000000000)';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+    
+    stmt = 'SELECT MADLIB_SCHEMA.bitmap_test(
+        array(select generate_series(1,100))::MADLIB_SCHEMA.bitmap, 11)';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_and
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    data1   TEXT[] := ARRAY['1,31,32,93,94', '1,2,3,4,5,6', '1,2,4,5,7,8,9,10,11', '1,2,100000'];
+    data2   TEXT[] := ARRAY['1,31', '1,2,3,4,5,6,7', '1,2,3,4,5,6,7,8,9,10,11', '1'];
+    exp     TEXT[] := ARRAY['1,31', '1~6', '1,2,4,5,7~11', '1'];
+    types   TEXT[] := ARRAY['bitmap'];
+    result  BOOL;
+    i       INT;
+    k       INT;
+    stmt    TEXT;
+BEGIN
+    FOR k in 1..array_upper(types, 1) LOOP
+        FOR i in 1..array_upper(data1, 1) LOOP
+            EXECUTE 'select textin(MADLIB_SCHEMA.' || types[k] || '_out(''' || 
+                    data1[i] || '''::MADLIB_SCHEMA.' || types[k] || ' & ''' || 
+                    data2[i] || '''::MADLIB_SCHEMA.' || types[k] || ')) = ''' || 
+                    exp[i] || ''';' INTO result;
+            PERFORM MADLIB_SCHEMA.test_assert(result); 
+        END LOOP;
+    END LOOP;
+
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT unnest(ARRAY[1,2,3,4,5,10008]::BIGINT[])';
+    EXECUTE 'DROP TABLE IF EXISTS t2';
+    EXECUTE 'CREATE TEMP TABLE t2(id) AS SELECT generate_series(1000, 10000)::BIGINT;';
+
+    FOR k in 1..array_upper(types, 1) LOOP    
+        stmt = 'SELECT textin(MADLIB_SCHEMA.' || types[k] || '_out(b1 & b2)) 
+                IS NULL FROM 
+                 (SELECT MADLIB_SCHEMA.' || types[k] || '_agg(id, 8) as b1 from t1) s, 
+                 (SELECT MADLIB_SCHEMA.' || types[k] || '_agg(id, 8) as b2 from t2) t';
+        EXECUTE stmt INTO result;
+        PERFORM MADLIB_SCHEMA.test_assert(result); 
+    END LOOP;
+
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT generate_series(1,20) UNION ALL
+            SELECT generate_series(32, 40) UNION ALL SELECT generate_series(63, 80)';
+    EXECUTE 'DROP TABLE IF EXISTS t2';
+    EXECUTE 'CREATE TEMP TABLE t2(id) AS SELECT generate_series(21, 31) UNION ALL
+            SELECT generate_series(41, 62) UNION ALL SELECT generate_series(81, 93)
+            UNION ALL SELECT generate_series(94, 1000)';
+    
+    FOR k in 1..array_upper(types, 1) LOOP    
+        stmt = 'SELECT textin(MADLIB_SCHEMA.' || types[k] || '_out(b1 & b2)) 
+                IS NULL FROM 
+                 (SELECT MADLIB_SCHEMA.' || types[k] || '_agg(id, 8) as b1 from t1) s, 
+                 (SELECT MADLIB_SCHEMA.' || types[k] || '_agg(id, 8) as b2 from t2) t';
+        EXECUTE stmt INTO result;
+        PERFORM MADLIB_SCHEMA.test_assert(result); 
+    END LOOP;
+    
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT generate_series(1,20) UNION ALL
+            SELECT generate_series(32, 40) UNION ALL SELECT generate_series(63, 80)';
+    EXECUTE 'DROP TABLE IF EXISTS t2';
+    EXECUTE 'CREATE TEMP TABLE t2(id) AS SELECT generate_series(1, 1000)';
+    
+    stmt = 'SELECT (bm1 & bm2)::INT4[] = ARRAY[4,1048575,511,262143]::INT4[] FROM
+            (SELECT MADLIB_SCHEMA.bitmap_agg(id, 4) as bm1 from t1) s,
+            (SELECT MADLIB_SCHEMA.bitmap_agg(id, 4) as bm2 from t2) t';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_eq_neq
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    data1   TEXT[] := ARRAY['1,31,32,93,94', '1,2,3,4,5,6', '1,2,4,5,7,8,9,10,11', '1,2,100000'];
+    data2   TEXT[] := ARRAY['1,31,32,93,94', '1,2,3,4,5,6', '1,2,4,5,7,8,9,10,11', '1,2,100000'];
+    data3   TEXT[] := ARRAY['1,31,32,93,95', '1,2,4,5,6,7', '2,3,2,3,4,4,4,1', '1,2,4'];
+    types   TEXT[] := ARRAY['bitmap'];
+    result  BOOL;
+    i       INT;
+    k       INT;
+    stmt    TEXT;
+BEGIN
+    FOR k in 1..array_upper(types, 1) LOOP
+        FOR i in 1..array_upper(data1, 1) LOOP
+            stmt = 'select ''' || 
+                    data1[i] || '''::MADLIB_SCHEMA.' || types[k] || ' = ''' || 
+                    data2[i] || '''::MADLIB_SCHEMA.' || types[k] ||  
+                    ';' ;
+            EXECUTE stmt INTO result;
+            PERFORM MADLIB_SCHEMA.test_assert(result); 
+
+            stmt = 'select ''' || 
+                    data1[i] || '''::MADLIB_SCHEMA.' || types[k] || ' <> ''' || 
+                    data3[i] || '''::MADLIB_SCHEMA.' || types[k] ||  
+                    ';' ;
+            EXECUTE stmt INTO result;
+            PERFORM MADLIB_SCHEMA.test_assert(result); 
+                        
+        END LOOP;
+    END LOOP;
+    
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_lt_gt
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    data1   TEXT[] := ARRAY['1,31,32,93,94', '1,2,3,4,5,6', '33'];
+    data2   TEXT[] := ARRAY['1,31,32,93,94,96', '1,2,3,4,5,6,7', '1,2,3,4,5,31,32'];
+    types   TEXT[] := ARRAY['bitmap'];
+    result  BOOL;
+    i       INT;
+    k       INT;
+    stmt    TEXT;
+BEGIN
+    FOR k in 1..array_upper(types, 1) LOOP
+        FOR i in 1..array_upper(data1, 1) LOOP
+            stmt = 'select ''' || 
+                    data1[i] || '''::MADLIB_SCHEMA.' || types[k] || ' < ''' || 
+                    data2[i] || '''::MADLIB_SCHEMA.' || types[k] ||  
+                    ';' ;
+            EXECUTE stmt INTO result;
+            PERFORM MADLIB_SCHEMA.test_assert(result); 
+            
+            stmt = 'select ''' || 
+                    data2[i] || '''::MADLIB_SCHEMA.' || types[k] || ' > ''' || 
+                    data1[i] || '''::MADLIB_SCHEMA.' || types[k] ||  
+                    ';' ;
+            EXECUTE stmt INTO result;
+            PERFORM MADLIB_SCHEMA.test_assert(result); 
+        END LOOP;
+    END LOOP;
+
+    stmt = 'SELECT ARRAY(SELECT generate_series(1,62) UNION ALL
+            SELECT generate_series(63, 66))::INT[]::MADLIB_SCHEMA.bitmap >
+            ARRAY(SELECT generate_series(63, 66))::INT[]::MADLIB_SCHEMA.bitmap';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+    
+    stmt = 'SELECT ARRAY(SELECT generate_series(63, 66))::INT[]::MADLIB_SCHEMA.bitmap <
+            ARRAY(SELECT generate_series(1,62) UNION ALL
+                        SELECT generate_series(63, 66))::INT[]::MADLIB_SCHEMA.bitmap';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+    
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL;
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_le_ge
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    data1   TEXT[] := ARRAY['1,31,32,93,94', '1,2,3,4,5,6', '1,2,3,4,5,31,32'];
+    data2   TEXT[] := ARRAY['1,31,32,93,94', '1,2,3,4,5,6,7', '1,2,3,4,5,31,33'];
+    types   TEXT[] := ARRAY['bitmap'];
+    result  BOOL;
+    i       INT;
+    k       INT;
+    stmt    TEXT;
+BEGIN
+    FOR k in 1..array_upper(types, 1) LOOP
+        FOR i in 1..array_upper(data1, 1) LOOP
+            stmt = 'select ''' || 
+                    data1[i] || '''::MADLIB_SCHEMA.' || types[k] || ' <= ''' || 
+                    data2[i] || '''::MADLIB_SCHEMA.' || types[k] ||  
+                    ';' ;
+            EXECUTE stmt INTO result;
+            PERFORM MADLIB_SCHEMA.test_assert(result); 
+            
+            stmt = 'select ''' || 
+                    data2[i] || '''::MADLIB_SCHEMA.' || types[k] || ' >= ''' || 
+                    data1[i] || '''::MADLIB_SCHEMA.' || types[k] ||  
+                    ';' ;
+            EXECUTE stmt INTO result;
+            PERFORM MADLIB_SCHEMA.test_assert(result); 
+        END LOOP;
+    END LOOP;
+    
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL;
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_array_return_bitmap
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    stmt    TEXT;
+    result  BOOL;
+BEGIN
+    stmt = 'SELECT ARRAY(SELECT generate_series(1,1000) UNION ALL
+            SELECT generate_series(2000, 10000))::INT8[]::MADLIB_SCHEMA.bitmap =
+            ARRAY(SELECT generate_series(2000, 10000) UNION ALL
+            SELECT generate_series(1,1000))::INT[]::MADLIB_SCHEMA.bitmap';
+    EXECUTE stmt INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+    
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL;
+
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_nonzero_positions
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    data1   TEXT[] := ARRAY['1,31,32,93,94,101', '1,2,3,4,5,6'];
+    exp   TEXT[] := ARRAY['1,31,32,93,94,101', '1,2,3,4,5,6'];
+    types   TEXT[] := ARRAY['bitmap'];
+    result  BOOL;
+    i       INT;
+    k       INT;
+    stmt    TEXT;
+BEGIN
+    FOR k in 1..array_upper(types, 1) LOOP
+        FOR i in 1..array_upper(data1, 1) LOOP
+            stmt = 'select MADLIB_SCHEMA.' || types[k] || '_nonzero_positions(''' || 
+                    data1[i] || '''::MADLIB_SCHEMA.' || types[k] || ')  = 
+                    string_to_array(''' || exp[i] || ''', '','')::BIGINT[]';
+            EXECUTE stmt INTO result;
+            PERFORM MADLIB_SCHEMA.test_assert(result); 
+        END LOOP;
+    END LOOP;
+    
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT generate_series(1,20) UNION ALL
+            SELECT generate_series(32, 40) UNION ALL SELECT generate_series(63, 80)
+            UNION ALL SELECT generate_series(200, 1000)';
+    FOR k in 1..array_upper(types, 1) LOOP
+        stmt = 'select MADLIB_SCHEMA.' || types[k] || '_nonzero_positions(MADLIB_SCHEMA.' ||
+            types[k] || '_agg(id, 4)) = array(SELECT generate_series(1,20) UNION ALL
+            SELECT generate_series(32, 40) UNION ALL SELECT generate_series(63, 80)
+            UNION ALL SELECT generate_series(200, 1000))::BIGINT[] FROM t1';
+        EXECUTE stmt INTO result;
+        PERFORM MADLIB_SCHEMA.test_assert(result); 
+    END LOOP;
+    
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_nonzero_count
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    data1   TEXT[] := ARRAY['1,31,32,93,94,101', '1,2,3,4,5,6, 10, 11, 22'];
+    exp     TEXT[] := ARRAY['6', '9'];
+    types   TEXT[] := ARRAY['bitmap'];
+    result  BOOL;
+    i       INT;
+    k       INT;
+    stmt    TEXT;
+BEGIN
+    FOR k in 1..array_upper(types, 1) LOOP
+        FOR i in 1..array_upper(data1, 1) LOOP
+            stmt = 'select MADLIB_SCHEMA.' || types[k] || '_nonzero_count(''' || 
+                    data1[i] || '''::MADLIB_SCHEMA.' || types[k] || ')  =  ' || exp[i] || ';';
+            EXECUTE stmt INTO result;
+            PERFORM MADLIB_SCHEMA.test_assert(result); 
+        END LOOP;
+    END LOOP;
+    
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT generate_series(1,20) UNION ALL
+            SELECT generate_series(32, 40) UNION ALL SELECT generate_series(63, 80)
+            UNION ALL SELECT generate_series(200, 1000)';
+    FOR k in 1..array_upper(types, 1) LOOP
+        stmt = 'select MADLIB_SCHEMA.' || types[k] || '_nonzero_count(MADLIB_SCHEMA.' ||
+            types[k] || '_agg(id, 4)) = count(id)::BIGINT FROM t1';
+        EXECUTE stmt INTO result;
+        PERFORM MADLIB_SCHEMA.test_assert(result); 
+        
+        EXECUTE 'select MADLIB_SCHEMA.' || types[k] || '_nonzero_count(
+                 ''1,1000, 1000000, 1000000000, 1000000000000''::MADLIB_SCHEMA.' ||
+                 types[k] || ') = 5'
+        INTO result;
+        PERFORM MADLIB_SCHEMA.test_assert(result); 
+    
+    END LOOP;
+    
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_return_array
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    exp     TEXT[] := ARRAY['{8,1048575,511,262143,-2147483645,2147475456,-1073741799,255}',
+                            '{7,4611687115792580607,131071,-9223372036854775807,9223372036854774784,-4611686018427387893,36028797018963967}'
+                            ];
+    types   TEXT[] := ARRAY['bitmap'];
+    result  BOOL;
+    i       INT;
+    k       INT;
+    stmt    TEXT;
+BEGIN
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT generate_series(1,20) UNION ALL
+            SELECT generate_series(32, 40) UNION ALL SELECT generate_series(63, 80)
+            UNION ALL SELECT generate_series(200, 1000)';
+    FOR k in 1..array_upper(types, 1) LOOP
+        stmt = 'select MADLIB_SCHEMA.' || types[k] || '_return_array(MADLIB_SCHEMA.' ||
+            types[k] || '_agg(id, 4))::BIGINT[] = ''' || exp[k] || '''::BIGINT[] FROM t1';
+        EXECUTE stmt INTO result;
+        PERFORM MADLIB_SCHEMA.test_assert(result); 
+    END LOOP;
+    
+    select '1,1000, 1000000, 1000000000, 1000000000000'::MADLIB_SCHEMA.bitmap::INT4[] = 
+            ARRAY[40,1,-2147483617,128,-2147451423,2,-2115257843,32768,-1073741825,
+            -1073741825,-1073741825,-1073741825,-1073741825,-1073741825,-1073741825,
+            -1073741825,-1073741825,-1073741825,-1073741825,-1073741825,-1073741825,
+            -1073741825,-1073741825,-1073741825,-1073741825,-1073741825,-1073741825,
+            -1073741825,-1073741825,-1073741825,-1073741825,-1073741825,-1073741825,
+            -1073741825,-1073741825,-1073741825,-1073741825,-1073741825,-2133931887,8]::INT4[]
+         INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+    
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_bitmap_return_varbit
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    data1   TEXT[] := ARRAY['1,31,32,93,94,101', '1,2,3,4,5,6, 10, 11, 22'];
+    exp     TEXT[] := ARRAY['10000001100000000000000000000000000000000000000000000000000000000000011000000000000000000000000000001', 
+                            '1000000000011000111111'];
+    types   TEXT[] := ARRAY['bitmap'];
+    result  BOOL;
+    i       INT;
+    k       INT;
+    stmt    TEXT;
+BEGIN
+    FOR k in 1..array_upper(types, 1) LOOP
+        FOR i in 1..array_upper(data1, 1) LOOP
+            stmt = 'select ''' || 
+                    data1[i] || '''::MADLIB_SCHEMA.' || types[k] || '::VARBIT  =  ''' || exp[i] || '''::VARBIT;';
+            EXECUTE stmt INTO result;
+            PERFORM MADLIB_SCHEMA.test_assert(result); 
+            
+            stmt = 'select ''' ||
+                    data1[i] || '''::MADLIB_SCHEMA.bitmap::VARBIT = ''' ||
+                    exp[i] || '''::VARBIT;';
+            EXECUTE stmt INTO result;
+            PERFORM MADLIB_SCHEMA.test_assert(result); 
+
+            stmt = 'select ''' ||
+                    exp[i] || '''::VARBIT::MADLIB_SCHEMA.bitmap::VARBIT = ''' ||
+                    exp[i] || '''::VARBIT;';
+            EXECUTE stmt INTO result;
+            PERFORM MADLIB_SCHEMA.test_assert(result); 
+            
+        END LOOP;
+    END LOOP;
+    
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id) AS SELECT generate_series(1,20) UNION ALL
+            SELECT generate_series(32, 40) UNION ALL SELECT generate_series(63, 80)
+            UNION ALL SELECT generate_series(200, 1000)';
+    
+    select v1 = v2 from
+    (select MADLIB_SCHEMA.bitmap_agg(id, 10)::VARBIT as v1 from t1) s,
+    (select array_agg(id order by id)::BIGINT[]::MADLIB_SCHEMA.bitmap::VARBIT as v2 from t1) t
+    INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+        
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+
+CREATE OR REPLACE FUNCTION MADLIB_SCHEMA.test_operator_class
+(
+)
+RETURNS TEXT AS $$
+DECLARE
+    result  BOOL;
+BEGIN
+    EXECUTE 'DROP TABLE IF EXISTS t1';
+    EXECUTE 'CREATE TEMP TABLE t1(id SERIAL, bm MADLIB_SCHEMA.bitmap)';
+    EXECUTE 'INSERT INTO t1(bm) 
+            SELECT ARRAY(SELECT generate_series(1,20))::MADLIB_SCHEMA.bitmap 
+            UNION ALL
+            SELECT ARRAY(SELECT generate_series(32, 40))::MADLIB_SCHEMA.bitmap
+            UNION ALL 
+            SELECT ARRAY(SELECT generate_series(63, 80))::MADLIB_SCHEMA.bitmap
+            UNION ALL 
+            SELECT ARRAY(SELECT generate_series(200, 1000))::MADLIB_SCHEMA.bitmap
+            UNION ALL
+            SELECT ARRAY(SELECT generate_series(32, 40))::MADLIB_SCHEMA.bitmap';
+        
+    EXECUTE 'SELECT max(cnt) = 2 FROM 
+            (SELECT bm, count(id) as cnt FROM t1 GROUP BY bm) t'
+    INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+    
+    EXECUTE 'SELECT bm = ARRAY(SELECT generate_series(32,40))::MADLIB_SCHEMA.bitmap
+             FROM (SELECT * FROM t1 ORDER BY bm LIMIT 1) t' INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result); 
+    
+    EXECUTE 'SELECT bm = ARRAY(SELECT generate_series(1,20))::MADLIB_SCHEMA.bitmap
+             FROM (SELECT * FROM t1 ORDER BY bm DESC LIMIT 1) t' INTO result;
+    PERFORM MADLIB_SCHEMA.test_assert(result);
+                     
+    
+    RETURN 'PASS';
+END
+$$ LANGUAGE PLPGSQL; 
+
+SELECT MADLIB_SCHEMA.test_bitmap_agg();
+SELECT MADLIB_SCHEMA.test_bitmap_in_out();
+SELECT MADLIB_SCHEMA.test_bitmap_or();
+SELECT MADLIB_SCHEMA.test_bitmap_and();
+SELECT MADLIB_SCHEMA.test_bitmap_set_test();
+SELECT MADLIB_SCHEMA.test_bitmap_xor();
+SELECT MADLIB_SCHEMA.test_bitmap_eq_neq();
+SELECT MADLIB_SCHEMA.test_bitmap_lt_gt();
+SELECT MADLIB_SCHEMA.test_bitmap_le_ge();
+SELECT MADLIB_SCHEMA.test_array_return_bitmap();
+SELECT MADLIB_SCHEMA.test_bitmap_nonzero_positions();
+SELECT MADLIB_SCHEMA.test_bitmap_nonzero_count();
+SELECT MADLIB_SCHEMA.test_bitmap_return_array();
+SELECT MADLIB_SCHEMA.test_bitmap_return_varbit();
+SELECT MADLIB_SCHEMA.test_bitmap_unnest();
+SELECT MADLIB_SCHEMA.test_operator_class();
+


### PR DESCRIPTION
JIRA: MADLIB-767
I implement the bitmap as a user defined type. The underlying storage is int4 array. The following functions are provided in this version:
1) aggregate: bitmap_agg
2) operators: |, &, ~ and #.
3) casts: int4[]/int8[] to bitmap, varbit to bitmap, bitmap to int4[] and bitmap to varbit.
4) functions: bitmap_set, bitmap_test, bitmap_nonzero_positions, bitmap_nonzero_count, and bitmap_unnest
5) comparator for btree operator class: >, <, >=, <=, =, <>.
