### PR TITLE
Abstraction Layer: Allow UDFs to access the protected member fcinfo and ...

### DIFF
--- a/src/ports/postgres/dbconnector/AnyType_impl.hpp
+++ b/src/ports/postgres/dbconnector/AnyType_impl.hpp
@@ -13,6 +13,16 @@ namespace dbconnector {
 
 namespace postgres {
 
+inline void * AnyType::getUserFuncContext(){
+    return this->mSysInfo->user_fctx;
+}
+inline void AnyType::setUserFuncContext(void * user_fctx){
+    this->mSysInfo->user_fctx = user_fctx;
+}
+inline MemoryContext AnyType::getCacheMemoryContext(){
+    return this->mSysInfo->cacheContext;
+}
+
 inline
 AnyType::AnyType(FunctionCallInfo inFnCallInfo)
   : mContentType(FunctionComposite),

--- a/src/ports/postgres/dbconnector/AnyType_proto.hpp
+++ b/src/ports/postgres/dbconnector/AnyType_proto.hpp
@@ -41,9 +41,17 @@ public:
     bool isComposite() const;
     AnyType& operator<<(const AnyType& inValue);
 
-    inline SystemInformation * getSysInfo(){
-        return this->mSysInfo;
-    }
+    // FIXME: A temporary workaround for UDF to get/set user_fctx, a better
+    // solution is desired which complies with the design principles of DB
+    // abstraction layer.
+    // For some analytic algorithms (e.g. LDA), a stateful function would be
+    // very useful which allows to carry some states accross invocations within
+    // a query. Alternatively, one can achieve similar functionaltiy using a
+    // windowed aggregator, but this may suffer from severe performance
+    // degradation.  
+    void * getUserFuncContext();
+    void setUserFuncContext(void * user_fctx);
+    MemoryContext getCacheMemoryContext();
 protected:
     /**
      * @brief RAII class to temporarily change \c sLazyConversionToDatum

--- a/src/ports/postgres/dbconnector/AnyType_proto.hpp
+++ b/src/ports/postgres/dbconnector/AnyType_proto.hpp
@@ -44,9 +44,6 @@ public:
     inline SystemInformation * getSysInfo(){
         return this->mSysInfo;
     }
-    inline FunctionCallInfo getFCInfo(){
-        return this->fcinfo;
-    }
 protected:
     /**
      * @brief RAII class to temporarily change \c sLazyConversionToDatum

--- a/src/ports/postgres/dbconnector/AnyType_proto.hpp
+++ b/src/ports/postgres/dbconnector/AnyType_proto.hpp
@@ -41,6 +41,12 @@ public:
     bool isComposite() const;
     AnyType& operator<<(const AnyType& inValue);
 
+    inline SystemInformation * getSysInfo(){
+        return this->mSysInfo;
+    }
+    inline FunctionCallInfo getFCInfo(){
+        return this->fcinfo;
+    }
 protected:
     /**
      * @brief RAII class to temporarily change \c sLazyConversionToDatum


### PR DESCRIPTION
...mSysInfo of class AnyTypet

Jira: MADLIB-775
The UDFs cannot access the protected members fcinfo and mSysInfo of class
AnyType, although the class UDF is declared as friend of class AnyType (Note
that the friendship cannot be inherited in C++). The reasons for a UDF to
access fcinfo include judging whether it is called in an aggregate state or
window state. The reasons for a UDF to access mSysInfo include using
mSysInfo->user_fctx to keep some internal states.
