### PR TITLE
Abstraction Layer: Incompatibility of construct_array and construct_md_a...

### DIFF
--- a/src/ports/greenplum/dbconnector/Compatibility.hpp
+++ b/src/ports/greenplum/dbconnector/Compatibility.hpp
@@ -69,6 +69,38 @@ AggCheckCallContext(FunctionCallInfo fcinfo, MemoryContext *aggcontext) {
 
 } // namnespace
 
+inline ArrayType* madlib_construct_array
+(
+    Datum*  elems,
+    int     nelems,
+    Oid     elmtype,
+    int     elmlen,
+    bool    elmbyval,
+    char    elmalign
+){
+    return 
+        construct_array(
+            elems, nelems, elmtype, elmlen, elmbyval, elmalign);
+}
+
+inline ArrayType* madlib_construct_md_array
+(
+    Datum*  elems,
+    bool*   nulls,
+    int     ndims,
+    int*    dims,
+    int*    lbs,
+    Oid     elmtype,
+    int     elmlen,
+    bool    elmbyval,
+    char    elmalign
+){
+    return
+        construct_md_array(
+            elems, nulls, ndims, dims, lbs, elmtype, elmlen, elmbyval,
+            elmalign);
+}
+
 } // namespace postgres
 
 } // namespace dbconnector


### PR DESCRIPTION
...rray

between Greenplum and PostgreSQL

Jira: MADLIB-776
The construct_array and construct_md_array have different behaviors in
Greenplum and PostgreSQL. When the first parameter is set to NULL in both
functions, Greenplum can work well, but PostgreSQL will crash the system. The
reason is that PostgreSQL does not check for null pointer and always calls
CopyArrayEls even the pointer is null.
