### PR TITLE
Fix profile/quantile/summary functions for table/column names when starting with numeric and/or non-ascii characters.

### DIFF
--- a/src/ports/postgres/modules/data_profile/profile.py_in
+++ b/src/ports/postgres/modules/data_profile/profile.py_in
@@ -131,7 +131,7 @@ def __get_profile_data( schema, table, numcols, non_numcols, aggs, funclist, buc
     for c in numcols:
         for a in aggs[ funclist + '_num']:
             i += 1;
-            sql += ', ' + a.replace('%%',c).replace('()','('+c+')') + ' AS "' + str(i) + '"'
+            sql += ', ' + a.replace('%%',c).replace('()','("'+c+'")') + ' AS "' + str(i) + '"'
             rowset.append( {  'schema_name': schema
                             , 'table_name': table
                             , 'column_name': c
@@ -143,7 +143,7 @@ def __get_profile_data( schema, table, numcols, non_numcols, aggs, funclist, buc
     for c in non_numcols:
         for a in aggs[ funclist + '_nonnum']:
             i += 1;
-            sql += ', ' + a.replace('%%',c).replace('()','('+c+')') + ' AS "' + str(i) + '"'
+            sql += ', ' + a.replace('%%',c).replace('()','("'+c+'")') + ' AS "' + str(i) + '"'
             rowset.append( {  'schema_name': schema
                             , 'table_name': table
                             , 'column_name': c
@@ -151,7 +151,7 @@ def __get_profile_data( schema, table, numcols, non_numcols, aggs, funclist, buc
                             , 'id': i
                             , 'value': None} )
     
-    sql += ' FROM ' + table + ';'
+    sql += ' FROM "' + table + '";'
     
     # Run the SQL
     rv = plpy.execute( sql)

--- a/src/ports/postgres/modules/quantile/quantile.sql_in
+++ b/src/ports/postgres/modules/quantile/quantile.sql_in
@@ -87,7 +87,7 @@ Begin
          Which at stored in that order into 'size', count object
          'quantile_size' is computed in terms of element count
     */
-    EXECUTE 'SELECT array[MIN('||col_name||'), AVG('||col_name||'), MAX('||col_name||')], COUNT(*) FROM '||table_name||' ' INTO size, count;
+    EXECUTE 'SELECT array[MIN("'||col_name||'"), AVG("'||col_name||'"), MAX("'||col_name||'")], COUNT(*) FROM "'||table_name||'" ' INTO size, count;
     quantile_size = (count*quantile)::BIGINT;
     full_size = count;
 
@@ -119,7 +119,7 @@ Begin
     */
     LOOP
         IF(increment = 0) THEN
-            EXECUTE 'SELECT ARRAY[MIN('||col_name||'),AVG('||col_name||'),MAX('||col_name||')],COUNT(*) FROM '||table_name||' WHERE '||col_name||' <= '||size[2]||';' INTO last_values, last_count;
+            EXECUTE 'SELECT ARRAY[MIN("'||col_name||'"),AVG("'||col_name||'"),MAX("'||col_name||'")],COUNT(*) FROM "'||table_name||'" WHERE "'||col_name||'" <= '||size[2]||';' INTO last_values, last_count;
         ELSE
             EXECUTE 'SELECT ARRAY[MIN(val),AVG(val),MAX(val)],COUNT(*) FROM temptable'||increment%2||' WHERE val <= '||size[2]||';' INTO last_values, last_count;
         END IF;
@@ -148,7 +148,7 @@ Begin
 
             --remove all rows that are larger than new max
             IF(increment = 0) THEN
-                EXECUTE 'INSERT INTO temptable'||(increment+1)%2||' SELECT '||col_name||' FROM '||table_name||' WHERE '||col_name||' <= '||size[3]||';';
+                EXECUTE 'INSERT INTO temptable'||(increment+1)%2||' SELECT "'||col_name||'" FROM "'||table_name||'" WHERE "'||col_name||'" <= '||size[3]||';';
             ELSE
                 EXECUTE 'INSERT INTO temptable'||(increment+1)%2||' SELECT val FROM temptable'||increment%2||' WHERE val <= '||size[3]||';';
                 EXECUTE 'TRUNCATE temptable'||increment%2||';';
@@ -166,7 +166,7 @@ Begin
             --remove all rows that are smaller than new min
             IF(increment = 0) THEN
                 --add a small offset to ensure the value that is equal to size[1] is NOT kept
-                EXECUTE 'INSERT INTO temptable'||(increment+1)%2||' SELECT '||col_name||' FROM '||table_name||' WHERE '||col_name||' > '||size[1]||'+1e-10;';
+                EXECUTE 'INSERT INTO temptable'||(increment+1)%2||' SELECT "'||col_name||'" FROM "'||table_name||'" WHERE "'||col_name||'" > '||size[1]||'+1e-10;';
             ELSE
                 EXECUTE 'INSERT INTO temptable'||(increment+1)%2||' SELECT val FROM temptable'||increment%2||' WHERE val > '||size[1]||'+1e-10;';
                 EXECUTE 'TRUNCATE temptable'||increment%2||';';
@@ -190,13 +190,13 @@ Begin
         At this point we terminated the binary search but we do not know what the reason why no progress could be made
         following is the code that determines what is the reason for the termination, and finds the exact solution depending on the reason
     */
-    EXECUTE 'SELECT MAX('||col_name||'),COUNT(*) FROM '||table_name||' WHERE '||col_name||' < '||size[2]||';' INTO last_value1, last_count1;
+    EXECUTE 'SELECT MAX("'||col_name||'"),COUNT(*) FROM "'||table_name||'" WHERE "'||col_name||'" < '||size[2]||';' INTO last_value1, last_count1;
 
     IF(last_count1 >= quantile_size) THEN
         RETURN last_value1;
     END IF;
 
-    EXECUTE 'SELECT MIN('||col_name||'),'||full_size||'-COUNT(*)+1 FROM '||table_name||' WHERE '||col_name||' > '||size[2]||';' INTO last_value2, last_count2;
+    EXECUTE 'SELECT MIN("'||col_name||'"),'||full_size||'-COUNT(*)+1 FROM "'||table_name||'" WHERE "'||col_name||'" > '||size[2]||';' INTO last_value2, last_count2;
 
 
     IF(last_count >= quantile_size) THEN
@@ -243,8 +243,8 @@ begin
         RAISE EXCEPTION 'Quantile should be between 0 and 0.99';
     END IF;
 
-    EXECUTE 'SELECT COUNT(*)*'||quantile||' FROM '||table_name||' ' INTO size;
-    EXECUTE 'SELECT ARRAY(SELECT '||col_name||' FROM (SELECT '||col_name||' FROM '||table_name||' ORDER BY '||col_name||' OFFSET '||floor(size)||'-1 LIMIT 2) AS g)' INTO result;
+    EXECUTE 'SELECT COUNT(*)*'||quantile||' FROM "'||table_name||'" ' INTO size;
+    EXECUTE 'SELECT ARRAY(SELECT "'||col_name||'" FROM (SELECT "'||col_name||'" FROM "'||table_name||'" ORDER BY "'||col_name||'" OFFSET '||floor(size)||'-1 LIMIT 2) AS g)' INTO result;
     EXECUTE 'SELECT '||result[2]||'*('||size||'%1)+'||result[1]||'*(1-'||size||'%1)' INTO res;
     return res;
 end

--- a/src/ports/postgres/modules/quantile/test/quantile.sql_in
+++ b/src/ports/postgres/modules/quantile/test/quantile.sql_in
@@ -16,11 +16,11 @@ declare
 	q FLOAT;
 begin
 	-- DROP TABLE IF EXISTS T;
-	CREATE TABLE T (
+	CREATE TABLE "T" (
 		val FLOAT
 	);
 
-	INSERT INTO T SELECT i % 100 FROM generate_series(1,1000) i;
+	INSERT INTO "T" SELECT i % 100 FROM generate_series(1,1000) i;
 	SELECT INTO q MADLIB_SCHEMA.quantile('T', 'val', .5);
 
 	SELECT INTO result CASE WHEN( q > 45 and q < 55) THEN 'PASS' ELSE 'FAIL' END;
@@ -32,7 +32,7 @@ begin
 	SELECT INTO q MADLIB_SCHEMA.quantile_big('T', 'val', .5);
 
 	SELECT INTO result CASE WHEN( q > 45 and q < 55) THEN 'PASS' ELSE 'FAIL' END;
-	DROP TABLE IF EXISTS T;
+	DROP TABLE IF EXISTS "T";
 	
     IF result = 'FAIL' THEN
         RAISE EXCEPTION 'Quantile_big install check failed: returned=%, expected=[45;55]', q;

--- a/src/ports/postgres/modules/summary/Summarizer.py_in
+++ b/src/ports/postgres/modules/summary/Summarizer.py_in
@@ -64,7 +64,7 @@ class Summarizer:
 
         rowcount = plpy.execute("""
             SELECT count(*) FROM {source_table}""".format(
-                source_table=self._source_table))[0]['count']
+                source_table="\"" + self._source_table + "\""))[0]['count']
         if rowcount == 0:
             plpy.error("""
                 Summary -- Relation '{source_table}' is empty""".format(
@@ -151,14 +151,14 @@ class Summarizer:
         args['column_types'] = ','.join(["'%s'" % c['typname'] for c in cols])
         args['column_number'] = ','.join([str(c['attnum']) for c in cols])
         if self._distinctify is 'Estimated':
-            args['distinct_columns'] = ','.join(["{schema_madlib}.fmsketch_dcount(%s)" % c['attname'] for c in cols])
+            args['distinct_columns'] = ','.join(["{schema_madlib}.fmsketch_dcount(\"%s\")" % c['attname'] for c in cols])
         elif self._distinctify is 'Exact':
             args['distinct_columns'] = ','.join(["count(distinct %s)" % c['attname'] for c in cols])
         else:
             args['distinct_columns'] = ','.join(["NULL" for c in cols])
-        args['missing_columns'] = ','.join(["sum(case when %s is null then 1 else 0 end)"%(
+        args['missing_columns'] = ','.join(["sum(case when \"%s\" is null then 1 else 0 end)"%(
                                                    c['attname']) for c in cols])
-        args['blank_columns'] = ','.join(["sum(case when {0} similar to E'\\\\W*' \
+        args['blank_columns'] = ','.join(["sum(case when \"{0}\" similar to E'\\\\W*' \
                                            then 1 else 0 end)".format(c['attname']) \
                                            if c['typname'] in ('varchar','bpchar','text','character varying')
                                               else 'NULL' for c in cols])
@@ -166,14 +166,14 @@ class Summarizer:
         numeric_types = ('int2','int4','int8','float4','float8','numeric')
         def numeric_type(operator, datatype):
             if datatype['typname'] in numeric_types:
-                return '%s(%s)' % (operator, datatype['attname'])
+                return '%s("%s")' % (operator, datatype['attname'])
             return "NULL"
 
         def minmax_type(minmax, c):
             if c['typname'] in numeric_types:
-                return '%s(%s)' % (minmax, c['attname'])
+                return '%s("%s")' % (minmax, c['attname'])
             if c['typname'] in ('varchar','bpchar','text'):
-                return "%s(length(%s))" % (minmax, c['attname'])
+                return "%s(length(\"%s\"))" % (minmax, c['attname'])
             return "NULL"
 
         def xtile_type(xtile, c):
@@ -190,7 +190,7 @@ class Summarizer:
                             'mfvsketch_quick_histogram')[self._get_mfv_quick]
             return  """
                     array_to_string(({schema_madlib}.{mfv_method}(
-                                {column},{topk}))[0:{topk}-1][{slice}], 
+                                \"{column}\",{topk}))[0:{topk}-1][{slice}], 
                                 '{delimiter}')""".format(
                                             schema_madlib=self._schema_madlib,
                                             mfv_method=mfv_method,
@@ -244,7 +244,7 @@ class Summarizer:
                     array[{max_columns}]::float8[] as max,
                     array[{mfv_value}]::text[] as mfv_value,
                     array[{mfv_count}]::text[] as mfv_count
-                FROM {source_table}{group_expr}
+                FROM \"{source_table}\"{group_expr}
          """.format(**args).format(schema_madlib=self._schema_madlib)
         return subquery
 
@@ -321,7 +321,7 @@ class Summarizer:
             ntiles = 'ntiles::float8[] as quantile_array,'
 
         final_query = """
-            CREATE TABLE {output_table} AS
+            CREATE TABLE \"{output_table}\" AS
             SELECT
                     group_by as group_by,
                     group_by_value as group_by_value,
@@ -362,6 +362,6 @@ class Summarizer:
 
     def run(self):
         self._validate_paras()
-        plpy.execute('DROP TABLE IF EXISTS {output_table}'.format(
+        plpy.execute('DROP TABLE IF EXISTS "{output_table}"'.format(
             output_table=self._output_table))
         plpy.execute(self._build_query())

--- a/src/ports/postgres/modules/summary/summary.py_in
+++ b/src/ports/postgres/modules/summary/summary.py_in
@@ -75,7 +75,7 @@ def summary(schema_madlib, source_table, output_table, target_cols, grouping_col
 
     row_count = plpy.execute(
         "SELECT count(*) FROM {output_table}".format(
-            output_table = output_table))[0]['count']
+            output_table = '"' + output_table + '"'))[0]['count']
     return (output_table, row_count, end - start)
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
Fix profile/quantile/summary functions to allow table/column name which starts with numeric characters (0-9) and/or multi-byte characters. BTW, I'm not sure how other functions need to be dealt with.
