### PR TITLE
Add Support for Postgres 9.3

### DIFF
--- a/methods/cart/src/pg_gp/dt.c
+++ b/methods/cart/src/pg_gp/dt.c
@@ -21,6 +21,7 @@
 #include "utils/typcache.h"
 #include "catalog/pg_type.h"
 #include "catalog/namespace.h"
+#include "lib/stringinfo.h"
 #include "nodes/execnodes.h"
 #include "nodes/nodes.h"
 #include "funcapi.h"

--- a/methods/kernel_machines/src/pg_gp/online_sv.c
+++ b/methods/kernel_machines/src/pg_gp/online_sv.c
@@ -18,6 +18,10 @@
 #include <math.h>
 #include <float.h>
 
+#if PG_VERSION_NUM >= 90300
+#include "access/htup_details.h"
+#endif
+
 #ifndef NO_PG_MODULE_MAGIC
 PG_MODULE_MAGIC;
 #endif

--- a/methods/kmeans/src/pg_gp/kmeans.c
+++ b/methods/kmeans/src/pg_gp/kmeans.c
@@ -115,7 +115,7 @@ internal_get_array_of_close_canopies(PG_FUNCTION_ARGS)
     PGFunction      metric_fn;
     
     ArrayType      *close_canopies_arr;
-    int4           *close_canopies;
+    int32          *close_canopies;
     int             num_close_canopies;
     size_t          bytes;
     MemoryContext   mem_context_for_function_calls;
@@ -127,7 +127,7 @@ internal_get_array_of_close_canopies(PG_FUNCTION_ARGS)
     metric_fn = get_metric_fn(PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 3)));
     
     mem_context_for_function_calls = setup_mem_context_for_functional_calls();
-    close_canopies = (int4 *) palloc(sizeof(int4) * num_all_canopies);
+    close_canopies = (int32 *) palloc(sizeof(int32) * num_all_canopies);
     num_close_canopies = 0;
     for (int i = 0; i < num_all_canopies; i++) {
         if (compute_metric(metric_fn, mem_context_for_function_calls,
@@ -143,7 +143,7 @@ internal_get_array_of_close_canopies(PG_FUNCTION_ARGS)
     if (num_close_canopies == 0)
         PG_RETURN_NULL();
 
-    bytes = ARR_OVERHEAD_NONULLS(1) + sizeof(int4) * num_close_canopies;
+    bytes = ARR_OVERHEAD_NONULLS(1) + sizeof(int32) * num_close_canopies;
     close_canopies_arr = (ArrayType *) palloc0(bytes);
     SET_VARSIZE(close_canopies_arr, bytes);
     ARR_ELEMTYPE(close_canopies_arr) = INT4OID;
@@ -151,7 +151,7 @@ internal_get_array_of_close_canopies(PG_FUNCTION_ARGS)
     ARR_DIMS(close_canopies_arr)[0] = num_close_canopies;
     ARR_LBOUND(close_canopies_arr)[0] = 1;
     memcpy(ARR_DATA_PTR(close_canopies_arr), close_canopies,
-        sizeof(int4) * num_close_canopies);
+        sizeof(int32) * num_close_canopies);
 
     PG_RETURN_ARRAYTYPE_P(close_canopies_arr);
 }
@@ -305,7 +305,7 @@ internal_kmeans_closest_centroid(PG_FUNCTION_ARGS) {
     int dist_metric = PG_GETARG_INT32(verify_arg_nonnull(fcinfo, 4)); 
 
     ArrayType      *canopy_ids_arr = NULL;
-    int4           *canopy_ids = NULL;
+    int32          *canopy_ids = NULL;
     bool            indirect;
     if (PG_ARGISNULL(5)) 
     {
@@ -320,7 +320,7 @@ internal_kmeans_closest_centroid(PG_FUNCTION_ARGS) {
             ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
                  errmsg("internal error: array of close canopies cannot be empty")));
-        canopy_ids = (int4*) ARR_DATA_PTR(canopy_ids_arr);
+        canopy_ids = (int32*) ARR_DATA_PTR(canopy_ids_arr);
         num_of_centroids = ARR_DIMS(canopy_ids_arr)[0];
     }
 

--- a/methods/sketch/src/pg_gp/countmin.h
+++ b/methods/sketch/src/pg_gp/countmin.h
@@ -6,6 +6,10 @@
 
 #ifndef _COUNTMIN_H_
 #define _COUNTMIN_H_
+
+#include <limits.h>  /* CHAR_BIT */
+
+
 #define INT64BITS (sizeof(int64)*CHAR_BIT)
 #define RANGES INT64BITS
 #define DEPTH 8 /* magic tuning value: number of hash functions */

--- a/methods/sketch/src/pg_gp/fm.c
+++ b/methods/sketch/src/pg_gp/fm.c
@@ -25,6 +25,8 @@
 
 /* THIS CODE MAY NEED TO BE REVISITED TO ENSURE ALIGNMENT! */
 
+#include <math.h>
+
 #include <postgres.h>
 #include <utils/array.h>
 #include <utils/elog.h>

--- a/methods/sketch/src/pg_gp/sketch_support.c
+++ b/methods/sketch/src/pg_gp/sketch_support.c
@@ -31,6 +31,9 @@
 /*
 @addtogroup grp_sketches
 */
+
+#include <math.h>
+
 /* THIS CODE MAY NEED TO BE REVISITED TO ENSURE ALIGNMENT! */
 
 #include <postgres.h>
@@ -171,10 +174,10 @@ uint32 leftmost_zero(uint8 *bits,
  * \param bitnum bit offset (from right, zero-indexed) in that sketch
  */
 Datum array_set_bit_in_place(bytea *bitmap,
-                             int4 numsketches,
-                             int4 sketchsz_bits,
-                             int4 sketchnum,
-                             int4 bitnum)
+                             int32 numsketches,
+                             int32 sketchsz_bits,
+                             int32 sketchnum,
+                             int32 bitnum)
 {
     char mask;
     char bytes_per_sketch = sketchsz_bits/CHAR_BIT;
@@ -370,10 +373,10 @@ Datum sketch_array_set_bit_in_place(PG_FUNCTION_ARGS)
 {
 
     bytea *bitmap = (bytea *)PG_GETARG_BYTEA_P(0);
-    int4   numsketches = PG_GETARG_INT32(1);
-    int4   sketchsz = PG_GETARG_INT32(2);        /* size in bits */
-    int4   sketchnum = PG_GETARG_INT32(3);        /* from the left! */
-    int4   bitnum = PG_GETARG_INT32(4);        /* from the right! */
+    int32   numsketches = PG_GETARG_INT32(1);
+    int32   sketchsz = PG_GETARG_INT32(2);        /* size in bits */
+    int32   sketchnum = PG_GETARG_INT32(3);        /* from the left! */
+    int32   bitnum = PG_GETARG_INT32(4);        /* from the right! */
 
     return array_set_bit_in_place(bitmap,
                                   numsketches,
@@ -383,9 +386,9 @@ Datum sketch_array_set_bit_in_place(PG_FUNCTION_ARGS)
 }
 
 /* In some cases with large numbers, log2 seems to round up incorrectly. */
-int4 safe_log2(int64 x)
+int32 safe_log2(int64 x)
 {
-    int4 out = trunc(log2(x));
+    int32 out = trunc(log2(x));
 
     while ((((int64)1) << out) > x)
         out--;

--- a/methods/sketch/src/pg_gp/sketch_support.h
+++ b/methods/sketch/src/pg_gp/sketch_support.h
@@ -13,7 +13,11 @@
 #define MAXINT8LEN              25 /*! number of chars to hold an int8 */
 #endif
 
-Datum  array_set_bit_in_place(bytea *, int4, int4, int4, int4);
+#ifndef CHAR_BIT
+#include <limits.h>
+#endif
+
+Datum  array_set_bit_in_place(bytea *, int32, int32, int32, int32);
 uint32 rightmost_one(uint8 *, size_t, size_t, size_t);
 uint32 leftmost_zero(uint8 *, size_t, size_t, size_t);
 uint32 ui_rightmost_one(uint32 v);
@@ -21,7 +25,7 @@ void   hex_to_bytes(char *hex, uint8 *bytes, size_t);
 void bit_print(uint8 *c, int numbytes);
 Datum md5_cstring(char *);
 bytea *sketch_md5_bytea(Datum, Oid);
-int4   safe_log2(int64);
+int32   safe_log2(int64);
 void   int64_big_endianize(uint64 *, uint32, bool);
 
 /*! macro to convert a pointer into a marshalled array of Datums into a Datum */

--- a/methods/svec/src/pg_gp/SparseData.c
+++ b/methods/svec/src/pg_gp/SparseData.c
@@ -24,6 +24,10 @@
 #include "access/htup.h"
 #include "catalog/pg_proc.h"
 
+#if PG_VERSION_NUM >= 90300
+#include "access/htup_details.h"
+#endif
+
 void* array_pos_ref = NULL;
 
 
@@ -141,14 +145,14 @@ int64 compword_to_int8(const char *entry)
 	char *numptr2 = (char *)(&num_2);
 	int32_t num_4;
 	char *numptr4 = (char *)(&num_4);
-	int64 num;
+	int64 num = 0;
 	char *numptr8 = (char *)(&num);
 
 	switch(size) {
 	        case 0: /* entry == NULL represents an array of ones; see
 			 * comment after definition of SparseDataStruct above
 			 */
-			return 1; break;
+			return 1;
 		case 1:
 			num = -(entry[0]);
 			break;

--- a/methods/svec/src/pg_gp/sparse_vector.h
+++ b/methods/svec/src/pg_gp/sparse_vector.h
@@ -17,8 +17,8 @@
  * \endinternal
  */
 typedef struct {
-	int4 vl_len_;   /**< This is unused at the moment */
-	int4 dimension; /**< Number of elements in this vector, special case is -1 indicates a scalar */
+	int32 vl_len_;   /**< This is unused at the moment */
+	int32 dimension; /**< Number of elements in this vector, special case is -1 indicates a scalar */
 	char data[1];   /**< The serialized SparseData representing the vector here */
 } SvecType;
 
@@ -33,7 +33,7 @@ typedef struct {
  *
  * All macros take an (SvecType *) as argument
  */
-#define SVECHDRSIZE	(VARHDRSZ + sizeof(int4))
+#define SVECHDRSIZE	(VARHDRSZ + sizeof(int32))
 /* Beginning of the serialized SparseData */
 #define SVEC_SDATAPTR(x)	((char *)(x)+SVECHDRSIZE)
 #define SVEC_SIZEOFSERIAL(x)	(SVECHDRSIZE+SIZEOF_SPARSEDATASERIAL((SparseData)SVEC_SDATAPTR(x)))

--- a/src/ports/greenplum/dbconnector/Compatibility.hpp
+++ b/src/ports/greenplum/dbconnector/Compatibility.hpp
@@ -67,7 +67,7 @@ AggCheckCallContext(FunctionCallInfo fcinfo, MemoryContext *aggcontext) {
 	return 0;
 }
 
-} // namnespace
+} // namespace
 
 inline ArrayType* madlib_construct_array
 (

--- a/src/ports/postgres/9.3/CMakeLists.txt
+++ b/src/ports/postgres/9.3/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_current_postgresql_version()
+add_extension_support()

--- a/src/ports/postgres/cmake/FindPostgreSQL.cmake
+++ b/src/ports/postgres/cmake/FindPostgreSQL.cmake
@@ -94,28 +94,40 @@ if(${PKG_NAME}_PG_CONFIG AND ${PKG_NAME}_CLIENT_INCLUDE_DIR)
     set(${PKG_NAME}_VERSION_MINOR 0)
     set(${PKG_NAME}_VERSION_PATCH 0)
     
-    if(EXISTS "${${PKG_NAME}_CLIENT_INCLUDE_DIR}/pg_config.h")
+	set(CONFIG_FILE ${${PKG_NAME}_CLIENT_INCLUDE_DIR}/pg_config.h)
+
+    if(EXISTS ${CONFIG_FILE})
         # Read and parse postgres version header file for version number
         if(${CMAKE_COMPILER_IS_GNUCC})
             # If we know the compiler, we can do something that is a little
             # smarter: Dump the definitions only.
             execute_process(
-                COMMAND ${CMAKE_C_COMPILER} -E -dD
-                    "${${PKG_NAME}_CLIENT_INCLUDE_DIR}/pg_config.h"
+                COMMAND ${CMAKE_C_COMPILER} -E -dD ${CONFIG_FILE}
                 OUTPUT_VARIABLE _PG_CONFIG_HEADER_CONTENTS
             )
         else(${CMAKE_COMPILER_IS_GNUCC})
-            file(READ "${${PKG_NAME}_CLIENT_INCLUDE_DIR}/pg_config.h"
-            _PG_CONFIG_HEADER_CONTENTS)
+            file(READ ${CONFIG_FILE} _PG_CONFIG_HEADER_CONTENTS)
         endif(${CMAKE_COMPILER_IS_GNUCC})
         
-        string(REGEX REPLACE ".*#define PACKAGE_NAME \"([^\"]+)\".*" "\\1"
-            _PACKAGE_NAME "${_PG_CONFIG_HEADER_CONTENTS}")
-            
-        string(REGEX REPLACE
+
+		# Get PACKAGE_NAME
+		if (_PG_CONFIG_HEADER_CONTENTS MATCHES "#define PACKAGE_NAME \".*\"")
+          string(REGEX REPLACE 
+			".*#define PACKAGE_NAME \"([^\"]+)\".*" "\\1"
+			_PACKAGE_NAME "${_PG_CONFIG_HEADER_CONTENTS}")
+		else(_PG_CONFIG_HEADER_CONTENTS MATCHES "#define PACKAGE_NAME \".*\"")
+          message(FATAL_ERROR "Unable to locate PACKAGE_NAME in \"${CONFIG_FILE}\".")
+		endif(_PG_CONFIG_HEADER_CONTENTS MATCHES "#define PACKAGE_NAME \".*\"")
+
+		# Get VERSION_NUM
+		if (_PG_CONFIG_HEADER_CONTENTS MATCHES "#define ${_PG_CONFIG_VERSION_NUM_MACRO} ([0-9]+).*")
+          string(REGEX REPLACE
             ".*#define ${_PG_CONFIG_VERSION_NUM_MACRO} ([0-9]+).*" "\\1"
             ${PKG_NAME}_VERSION_NUM "${_PG_CONFIG_HEADER_CONTENTS}")
-        
+		else(_PG_CONFIG_HEADER_CONTENTS MATCHES "#define ${_PG_CONFIG_VERSION_NUM_MACRO} ([0-9]+).*")
+		  set(${PKG_NAME}_VERSION_NUM "unknown")
+		endif(_PG_CONFIG_HEADER_CONTENTS MATCHES "#define ${_PG_CONFIG_VERSION_NUM_MACRO} ([0-9]+).*")
+
         if(${PKG_NAME}_VERSION_NUM MATCHES "^[0-9]+$")
             math(EXPR ${PKG_NAME}_VERSION_MAJOR "${${PKG_NAME}_VERSION_NUM} / 10000")
             math(EXPR ${PKG_NAME}_VERSION_MINOR "(${${PKG_NAME}_VERSION_NUM} % 10000) / 100")
@@ -125,17 +137,25 @@ if(${PKG_NAME}_PG_CONFIG AND ${PKG_NAME}_CLIENT_INCLUDE_DIR)
             # Macro with version number was not found. We use the version string
             # macro as a fallback. Example when this is used: Greenplum < 4.1
             # does not have a GP_VERSION_NUM macro, but only GP_VERSION.
-            string(REGEX REPLACE
-                ".*#define ${_PG_CONFIG_VERSION_MACRO} \"([^\"]+)\".*" "\\1"   
-                ${PKG_NAME}_VERSION_STRING "${_PG_CONFIG_HEADER_CONTENTS}")
-            string(REGEX REPLACE "([0-9]+).*" "\\1"
+
+			# Get VERSION
+			if (_PG_CONFIG_HEADER_CONTENTS MATCHES "#define ${_PG_CONFIG_VERSION_MACRO} ([0-9]+).*")
+			  string(REGEX REPLACE
+				".*#define ${_PG_CONFIG_VERSION_MACRO} ([0-9]+).*" "\\1"
+				${PKG_NAME}_VERSION_STRING "${_PG_CONFIG_HEADER_CONTENTS}")
+              string(REGEX REPLACE "([0-9]+).*" "\\1"
                 ${PKG_NAME}_VERSION_MAJOR "${${PKG_NAME}_VERSION_STRING}")
-            string(REGEX REPLACE "[0-9]+\\.([0-9]+).*" "\\1"
+              string(REGEX REPLACE "[0-9]+\\.([0-9]+).*" "\\1"
                 ${PKG_NAME}_VERSION_MINOR "${${PKG_NAME}_VERSION_STRING}")
-            string(REGEX REPLACE "[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1"
+              string(REGEX REPLACE "[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1"
                 ${PKG_NAME}_VERSION_PATCH "${${PKG_NAME}_VERSION_STRING}")
+
+			else(_PG_CONFIG_HEADER_CONTENTS MATCHES "#define ${_PG_CONFIG_VERSION_MACRO} ([0-9]+).*")
+			  set(${PKG_NAME}_VERSION_STRING "unknown")
+			endif(_PG_CONFIG_HEADER_CONTENTS MATCHES "#define ${_PG_CONFIG_VERSION_MACRO} ([0-9]+).*")
+
         endif(${PKG_NAME}_VERSION_NUM MATCHES "^[0-9]+$")
-    endif(EXISTS "${${PKG_NAME}_CLIENT_INCLUDE_DIR}/pg_config.h")
+    endif(EXISTS ${CONFIG_FILE})
 
     if(_PACKAGE_NAME STREQUAL "${_NEEDED_PG_CONFIG_PACKAGE_NAME}")
         if((NOT DEFINED PACKAGE_FIND_VERSION) OR
@@ -170,18 +190,22 @@ if(${PKG_NAME}_PG_CONFIG AND ${PKG_NAME}_CLIENT_INCLUDE_DIR)
 
             architecture("${${PKG_NAME}_EXECUTABLE}" ${PKG_NAME}_ARCHITECTURE)
         else()
-            message(STATUS "Found pg_config at \"${${PKG_NAME}_PG_CONFIG}\", "
-                "but it belongs to version ${${PKG_NAME}_VERSION_STRING} "
-                "whereas ${PACKAGE_FIND_VERSION} was requested. We will ignore "
-                "this installation.")
+		  if(${PACKAGE_FIND_VERSION})
+            message(FATAL_ERROR "Found \"${${PKG_NAME}_PG_CONFIG}\", "
+              "but it belongs to ${_PACKAGE_NAME} ${${PKG_NAME}_VERSION_STRING} "
+              "where ${_NEEDED_PG_CONFIG_PACKAGE_NAME} ${PACKAGE_FIND_VERSION} "
+			  "was requested.")
+		  endif(${PACKAGE_FIND_VERSION})
         endif()
     else(_PACKAGE_NAME STREQUAL "${_NEEDED_PG_CONFIG_PACKAGE_NAME}")
+	  if(${PACKAGE_FIND_VERSION})
         # There are DBMSs derived from PostgreSQL that also contain pg_config.
         # So there might be many pg_config installed on a system.
-        message(STATUS "Found pg_config at "
-            "\"${${PKG_NAME}_PG_CONFIG}\", but it does not belong to "
-            "${_NEEDED_PG_CONFIG_PACKAGE_NAME}. "
-            "We will ignore this installation.")
+        message(FATAL_ERROR "Found \"${${PKG_NAME}_PG_CONFIG}\", "
+          "but it belongs to ${_PACKAGE_NAME} "
+          "where ${_NEEDED_PG_CONFIG_PACKAGE_NAME} ${PACKAGE_FIND_VERSION} "
+		  "was requested.")
+	  endif(${PACKAGE_FIND_VERSION})
     endif(_PACKAGE_NAME STREQUAL "${_NEEDED_PG_CONFIG_PACKAGE_NAME}")
 endif(${PKG_NAME}_PG_CONFIG AND ${PKG_NAME}_CLIENT_INCLUDE_DIR)
 
@@ -194,5 +218,5 @@ find_package_handle_standard_args(${PACKAGE_FIND_NAME}
         ${PKG_NAME}_CLIENT_INCLUDE_DIR
         ${PKG_NAME}_SERVER_INCLUDE_DIR
     VERSION_VAR
-        ${PKG_NAME}_VERSION_STRING
+        "${_PACKAGE_NAME} ${PKG_NAME}_VERSION_STRING"
 )

--- a/src/ports/postgres/cmake/FindPostgreSQL_9_3.cmake
+++ b/src/ports/postgres/cmake/FindPostgreSQL_9_3.cmake
@@ -1,0 +1,2 @@
+set(_FIND_PACKAGE_FILE "${CMAKE_CURRENT_LIST_FILE}")
+include("${CMAKE_CURRENT_LIST_DIR}/FindPostgreSQL.cmake")

--- a/src/ports/postgres/dbconnector/Compatibility.hpp
+++ b/src/ports/postgres/dbconnector/Compatibility.hpp
@@ -10,7 +10,13 @@
 extern "C" {
     #include <access/tupmacs.h>
     #include <utils/memutils.h>
+
+    #if PG_VERSION_NUM >= 90300
+        #include <access/htup_details.h>
+    #endif
 }
+
+
 namespace madlib {
 
 namespace dbconnector {
@@ -97,7 +103,7 @@ AggCheckCallContext(FunctionCallInfo fcinfo, MemoryContext *aggcontext) {
 
 #endif // PG_VERSION_NUM < 90000
 
-} // namnespace
+} // namespace
 
 
 /**
@@ -116,7 +122,7 @@ static ArrayType* construct_md_array_zero
     char    elmalign
 ){
     ArrayType  *result;
-    int32       nbytes;
+    size_t      nbytes;
     int32       dataoffset;
     int         i;
     int         nelems;


### PR DESCRIPTION
Build System: Add Support for Postgres 9.3 and cleanup of cmake build targets 

Jira: MADLIB-782 
1) Adds the new port folder for Postgres 9.3
2) Adjusts the cmake FindPostgres function to handle REGEX REPLACE better so that it outputs reasonable error messages.
3) Replaces all occurrences of int4 with int32 due to removal of the int4 alias in postgres 9.3
4) Adds #include for htup_details.h for functions that access HeapTuple or heap_form_tuple directly.
5) Adds #include for various system headers no longer included by the postgres headers.
