### PR TITLE
Specifically use /bin/bash in madpack

### DIFF
--- a/src/bin/madpack
+++ b/src/bin/madpack
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script does the following:
 # 0. If indicated by environent variables, look for DBMS-supplied Python


### PR DESCRIPTION
In general /bin/sh is equivalent to /bin/bash, but not on ubuntu where /bin/sh is actually /bin/dash.  This matters because the madpack script uses `pushd` and `popd` which are bash-specific enhancements; on ubuntu this script causes errors like:

```
/usr/local/madlib/bin/madpack: pushd: not found
/usr/local/madlib/bin/madpack: popd: not found
```

The fix is to specifically use bash.  For more info:
- http://askubuntu.com/questions/141928/what-is-difference-between-bin-sh-and-bin-bash
