### PR TITLE
Fixing the elasticnet prediction functions to work with cross-validation

### DIFF
--- a/src/ports/postgres/modules/elastic_net/elastic_net.py_in
+++ b/src/ports/postgres/modules/elastic_net/elastic_net.py_in
@@ -548,7 +548,7 @@ def __elastic_net_gaussian_predict_all(schema_madlib, tbl_model, tbl_new_source,
 
     dense_vars = mad_vec(plpy.execute(
         """
-        select features_selected as fs
+        select features as fs
         from {tbl_model}
         """.format(tbl_model=tbl_model))[0]["fs"])
 
@@ -566,7 +566,7 @@ def __elastic_net_gaussian_predict_all(schema_madlib, tbl_model, tbl_new_source,
         create table {tbl_predict} as
             select
                 id,
-                {schema_madlib}.elastic_net_gaussian_predict(coef_nonzero,
+                {schema_madlib}.elastic_net_gaussian_predict(coef_all,
                                                             intercept, ind_var)
                                  as prediction
             from
@@ -607,7 +607,7 @@ def __elastic_net_binomial_predict_all(schema_madlib, tbl_model, tbl_new_source,
 
     dense_vars = mad_vec(plpy.execute(
         """
-        select features_selected as fs
+        select features as fs
         from {tbl_model}
         """.format(tbl_model=tbl_model))[0]["fs"])
 
@@ -625,7 +625,7 @@ def __elastic_net_binomial_predict_all(schema_madlib, tbl_model, tbl_new_source,
         create table {tbl_predict} as
             select
                 id,
-                {schema_madlib}.elastic_net_binomial_predict(coef_nonzero,
+                {schema_madlib}.elastic_net_binomial_predict(coef_all,
                                                             intercept, ind_var)
                                  as prediction
             from


### PR DESCRIPTION
When elasticnet net selects no variables at all during cross-validation (high penalty), the prediction functions generate empty arrays because they only use the selected variables. These empty arrays (array[]) then cause SQL syntax errors. This patch fixes the problem.

Jira: MADLIB-824
Signed-off-by: Ronert Obst ronert.obst@gmail.com
