### PR TITLE
include materialized views when considering whether a table exists for postgresql

### DIFF
--- a/src/ports/postgres/modules/regress/test/logistic.sql_in
+++ b/src/ports/postgres/modules/regress/test/logistic.sql_in
@@ -43,6 +43,9 @@ INSERT INTO patients(ID, second_attack, treatment, trait_anxiety) VALUES
 (21, 0, 0, NULL),
 (22, 0, NULL, 60);
 
+CREATE MATERIALIZED VIEW patients_mat_view AS 
+  (SELECT * FROM patients) ;
+
 drop table if exists temp_result;
 drop table if exists temp_result_summary;
 select logregr_train(
@@ -69,6 +72,36 @@ SELECT assert(
     num_missing_rows_skipped = 3,
     'Logistic regression with IRLS optimizer (patients test): Wrong results'
 ) FROM temp_result;
+
+-- Run the same test as above, but use the materialized view of patients.
+--   Here we test only that materialized views are accessible.
+drop table if exists temp_result;
+drop table if exists temp_result_summary;
+select logregr_train(
+    'patients_mat_view',
+    'temp_result',
+    'second_attack',
+    'ARRAY[1, treatment, trait_anxiety]',
+    Null,
+    20,
+    'irls'
+);
+
+-- The coefficients are from the source above, the other values have been
+-- computed with the IRLS optimizer in MADlib
+SELECT assert(
+    relative_error(coef, ARRAY[-6.36, -1.02, 0.119]) < 1e-3 AND
+    relative_error(log_likelihood, -9.41) < 1e-3 AND
+    relative_error(std_err, ARRAY[3.21, 1.17, 0.0550]) < 0.002 AND
+    relative_error(z_stats, ARRAY[-1.98, -0.874, 2.17]) < 0.002 AND
+    relative_error(p_values, ARRAY[0.0477, 0.382, 0.0304]) < 1e-3 AND
+    relative_error(odds_ratios, ARRAY[0.00172, 0.359, 1.13]) < 0.004 AND
+    relative_error(condition_no, sqrt(106329)) < 1e-2 AND
+    num_rows_processed = 20 AND
+    num_missing_rows_skipped = 3,
+    'Logistic regression with IRLS optimizer (patients test): Wrong results'
+) FROM temp_result;
+
 
 drop table if exists temp_result;
 drop table if exists temp_result_summary;

--- a/src/ports/postgres/modules/utilities/validate_args.py_in
+++ b/src/ports/postgres/modules/utilities/validate_args.py_in
@@ -109,7 +109,12 @@ def table_exists(tbl):
             SELECT EXISTS(
                 SELECT 1 FROM information_schema.tables
                 WHERE table_name = '{table}'
-                AND table_schema IN {schema_str})
+                AND table_schema IN {schema_str}
+                UNION
+                SELECT 1 FROM pg_catalog.pg_matviews
+                WHERE matviewname = '{table}' 
+                AND schemaname IN {schema_str}
+            )     
             AS table_exists
             """.format(table=table,
                        schema_str=schema_str))[0]['table_exists']

--- a/src/ports/postgres/modules/utilities/validate_args.py_in
+++ b/src/ports/postgres/modules/utilities/validate_args.py_in
@@ -106,16 +106,7 @@ def table_exists(tbl):
     if schema_str and table:
         does_table_exist = plpy.execute(
             """
-            SELECT EXISTS(
-                SELECT 1 FROM information_schema.tables
-                WHERE table_name = '{table}'
-                AND table_schema IN {schema_str}
-                UNION
-                SELECT 1 FROM pg_catalog.pg_matviews
-                WHERE matviewname = '{table}' 
-                AND schemaname IN {schema_str}
-            )     
-            AS table_exists
+            SELECT madlib.__table_exists('{table}') AS table_exists
             """.format(table=table,
                        schema_str=schema_str))[0]['table_exists']
         return bool(does_table_exist)

--- a/src/ports/postgres/modules/utilities/validate_args.py_in
+++ b/src/ports/postgres/modules/utilities/validate_args.py_in
@@ -95,23 +95,22 @@ def table_exists(tbl):
     """
     Returns True if the table exists in the database.
 
-    If the table name is not schema qualified then current_schemas() is used.
-    The table name is searched in information_schema.tables.
+    If the table name is not schema qualified then search_path is used.
+    A select query returning no rows is executed against the relation
+    to determine its presence and suitability.
 
     Args:
         @param tbl Name of the table. Can be schema qualified. If it is not
                     qualified then the current schema is used.
     """
-    schema_str, table = _get_table_schema_names(tbl)
-    if schema_str and table:
-        does_table_exist = plpy.execute(
+    try:
+        plpy.execute(
             """
-            SELECT madlib.__table_exists('{table}') AS table_exists
-            """.format(table=table,
-                       schema_str=schema_str))[0]['table_exists']
-        return bool(does_table_exist)
-    else:
+            SELECT * FROM {table} WHERE false
+            """.format(table=tbl))
+    except Exception:
         return False
+    return True 
 #-------------------------------------------------------------------------
 
 


### PR DESCRIPTION
I've found it's convenient to create training sets as materialized views.  

At present, the validation that a table exists relies on a query to information_schema.tables which unfortunately does not include materialized views.  This patch simply adds to the query to check the pg_catalog for a matching materialized view.

A workflow I'm enjoying is to create training sets and test sets as materialized views.  For example, you can take a simple random sample over large tables and do cpu expensive transforms, creating the data in a flattened materialized view containing parameter fields and independent variable fields. 

This nicely allows for creating a number of sampled sets and keeping them around.
